### PR TITLE
Fix webkit-text-stoke and webkit-text-fill-color properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -670,15 +670,16 @@
     ],
     "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
-    "computed": "asSpecified",
+    "computed": "'color'",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-text-stroke": {
-    "syntax": "&lt;length&gt; &lt;color&gt;",
+    "syntax": "&lt;length&gt; || &lt;color&gt;",
     "media": "visual",
     "inherited": true,
     "animationType": [
+      "-webkit-text-stroke-width",
       "-webkit-text-stroke-color"
     ],
     "percentages": "no",
@@ -690,8 +691,11 @@
       "-webkit-text-stroke-color"
     ],
     "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "computed": [
+      "-webkit-text-stroke-width",
+      "-webkit-text-stroke-color"
+    ],
+    "order": "canonicalOrder",
     "status": "nonstandard"
   },
   "-webkit-text-stroke-color": {
@@ -703,9 +707,9 @@
     "groups": [
       "WebKit Extensions"
     ],
-    "initial": "<code>rgb(0, 0, 0)</code>",
+    "initial": "<code>currentColor</code>",
     "appliesto": "allElements",
-    "computed": "asSpecified",
+    "computed": "'color'",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -720,7 +724,7 @@
     ],
     "initial": "<code>0</code>",
     "appliesto": "allElements",
-    "computed": "asSpecified",
+    "computed": "absoluteWidth",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },

--- a/css/properties.json
+++ b/css/properties.json
@@ -707,7 +707,7 @@
     "groups": [
       "WebKit Extensions"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -1487,7 +1487,7 @@
     "groups": [
       "CSS Background and Borders"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -1920,7 +1920,7 @@
     "groups": [
       "CSS Background and Borders"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -2037,7 +2037,7 @@
     "groups": [
       "CSS Background and Borders"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -2164,7 +2164,7 @@
     "groups": [
       "CSS Background and Borders"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -2690,7 +2690,7 @@
     "groups": [
       "CSS Columns"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "multicolElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -5608,7 +5608,7 @@
     "groups": [
       "CSS Text Decoration"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",
@@ -5707,7 +5707,7 @@
     "groups": [
       "CSS Text Decoration"
     ],
-    "initial": "<code>currentColor</code>",
+    "initial": "<code>currentcolor</code>",
     "appliesto": "allElements",
     "computed": "'color'",
     "order": "uniqueOrder",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1164,6 +1164,12 @@
     "de": "absolute {{cssxref(\"length\")}}",
     "ru": "абсолютная {{cssxref(\"length\")}}"
   },
+  "absoluteWidth": {
+    "en-US": "absolute {{cssxref(\"width\")}}",
+    "fr": "une longueur (type {{cssxref(\"width\")}}) absolue",
+    "de": "absolute {{cssxref(\"width\")}}",
+    "ru": "абсолютная {{cssxref(\"width\")}}"
+  },
   "absoluteLengthZeroIfBorderStyleNoneOrHidden": {
     "en-US": "absolute length; <code>0</code> if the border style is <code>none</code> or <code>hidden</code>",
     "de": "absolute Länge; <code>0</code>, falls der Rahmenstil <code>none</code> oder <code>hidden</code> ist",


### PR DESCRIPTION
According to the [CSS Compatibility Specification](https://compat.spec.whatwg.org/#the-webkit-text-stroke), fix some of these values.