### PR TITLE
Fix <'-webkit-mask-position'> syntax

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -555,7 +555,7 @@
     "status": "nonstandard"
   },
   "-webkit-mask-position": {
-    "syntax": "&lt;mask-position&gt; [ , &lt;mask-position&gt; ]#",
+    "syntax": "&lt;mask-position&gt;#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
`<mask-position> [, <mask-position> ]#` is invalid syntax, since group should start with comma and multiplier is `one or more comma separated occurrences`