### PR TITLE
-moz-image-region can be auto

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -151,7 +151,7 @@
     "status": "nonstandard"
   },
   "-moz-image-region": {
-    "syntax": "&lt;shape&gt;",
+    "syntax": "&lt;shape&gt; | auto",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
Only Firefox handles this property, and we do parse auto values for it.