### PR TITLE
proper fs agnostic npm package

### DIFF
--- a/css/index.js
+++ b/css/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  atRules:    require('./at-rules'),
+  selectors:  require('./selectors'),
+  types:      require('./types'),
+  properties: require('./properties'),
+  syntaxes:   require('./syntaxes'),
+  units:      require('./units'),
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  css: require('./css'),
+  l10n: require('./l10n'),
+}

--- a/l10n/index.js
+++ b/l10n/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  css: require('./css'),
+  svg: require('./svg'),
+}

--- a/l10n/index.js
+++ b/l10n/index.js
@@ -1,4 +1,3 @@
 module.exports = {
   css: require('./css'),
-  svg: require('./svg'),
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mdn-data",
   "version": "1.0.0",
   "description": "Open Web data by the Mozilla Developer Network",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mdn/data.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-data",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Open Web data by the Mozilla Developer Network",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
this PR helps #36 and makes mdn-data 
1) ordinary npm package with normal entry point
2) filesystem agnostic, therefore consumers wont rely on specific paths in the package