### PR TITLE
Follow up of #22 - remove {{cssxref("width")}} from absoluteWidth

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1165,10 +1165,7 @@
     "ru": "абсолютная {{cssxref(\"length\")}}"
   },
   "absoluteWidth": {
-    "en-US": "absolute {{cssxref(\"width\")}}",
-    "fr": "une longueur (type {{cssxref(\"width\")}}) absolue",
-    "de": "absolute {{cssxref(\"width\")}}",
-    "ru": "абсолютная {{cssxref(\"width\")}}"
+    "en-US": "absolute width"
   },
   "absoluteLengthZeroIfBorderStyleNoneOrHidden": {
     "en-US": "absolute length; <code>0</code> if the border style is <code>none</code> or <code>hidden</code>",


### PR DESCRIPTION
Since `absoluteWidth` has nothing to do with `width` property, we should not link it to the `width` property. This is a follow-up for #22.

cc @SebastianZ 