### PR TITLE
Add Storage API and remove dupe, incomplete Console API

### DIFF
--- a/api/groups.json
+++ b/api/groups.json
@@ -262,12 +262,6 @@
                         "error",
                         "contactchange" ]
     },
-    "Console API": {
-        "interfaces": [ "Console" ],
-        "methods": [],
-        "properties": [],
-        "events": []
-    },
     "CSS Counter Styles": {
         "overview":   [ "CSS Counter Styles" ],
         "interfaces": [ "CSSCounterStyleRule" ],
@@ -1363,6 +1357,16 @@
         "methods":    [],
         "properties": [],
         "events":     [ "speakerforcedchange" ]
+    },
+    "Storage": {
+        "overview":   [ "Storage API" ],
+        "interfaces": [ "StorageManager",
+                        "NavigatorStorage",
+                        "StorageEstimate" ],
+        "methods":    [],
+        "properties": [ "Navigator.storage",
+                        "WorkerNavigator.storage" ],
+        "events":     []
     },
     "SVG": {
         "interfaces": [ "SVGAElement",


### PR DESCRIPTION
This PR adds the record for the Storage API, which goes by the name
“Storage” in the SpecName table. It also removes a duplicate,
incomplete record for the Console API which appeared recently for some
reason, breaking JSON linting.