### PR TITLE
Replace "yes" value for "percentage" field to proper values

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -220,7 +220,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
-    "percentages": "yes",
+    "percentages": "referToDimensionOfBorderBox",
     "groups": [
       "Mozilla Extensions"
     ],
@@ -235,7 +235,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
-    "percentages": "yes",
+    "percentages": "referToDimensionOfBorderBox",
     "groups": [
       "Mozilla Extensions"
     ],
@@ -250,7 +250,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
-    "percentages": "yes",
+    "percentages": "referToDimensionOfBorderBox",
     "groups": [
       "Mozilla Extensions"
     ],
@@ -265,7 +265,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
-    "percentages": "yes",
+    "percentages": "referToDimensionOfBorderBox",
     "groups": [
       "Mozilla Extensions"
     ],
@@ -3669,7 +3669,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "length",
-    "percentages": "yes, as the dimension of the element",
+    "percentages": "referToDimensionOfContentArea",
     "groups": [
       "CSS Grid Layout"
     ],
@@ -3759,7 +3759,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "length",
-    "percentages": "yes, as the dimension of the element",
+    "percentages": "referToDimensionOfContentArea",
     "groups": [
       "CSS Grid Layout"
     ],


### PR DESCRIPTION
A `yes` value for `percentage` is incorrect since it should describe what it refers to when applicable.
- `-moz-outline-radius-*` - set the same value as for `border-radius-*` since [MDN says](https://developer.mozilla.org/en/docs/Web/CSS/-moz-outline-radius):
> A `<percentage>`; see border-radius for details.
- `grid-column-gap` & `grid-row-gap` https://www.w3.org/TR/css-grid-1/#propdef-grid-column-gap