### PR TITLE
Bring media related data up-to-date with production

### DIFF
--- a/api/groups.json
+++ b/api/groups.json
@@ -997,16 +997,20 @@
                         "started",
                         "devicechange" ]
     },
-    "Media Recorder API": {
-        "overview":   [ "MediaRecorder API" ],
-        "interfaces": [ "MediaRecorder" ],
+    "MediaStream Recording": {
+        "overview":   [ "MediaStream Recording API" ],
+        "guides":     [ { "url": "/en-US/docs/Web/API/MediaStream_Recording_API/Using_the_MediaStream_Recording_API",
+                          "title": "Using the MediaStream recording API" } ],
+        "interfaces": [ "MediaRecorder",
+                        "BlobEvent" ],
         "methods":    [],
         "properties": [],
-        "events":     [ "start_(MediaRecorder)",
+        "events":     [ "start",
                         "stop",
                         "dataavailable",
                         "pause",
-                        "resume" ]
+                        "resume",
+                        "error" ]
     },
     "Media Source Extensions": {
         "interfaces": [ "MediaSource",


### PR DESCRIPTION
This fixes the name of MediaStream Recording, adds some missing items,
and adds the guide material so it will appear in the sidebar where it
should be.