### PR TITLE
user-select initial property should be 'auto'

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6075,7 +6075,7 @@
     "groups": [
       "Mozilla Extensions"
     ],
-    "initial": "<code>none</code>",
+    "initial": "<code>auto</code>",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",


### PR DESCRIPTION
According to the draft spec on user-select that is sourced from MDN docs, the initial for user-select is 'auto' and not 'none'. This is also true in the way it is implemented in supported browsers.
https://drafts.csswg.org/css-ui-4/#propdef-user-select