### PR TITLE
Add "auto" to -moz-user-input

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -321,7 +321,7 @@
     "status": "nonstandard"
   },
   "-moz-user-input": {
-    "syntax": "none | enabled | disabled",
+    "syntax": "auto | none | enabled | disabled",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",
@@ -329,7 +329,7 @@
     "groups": [
       "Mozilla Extensions"
     ],
-    "initial": "<code>none</code>",
+    "initial": "<code>auto</code>",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",


### PR DESCRIPTION
From [the code](https://dxr.mozilla.org/mozilla-central/rev/6a23526fe5168087d7e4132c0705aefcaed5f571/layout/style/nsRuleNode.cpp#5273-5278), it seems the initial value is actually "auto" rather than "none".