### PR TITLE
change scroll-snap-points-* to use length-percentage

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5366,7 +5366,7 @@
     "status": "standard"
   },
   "scroll-snap-points-x": {
-    "syntax": "none | repeat( &lt;length&gt; )",
+    "syntax": "none | repeat( &lt;length-percentage&gt; )",
     "media": "interactive",
     "inherited": false,
     "animationType": "discrete",
@@ -5381,7 +5381,7 @@
     "status": "obsolete"
   },
   "scroll-snap-points-y": {
-    "syntax": "none | repeat( &lt;length&gt; )",
+    "syntax": "none | repeat( &lt;length-percentage&gt; )",
     "media": "interactive",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
Only firefox implements these, and it's deprecated (and removed from the then-draft spec) so no other browser is likely to start implementing this. We should just specify what firefox does in this case (which is handle both lengths and percentages)