### PR TITLE
Use absoluteLength instead of absoluteWidth for -webkit-text-stroke-width's computed value

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -724,7 +724,7 @@
     ],
     "initial": "<code>0</code>",
     "appliesto": "allElements",
-    "computed": "absoluteWidth",
+    "computed": "absoluteLength",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1164,9 +1164,6 @@
     "de": "absolute {{cssxref(\"length\")}}",
     "ru": "абсолютная {{cssxref(\"length\")}}"
   },
-  "absoluteWidth": {
-    "en-US": "absolute width"
-  },
   "absoluteLengthZeroIfBorderStyleNoneOrHidden": {
     "en-US": "absolute length; <code>0</code> if the border style is <code>none</code> or <code>hidden</code>",
     "de": "absolute Länge; <code>0</code>, falls der Rahmenstil <code>none</code> oder <code>hidden</code> ist",


### PR DESCRIPTION
According to the spec, '-webkit-text-stroke-width' property uses <line-width> as
its specified value. And all the <line-width>s properties seem to be computed to
'absolute length', not 'absolute width'. So, let's use 'absolute length' for
the computed value of '-webkit-text-stroke-width' property.

Spec issue: https://github.com/whatwg/compat/issues/67