### PR TITLE
Added 'caret-color' definition

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2544,6 +2544,21 @@
     "order": "uniqueOrder",
     "status": "standard"
   },
+  "caret-color": {
+    "syntax": "auto | &lt;color&gt;",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS User Interface"
+    ],
+    "initial": "<code>auto</code>",
+    "appliesto": "allElements",
+    "computed": "asAutoOrColor",
+    "order": "perGrammar",
+    "status": "standard"
+  },
   "clear": {
     "syntax": "none | left | right | both | inline-start | inline-end",
     "media": "visual",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1152,6 +1152,10 @@
     "fr": "identiques aux propriétés qui décalent les boîtes : {{cssxref(\"top\")}}, {{cssxref(\"right\")}}, {{cssxref(\"bottom\")}}, {{cssxref(\"left\")}} sauf que ces directions sont logiques",
     "ru": "также как смещение блоков свойствами: {{cssxref(\"top\")}}, {{cssxref(\"right\")}}, {{cssxref(\"bottom\")}}, {{cssxref(\"left\")}}, кроме того направления логичны"
   },
+  "asAutoOrColor": {
+    "en-US": "<code>auto</code> is computed as specified and <code>&lt;color&gt;</code> values are computed as defined for the {{cssxref(\"color\")}} property.",
+    "de": "<code>auto</code> wird wie angegeben berechnet und <code>&lt;color&gt;</code> Werte werden wie für die {{cssxref(\"color\")}} Eigenschaft berechnet."
+  },
   "asLength": {
     "en-US": "as {{cssxref(\"length\")}}",
     "de": "als {{cssxref(\"length\")}}",


### PR DESCRIPTION
The `caret-color` CSS property was implemented in [bug 1063162](https://bugzilla.mozilla.org/show_bug.cgi?id=1063162).

Sebastian