### PR TITLE
Add the "Background Tasks" stuff for Fx 52

### DIFF
--- a/api/groups.json
+++ b/api/groups.json
@@ -64,6 +64,14 @@
                         "mozinterruptbegin",
                         "mozinterruptend" ]
     },
+    "Background Tasks": {
+      "overview":     [ "Cooperative Scheduling of Background Tasks API" ],
+      "interfaces":   [ "IdleDeadline" ],
+      "methods":      [ "Window.cancelIdleCallback()",
+                        "Window.requestIdleCallback()" ],
+      "properties":   [],
+      "events":       []
+    },
     "Battery API": {
         "overview":   [ "Battery Status API" ],
         "guides":     [ { "url":   "/Apps/Build/gather_and_modify_data/retrieving_battery_status_information",

--- a/api/interfaces.json
+++ b/api/interfaces.json
@@ -963,6 +963,10 @@
     "inh": "Event",
     "impl": []
   },
+  "IdleDeadline": {
+    "inh": "",
+    "impl": []
+  },
   "ImageCapture": {
     "inh": "EventTarget",
     "impl": []


### PR DESCRIPTION
This PR adds the "Background Tasks" group to groups.json and the IdleDeadline interface to interfaces.json.