### PR TITLE
Added Spanish translation for "min-height" CSS property strings

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -422,6 +422,7 @@
   "allElementsButNonReplacedAndTableColumns": {
     "en-US": "all elements but non-replaced inline elements, table columns, and column groups",
     "de": "alle Elemente außer nicht ersetzte Inlineelemente, Tabellenspalten und Spaltengruppen",
+    "es": "elementos de bloque o remplazados",
     "fr": "tous les éléments sauf les éléments en ligne non remplacés, les colonnes de tableaux et les groupes de colonnes",
     "ja": "次の要素を除く全要素：非置換インライン要素、テーブルの列、列グループ",
     "ru": "все элементы, кроме незаменяемых строчных элементов, табличных колонок и групп колонок"
@@ -931,6 +932,7 @@
   "regardingHeightOfGeneratedBoxContainingBlockPercentages0": {
     "en-US": "The percentage is calculated with respect to the height of the generated box's containing block. If the height of the containing block is not specified explicitly (i.e., it depends on content height), and this element is not absolutely positioned, the percentage value is treated as <code>0<\/code>.",
     "de": "Der Prozentwert wird unter Berücksichtigung der Höhe des die generierte Box beinhaltenden Blocks berechnet. Falls die Höhe des beinhaltenden Blocks nicht explizit angegeben wurde (d. h. sie hängt von der Höhe des Inhalts ab) und dieses Element nicht absolut positioniert ist, wird der Prozentwert wie <code>0<\/code> behandelt.",
+    "es": "Se refiere a la altura del bloque contenedor.",
     "fr": "Le poucentage est par rapport \u00e0 la hauteur de la bo\u00eete g\u00e9n\u00e9r\u00e9e par le bloc contenant. Si la hauteur du bloc contenant n'est pas explicitement sp\u00e9cifi\u00e9e (c'est-\u00e0-dire qu'elle d\u00e9pend de la hauteur du contenu), et si cet \u00e9l\u00e9ment n'est pas absolument positionn\u00e9 , la valeur du pourcentage est trait\u00e9e comme si elle valait <code>0<\/code>.",
     "ja": "パーセンテージは、生成ボックスの包含ブロックの高さを基準に計算されます。 包含ブロックの高さが明示的に定義されず（この場合コンテンツの高さに依存します）この要素が絶対位置指定されていないなら、パーセンテージ値は 0 として扱われます。",
     "ru": "Процент для генерируемого блока рассчитывается по отношению к высоте содержащего блока. Если высота содержащего блока не задана явно (т.е. зависит от высоты содержимого), и этот этот элемент позиционирован не абсолютно, процентное значение интерпретируется как <code>0<\/code>."


### PR DESCRIPTION
The strings were taken from the page https://developer.mozilla.org/es/docs/Web/CSS/min-height.

Sebastian