### PR TITLE
Fix computed values of color properties ("'color'" -> "computedColor")

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -670,7 +670,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -709,7 +709,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -1128,7 +1128,7 @@
     ],
     "initial": "transparent",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
@@ -1489,7 +1489,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -1922,7 +1922,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -2039,7 +2039,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -2166,7 +2166,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -2707,7 +2707,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "multicolElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "status": "standard"
   },
@@ -5687,7 +5687,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
@@ -5786,7 +5786,7 @@
     ],
     "initial": "currentcolor",
     "appliesto": "allElements",
-    "computed": "'color'",
+    "computed": "computedColor",
     "order": "uniqueOrder",
     "status": "standard"
   },


### PR DESCRIPTION
There are two different value of `computed` field for color properties:
- `"computed": "'color'"` (10 occuriencies)
- `"computed": "computedColor"` (5 occuriencies)

Specs uses:
> Computed value:	the computed color

(example https://www.w3.org/TR/css3-background/#the-background-color)

"'color'" looks odd (no other quoted values) and probably a it's legacy value. It should be replaced for `computedColor`