### PR TITLE
Replace deprecated <uri> for <url>

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -120,7 +120,7 @@
     "status": "nonstandard"
   },
   "@font-face": {
-    "syntax": "@font-face {\n  [ font-family: &lt;family-name&gt;; ] ||\n  [ src: [ &lt;uri&gt; [ format(&lt;string&gt;#) ]? | &lt;font-face-name&gt; ]#; ] ||\n  [ unicode-range: &lt;urange&gt;#; ] ||\n  [ font-variant: &lt;font-variant&gt;; ] ||\n  [ font-feature-settings: normal | &lt;feature-tag-value&gt;#; ] ||\n  [ font-stretch: &lt;font-stretch&gt;; ] ||\n  [ font-weight: &lt;weight&gt;; ] ||\n  [ font-style: &lt;style&gt;; ]\n}",
+    "syntax": "@font-face {\n  [ font-family: &lt;family-name&gt;; ] ||\n  [ src: [ &lt;url&gt; [ format(&lt;string&gt;#) ]? | &lt;font-face-name&gt; ]#; ] ||\n  [ unicode-range: &lt;urange&gt;#; ] ||\n  [ font-variant: &lt;font-variant&gt;; ] ||\n  [ font-feature-settings: normal | &lt;feature-tag-value&gt;#; ] ||\n  [ font-stretch: &lt;font-stretch&gt;; ] ||\n  [ font-weight: &lt;weight&gt;; ] ||\n  [ font-style: &lt;style&gt;; ]\n}",
     "interfaces": [
       "CSSFontFaceRule"
     ],
@@ -255,7 +255,7 @@
     "status": "standard"
   },
   "@namespace": {
-    "syntax": "@namespace &lt;namespace-prefix&gt;? [ &lt;string&gt; | &lt;uri&gt; ];",
+    "syntax": "@namespace &lt;namespace-prefix&gt;? [ &lt;string&gt; | &lt;url&gt; ];",
     "groups": [
       "CSS Namespaces"
     ],

--- a/css/properties.json
+++ b/css/properties.json
@@ -46,7 +46,7 @@
     "status": "nonstandard"
   },
   "-moz-binding": {
-    "syntax": "&lt;uri&gt; | none",
+    "syntax": "&lt;url&gt; | none",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2792,7 +2792,7 @@
     "status": "experimental"
   },
   "content": {
-    "syntax": "normal | none | [ &lt;string&gt; | &lt;uri&gt; | &lt;counter&gt; | attr() | open-quote | close-quote | no-open-quote | no-close-quote ]+",
+    "syntax": "normal | none | [ &lt;string&gt; | &lt;url&gt; | &lt;counter&gt; | attr() | open-quote | close-quote | no-open-quote | no-close-quote ]+",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",
@@ -2837,7 +2837,7 @@
     "status": "standard"
   },
   "cursor": {
-    "syntax": "[ [ &lt;uri&gt; [ &lt;x&gt; &lt;y&gt; ]? , ]* [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing ] ]",
+    "syntax": "[ [ &lt;url&gt; [ &lt;x&gt; &lt;y&gt; ]? , ]* [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing ] ]",
     "media": "visual, interactive",
     "inherited": true,
     "animationType": "discrete",
@@ -4074,7 +4074,7 @@
     "status": "standard"
   },
   "list-style-image": {
-    "syntax": "&lt;uri&gt; | none",
+    "syntax": "&lt;url&gt; | none",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
> ... CSS Level 3 came back to the initial definition, this time explicitly defined. The functional notation url() denotes a <url> CSS data type and no more the more generic <uri> CSS data type.

https://developer.mozilla.org/en-US/docs/Web/CSS/url