### PR TITLE
Extend syntax.json format

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -1,200 +1,596 @@
 {
-  "absolute-size": "xx-small | x-small | small | medium | large | x-large | xx-large",
-  "alpha-value": "<number> | <percentage>",
-  "angle-percentage": "<angle> | <percentage>",
-  "animateable-feature": "scroll-position | contents | <custom-ident>",
-  "attachment": "scroll | fixed | local",
-  "attr()": "attr( <attr-name> <type-or-unit>? [, <attr-fallback> ]? )",
-  "auto-repeat": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )",
-  "auto-track-list": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?",
-  "basic-shape": "<inset()> | <circle()> | <ellipse()> | <polygon()>",
-  "bg-image": "none | <image>",
-  "bg-layer": "<bg-image> || <position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box>{1,2}",
-  "bg-size": "[ <length-percentage> | auto ]{1,2} | cover | contain",
-  "blur()": "blur( <length> )",
-  "blend-mode": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity",
-  "box": "border-box | padding-box | content-box",
-  "br-style": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset",
-  "br-width": "<length> | thin | medium | thick",
-  "brightness()": "brightness( <number-percentage> )",
-  "calc()": "calc( <calc-sum> )",
-  "calc-sum": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*",
-  "calc-product": "<calc-value> [ '*' <calc-value> | '/' <number> ]*",
-  "calc-value": "<number> | <dimension> | <percentage> | ( <calc-sum> )",
-  "cf-final-image": "<image> | <color>",
-  "cf-mixing-image": "<percentage>? && <image>",
-  "circle()": "circle( [ <shape-radius> ]? [ at <position> ]? )",
-  "clip-source": "<url>",
-  "color": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>",
-  "color-stop": "<color> <length-percentage>?",
-  "color-stop-list": "<color-stop>#{2,}",
-  "common-lig-values": "[ common-ligatures | no-common-ligatures ]",
-  "composite-style": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor",
-  "compositing-operator": "add | subtract | intersect | exclude",
-  "contextual-alt-values": "[ contextual | no-contextual ]",
-  "content-list": "[ <string> | contents | <url> | <quote> | <target> | <leader()> ]+",
-  "contrast()": "contrast( [ <number-percentage> ] )",
-  "counter-style": "<counter-style-name> | symbols()",
-  "counter-style-name": "<custom-ident>",
-  "cross-fade()": "cross-fade( <cf-mixing-image> , <cf-final-image>? )",
-  "deprecated-system-color": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonFace | ButtonHighlight | ButtonShadow | ButtonText | CaptionText | GrayText | Highlight | HighlightText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText",
-  "discretionary-lig-values": "[ discretionary-ligatures | no-discretionary-ligatures ]",
-  "display-box": "contents | none",
-  "display-inside": "flow | flow-root | table | flex | grid | subgrid | ruby",
-  "display-internal": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container",
-  "display-legacy": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid",
-  "display-listitem": "list-item && <display-outside>? && [ flow | flow-root ]?",
-  "display-outside": "block | inline | run-in",
-  "drop-shadow()": "drop-shadow( <length>{2,3} <color>? )",
-  "east-asian-variant-values": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]",
-  "east-asian-width-values": "[ full-width | proportional-width ]",
-  "element()": "element( <id-selector> )",
-  "ellipse()": "ellipse( [ <shape-radius>{2} ]? [ at <position> ]? )",
-  "ending-shape": "circle | ellipse",
-  "explicit-track-list": "[ <line-names>? <track-size> ]+ <line-names>?",
-  "family-name": "<string> | <custom-ident>+",
-  "feature-tag-value": "<string> [ <integer> | on | off ]?",
-  "feature-type": "@stylistic | @historical-forms | @styleset | @character-variant | @swash | @ornaments | @annotation",
-  "feature-value-block": "<feature-type> {\n  <feature-value-declaration-list>\n}",
-  "feature-value-block-list": "<feature-value-block>+",
-  "feature-value-declaration": "<custom-ident>: <integer>+;",
-  "feature-value-declaration-list": "<feature-value-declaration>",
-  "feature-value-name": "<custom-ident>",
-  "fill-rule": "nonzero | evenodd",
-  "filter-function": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>",
-  "filter-function-list": "[ <filter-function> | <url> ]+",
-  "final-bg-layer": "<bg-image> || <position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box> || <box> || <'background-color'>",
-  "fit-content()": "fit-content( [ <length> | <percentage> ] )",
-  "fixed-breadth": "<length-percentage>",
-  "fixed-repeat": "repeat( [ <positive-integer> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )",
-  "fixed-size": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )",
-  "font-variant-css21": "[ normal | small-caps ]",
-  "frequency-percentage": "<frequency> | <percentage>",
-  "general-enclosed": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )",
-  "generic-family": "serif | sans-serif | cursive | fantasy | monospace",
-  "generic-name": "serif | sans-serif | cursive | fantasy | monospace",
-  "geometry-box": "<shape-box> | fill-box | stroke-box | view-box",
-  "gradient": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>",
-  "grayscale()": "grayscale( <number-percentage> )",
-  "grid-line": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]",
-  "historical-lig-values": "[ historical-ligatures | no-historical-ligatures ]",
-  "hsl()": "hsl( [ <hue> <percentage> <percentage> [ / <alpha-value> ]? ] | [ <hue>, <percentage>, <percentage>, <alpha-value>? ] )",
-  "hsla()": "hsla( [ <hue> <percentage> <percentage> [ / <alpha-value> ]? ] | [ <hue>, <percentage>, <percentage>, <alpha-value>? ] )",
-  "hue": "<number> | <angle>",
-  "hue-rotate()": "hue-rotate( <angle> )",
-  "image": "<url> | <image()> | <image-set()> | <element()> | <cross-fade()> | <gradient>",
-  "image()": "image( [ [ <image> | <string> ]? , <color>? ]! )",
-  "image-set()": "image-set( <image-set-option># )",
-  "image-set-option": "[ <image> | <string> ] <resolution>",
-  "inflexible-breadth": "<length> | <percentage> | min-content | max-content | auto",
-  "inset()": "inset( <length-percentage>{1,4} [ round <border-radius> ]? )",
-  "invert()": "invert( <number-percentage> )",
-  "keyframes-name": "<custom-ident> | <string>",
-  "keyframe-block": "<keyframe-selector># {\n  <declaration-list>\n}",
-  "keyframe-block-list": "<keyframe-block>+",
-  "keyframe-selector": "from | to | <percentage>",
-  "leader()": "leader( dotted | solid | space | <string> )",
-  "length-percentage": "<length> | <percentage>",
-  "line-names": "'[' <custom-ident>* ']'",
-  "line-name-list": "[ <line-names> | <name-repeat> ]+",
-  "linear-gradient()": "linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
-  "mask-layer": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>",
-  "mask-position": "[ <length-percentage> | left | center | right ] [ <length-percentage> | top | center | bottom ]?",
-  "mask-reference": "none | <image> | <mask-source>",
-  "mask-source": "<url>",
-  "masking-mode": "alpha | luminance | match-source",
-  "matrix()": "matrix( <number> [, <number> ]{5,5} )",
-  "matrix3d()": "matrix3d( <number> [, <number> ]{15,15} )",
-  "media-and": "<media-in-parens> [ and <media-in-parens> ]+",
-  "media-condition": "<media-not> | <media-and> | <media-or> | <media-in-parens>",
-  "media-condition-without-or": "<media-not> | <media-and> | <media-in-parens>",
-  "media-feature": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )",
-  "media-in-parens": "( <media-condition> ) | <media-feature> | <general-enclosed>",
-  "media-not": "not <media-in-parens>",
-  "media-or": "<media-in-parens> [ or <media-in-parens> ]+",
-  "media-query": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?",
-  "media-query-list": "<media-query>#",
-  "media-type": "<ident>",
-  "mf-boolean": "<mf-name>",
-  "mf-name": "<ident>",
-  "mf-plain": "<mf-name> : <mf-value>",
-  "mf-range": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>",
-  "mf-value": "<number> | <dimension> | <ident> | <ratio>",
-  "minmax()": "minmax( [ <length> | <percentage> | <flex> | min-content | max-content | auto ] , [ <length> | <percentage> | <flex> | min-content | max-content | auto ] )",
-  "named-color": "transparent | aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen",
-  "namespace-prefix": "<ident>",
-  "number-percentage": "<number> | <percentage>",
-  "numeric-figure-values": "[ lining-nums | oldstyle-nums ]",
-  "numeric-fraction-values": "[ diagonal-fractions | stacked-fractions ]",
-  "numeric-spacing-values": "[ proportional-nums | tabular-nums ]",
-  "nth": "<an-plus-b> | even | odd",
-  "opacity()": "opacity( [ <number-percentage> ] )",
-  "page-body": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>",
-  "page-margin-box": "<page-margin-box-type> {\n  <declaration-list>\n}",
-  "page-margin-box-type": "@top-left-corner | @top-left | @top-center | @top-right | @top-right-corner | @bottom-left-corner | @bottom-left | @bottom-center | @bottom-right | @bottom-right-corner | @left-top | @left-middle | @left-bottom | @right-top | @right-middle | @right-bottom",
-  "page-selector-list": "[ <page-selector># ]?",
-  "page-selector": "<pseudo-page>+ | <ident> <pseudo-page>*",
-  "perspective()": "perspective( <length> )",
-  "polygon()": "polygon( <fill-rule>? , [ <length-percentage> <length-percentage> ]# )",
-  "position": "[[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ]]",
-  "pseudo-page": ": [ left | right | first | blank ]",
-  "quote": "open-quote | close-quote | no-open-quote | no-close-quote",
-  "radial-gradient()": "radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )",
-  "relative-size": "larger | smaller",
-  "repeat-style": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}",
-  "repeating-linear-gradient()": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
-  "repeating-radial-gradient()": "repeating-radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )",
-  "rgb()": "rgb( [ [ <percentage>{3} | <number>{3} ] [ / <alpha-value> ]? ] | [ [ <percentage>#{3} | <number>#{3} ] , <alpha-value>? ] )",
-  "rgba()": "rgba( [ [ <percentage>{3} | <number>{3} ] [ / <alpha-value> ]? ] | [ [ <percentage>#{3} | <number>#{3} ] , <alpha-value>? ] )",
-  "rotate()": "rotate( <angle> )",
-  "rotate3d()": "rotate3d( <number> , <number> , <number> , <angle> )",
-  "rotateX()": "rotateX( <angle> )",
-  "rotateY()": "rotateY( <angle> )",
-  "rotateZ()": "rotateZ( <angle> )",
-  "saturate()": "saturate( <number-percentage> )",
-  "scale()": "scale( <number> [, <number> ]? )",
-  "scale3d()": "scale3d( <number> , <number> , <number> )",
-  "scaleX()": "scaleX( <number> )",
-  "scaleY()": "scaleY( <number> )",
-  "scaleZ()": "scaleZ( <number> )",
-  "shape-radius": "<length-percentage> | closest-side | farthest-side",
-  "skew()": "skew( <angle> [, <angle> ]? )",
-  "skewX()": "skewX( <angle> )",
-  "skewY()": "skewY( <angle> )",
-  "sepia()": "sepia( <number-percentage> )",
-  "shadow": "inset? && <length>{2,4} && <color>?",
-  "shadow-t": "[ <length>{2,3} && <color>? ]",
-  "shape": "rect(<top>, <right>, <bottom>, <left>)",
-  "shape-box": "<box> | margin-box",
-  "side-or-corner": "[ left | right ] || [ top | bottom ]",
-  "single-animation": "<time> || <single-timing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]",
-  "single-animation-direction": "normal | reverse | alternate | alternate-reverse",
-  "single-animation-fill-mode": "none | forwards | backwards | both",
-  "single-animation-iteration-count": "infinite | <number>",
-  "single-animation-play-state": "running | paused",
-  "single-timing-function": "<single-transition-timing-function>",
-  "single-transition": "[ none | <single-transition-property> ] || <time> || <single-transition-timing-function> || <time>",
-  "single-transition-timing-function": "ease | linear | ease-in | ease-out | ease-in-out | step-start | step-end | steps( <integer> [, [ start | end ] ]? ) | cubic-bezier( <number>, <number>, <number>, <number> )",
-  "single-transition-property": "all | <custom-ident>",
-  "size": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}",
-  "symbol": "<string> | <image> | <ident>",
-  "target": "<target-counter()> | <target-counters()> | <target-text()>",
-  "target-counter()": "target-counter( [ <string> | <url> ] , <custom-ident> [, <counter-style> ]? )",
-  "target-counters()": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> [, <counter-style> ]? )",
-  "target-text()": "target-text( [ <string> | <url> ] [, [ content | before | after | first-letter ] ]? )",
-  "time-percentage": "<time> | <percentage>",
-  "track-breadth": "<length-percentage> | <flex> | min-content | max-content | auto",
-  "track-list": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?",
-  "track-repeat": "repeat( [ <positive-integer> ] , [ <line-names>? <track-size> ]+ <line-names>? )",
-  "track-size": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( [ <length> | <percentage> ] )",
-  "transform-function": "[ <matrix()> || <translate()> || <translateX()> || <translateY()> || <scale()> || <scaleX()> || <scaleY()> || <rotate()> || <skew()> || <skewX()> || <skewY()> || <matrix3d()> || <translate3d()> || <translateZ()> || <scale3d()> || <scaleZ()> || <rotate3d()> || <rotateX()> || <rotateY()> || <rotateZ()> || <perspective()> ]+",
-  "transform-list": "<transform-function>+",
-  "translate()": "translate( <length-percentage> [, <length-percentage> ]? )",
-  "translate3d()": "translate3d( <length-percentage> , <length-percentage> , <length> )",
-  "translateX()": "translateX( <length-percentage> )",
-  "translateY()": "translateY( <length-percentage> )",
-  "translateZ()": "translateZ( <length> )",
-  "type-or-unit": "string | integer | color | url | integer | number | length | angle | time | frequency | em | ex | px | rem | vw | vh | vmin | vmax | mm | q | cm | in | pt | pc | deg | grad | rad | ms | s | Hz | kHz | %",
-  "var()": "var( <custom-property-name> [, <declaration-value> ]? )",
-  "viewport-length": "auto | <length-percentage>"
+  "absolute-size": {
+    "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large"
+  },
+  "alpha-value": {
+    "syntax": "<number> | <percentage>"
+  },
+  "angle-percentage": {
+    "syntax": "<angle> | <percentage>"
+  },
+  "animateable-feature": {
+    "syntax": "scroll-position | contents | <custom-ident>"
+  },
+  "attachment": {
+    "syntax": "scroll | fixed | local"
+  },
+  "attr()": {
+    "syntax": "attr( <attr-name> <type-or-unit>? [, <attr-fallback> ]? )"
+  },
+  "auto-repeat": {
+    "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+  },
+  "auto-track-list": {
+    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+  },
+  "basic-shape": {
+    "syntax": "<inset()> | <circle()> | <ellipse()> | <polygon()>"
+  },
+  "bg-image": {
+    "syntax": "none | <image>"
+  },
+  "bg-layer": {
+    "syntax": "<bg-image> || <position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box>{1,2}"
+  },
+  "bg-size": {
+    "syntax": "[ <length-percentage> | auto ]{1,2} | cover | contain"
+  },
+  "blur()": {
+    "syntax": "blur( <length> )"
+  },
+  "blend-mode": {
+    "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
+  },
+  "box": {
+    "syntax": "border-box | padding-box | content-box"
+  },
+  "br-style": {
+    "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
+  },
+  "br-width": {
+    "syntax": "<length> | thin | medium | thick"
+  },
+  "brightness()": {
+    "syntax": "brightness( <number-percentage> )"
+  },
+  "calc()": {
+    "syntax": "calc( <calc-sum> )"
+  },
+  "calc-sum": {
+    "syntax": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
+  },
+  "calc-product": {
+    "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
+  },
+  "calc-value": {
+    "syntax": "<number> | <dimension> | <percentage> | ( <calc-sum> )"
+  },
+  "cf-final-image": {
+    "syntax": "<image> | <color>"
+  },
+  "cf-mixing-image": {
+    "syntax": "<percentage>? && <image>"
+  },
+  "circle()": {
+    "syntax": "circle( [ <shape-radius> ]? [ at <position> ]? )"
+  },
+  "clip-source": {
+    "syntax": "<url>"
+  },
+  "color": {
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>"
+  },
+  "color-stop": {
+    "syntax": "<color> <length-percentage>?"
+  },
+  "color-stop-list": {
+    "syntax": "<color-stop>#{2,}"
+  },
+  "common-lig-values": {
+    "syntax": "[ common-ligatures | no-common-ligatures ]"
+  },
+  "composite-style": {
+    "syntax": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"
+  },
+  "compositing-operator": {
+    "syntax": "add | subtract | intersect | exclude"
+  },
+  "contextual-alt-values": {
+    "syntax": "[ contextual | no-contextual ]"
+  },
+  "content-list": {
+    "syntax": "[ <string> | contents | <url> | <quote> | <target> | <leader()> ]+"
+  },
+  "contrast()": {
+    "syntax": "contrast( [ <number-percentage> ] )"
+  },
+  "counter-style": {
+    "syntax": "<counter-style-name> | symbols()"
+  },
+  "counter-style-name": {
+    "syntax": "<custom-ident>"
+  },
+  "cross-fade()": {
+    "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
+  },
+  "deprecated-system-color": {
+    "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonFace | ButtonHighlight | ButtonShadow | ButtonText | CaptionText | GrayText | Highlight | HighlightText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
+  },
+  "discretionary-lig-values": {
+    "syntax": "[ discretionary-ligatures | no-discretionary-ligatures ]"
+  },
+  "display-box": {
+    "syntax": "contents | none"
+  },
+  "display-inside": {
+    "syntax": "flow | flow-root | table | flex | grid | subgrid | ruby"
+  },
+  "display-internal": {
+    "syntax": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
+  },
+  "display-legacy": {
+    "syntax": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
+  },
+  "display-listitem": {
+    "syntax": "list-item && <display-outside>? && [ flow | flow-root ]?"
+  },
+  "display-outside": {
+    "syntax": "block | inline | run-in"
+  },
+  "drop-shadow()": {
+    "syntax": "drop-shadow( <length>{2,3} <color>? )"
+  },
+  "east-asian-variant-values": {
+    "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
+  },
+  "east-asian-width-values": {
+    "syntax": "[ full-width | proportional-width ]"
+  },
+  "element()": {
+    "syntax": "element( <id-selector> )"
+  },
+  "ellipse()": {
+    "syntax": "ellipse( [ <shape-radius>{2} ]? [ at <position> ]? )"
+  },
+  "ending-shape": {
+    "syntax": "circle | ellipse"
+  },
+  "explicit-track-list": {
+    "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
+  },
+  "family-name": {
+    "syntax": "<string> | <custom-ident>+"
+  },
+  "feature-tag-value": {
+    "syntax": "<string> [ <integer> | on | off ]?"
+  },
+  "feature-type": {
+    "syntax": "@stylistic | @historical-forms | @styleset | @character-variant | @swash | @ornaments | @annotation"
+  },
+  "feature-value-block": {
+    "syntax": "<feature-type> {\n  <feature-value-declaration-list>\n}"
+  },
+  "feature-value-block-list": {
+    "syntax": "<feature-value-block>+"
+  },
+  "feature-value-declaration": {
+    "syntax": "<custom-ident>: <integer>+;"
+  },
+  "feature-value-declaration-list": {
+    "syntax": "<feature-value-declaration>"
+  },
+  "feature-value-name": {
+    "syntax": "<custom-ident>"
+  },
+  "fill-rule": {
+    "syntax": "nonzero | evenodd"
+  },
+  "filter-function": {
+    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
+  },
+  "filter-function-list": {
+    "syntax": "[ <filter-function> | <url> ]+"
+  },
+  "final-bg-layer": {
+    "syntax": "<bg-image> || <position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box> || <box> || <'background-color'>"
+  },
+  "fit-content()": {
+    "syntax": "fit-content( [ <length> | <percentage> ] )"
+  },
+  "fixed-breadth": {
+    "syntax": "<length-percentage>"
+  },
+  "fixed-repeat": {
+    "syntax": "repeat( [ <positive-integer> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+  },
+  "fixed-size": {
+    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
+  },
+  "font-variant-css21": {
+    "syntax": "[ normal | small-caps ]"
+  },
+  "frequency-percentage": {
+    "syntax": "<frequency> | <percentage>"
+  },
+  "general-enclosed": {
+    "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
+  },
+  "generic-family": {
+    "syntax": "serif | sans-serif | cursive | fantasy | monospace"
+  },
+  "generic-name": {
+    "syntax": "serif | sans-serif | cursive | fantasy | monospace"
+  },
+  "geometry-box": {
+    "syntax": "<shape-box> | fill-box | stroke-box | view-box"
+  },
+  "gradient": {
+    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+  },
+  "grayscale()": {
+    "syntax": "grayscale( <number-percentage> )"
+  },
+  "grid-line": {
+    "syntax": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
+  },
+  "historical-lig-values": {
+    "syntax": "[ historical-ligatures | no-historical-ligatures ]"
+  },
+  "hsl()": {
+    "syntax": "hsl( [ <hue> <percentage> <percentage> [ / <alpha-value> ]? ] | [ <hue>, <percentage>, <percentage>, <alpha-value>? ] )"
+  },
+  "hsla()": {
+    "syntax": "hsla( [ <hue> <percentage> <percentage> [ / <alpha-value> ]? ] | [ <hue>, <percentage>, <percentage>, <alpha-value>? ] )"
+  },
+  "hue": {
+    "syntax": "<number> | <angle>"
+  },
+  "hue-rotate()": {
+    "syntax": "hue-rotate( <angle> )"
+  },
+  "image": {
+    "syntax": "<url> | <image()> | <image-set()> | <element()> | <cross-fade()> | <gradient>"
+  },
+  "image()": {
+    "syntax": "image( [ [ <image> | <string> ]? , <color>? ]! )"
+  },
+  "image-set()": {
+    "syntax": "image-set( <image-set-option># )"
+  },
+  "image-set-option": {
+    "syntax": "[ <image> | <string> ] <resolution>"
+  },
+  "inflexible-breadth": {
+    "syntax": "<length> | <percentage> | min-content | max-content | auto"
+  },
+  "inset()": {
+    "syntax": "inset( <length-percentage>{1,4} [ round <border-radius> ]? )"
+  },
+  "invert()": {
+    "syntax": "invert( <number-percentage> )"
+  },
+  "keyframes-name": {
+    "syntax": "<custom-ident> | <string>"
+  },
+  "keyframe-block": {
+    "syntax": "<keyframe-selector># {\n  <declaration-list>\n}"
+  },
+  "keyframe-block-list": {
+    "syntax": "<keyframe-block>+"
+  },
+  "keyframe-selector": {
+    "syntax": "from | to | <percentage>"
+  },
+  "leader()": {
+    "syntax": "leader( dotted | solid | space | <string> )"
+  },
+  "length-percentage": {
+    "syntax": "<length> | <percentage>"
+  },
+  "line-names": {
+    "syntax": "'[' <custom-ident>* ']'"
+  },
+  "line-name-list": {
+    "syntax": "[ <line-names> | <name-repeat> ]+"
+  },
+  "linear-gradient()": {
+    "syntax": "linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )"
+  },
+  "mask-layer": {
+    "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
+  },
+  "mask-position": {
+    "syntax": "[ <length-percentage> | left | center | right ] [ <length-percentage> | top | center | bottom ]?"
+  },
+  "mask-reference": {
+    "syntax": "none | <image> | <mask-source>"
+  },
+  "mask-source": {
+    "syntax": "<url>"
+  },
+  "masking-mode": {
+    "syntax": "alpha | luminance | match-source"
+  },
+  "matrix()": {
+    "syntax": "matrix( <number> [, <number> ]{5,5} )"
+  },
+  "matrix3d()": {
+    "syntax": "matrix3d( <number> [, <number> ]{15,15} )"
+  },
+  "media-and": {
+    "syntax": "<media-in-parens> [ and <media-in-parens> ]+"
+  },
+  "media-condition": {
+    "syntax": "<media-not> | <media-and> | <media-or> | <media-in-parens>"
+  },
+  "media-condition-without-or": {
+    "syntax": "<media-not> | <media-and> | <media-in-parens>"
+  },
+  "media-feature": {
+    "syntax": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
+  },
+  "media-in-parens": {
+    "syntax": "( <media-condition> ) | <media-feature> | <general-enclosed>"
+  },
+  "media-not": {
+    "syntax": "not <media-in-parens>"
+  },
+  "media-or": {
+    "syntax": "<media-in-parens> [ or <media-in-parens> ]+"
+  },
+  "media-query": {
+    "syntax": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
+  },
+  "media-query-list": {
+    "syntax": "<media-query>#"
+  },
+  "media-type": {
+    "syntax": "<ident>"
+  },
+  "mf-boolean": {
+    "syntax": "<mf-name>"
+  },
+  "mf-name": {
+    "syntax": "<ident>"
+  },
+  "mf-plain": {
+    "syntax": "<mf-name> : <mf-value>"
+  },
+  "mf-range": {
+    "syntax": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
+  },
+  "mf-value": {
+    "syntax": "<number> | <dimension> | <ident> | <ratio>"
+  },
+  "minmax()": {
+    "syntax": "minmax( [ <length> | <percentage> | <flex> | min-content | max-content | auto ] , [ <length> | <percentage> | <flex> | min-content | max-content | auto ] )"
+  },
+  "named-color": {
+    "syntax": "transparent | aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
+  },
+  "namespace-prefix": {
+    "syntax": "<ident>"
+  },
+  "number-percentage": {
+    "syntax": "<number> | <percentage>"
+  },
+  "numeric-figure-values": {
+    "syntax": "[ lining-nums | oldstyle-nums ]"
+  },
+  "numeric-fraction-values": {
+    "syntax": "[ diagonal-fractions | stacked-fractions ]"
+  },
+  "numeric-spacing-values": {
+    "syntax": "[ proportional-nums | tabular-nums ]"
+  },
+  "nth": {
+    "syntax": "<an-plus-b> | even | odd"
+  },
+  "opacity()": {
+    "syntax": "opacity( [ <number-percentage> ] )"
+  },
+  "page-body": {
+    "syntax": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
+  },
+  "page-margin-box": {
+    "syntax": "<page-margin-box-type> {\n  <declaration-list>\n}"
+  },
+  "page-margin-box-type": {
+    "syntax": "@top-left-corner | @top-left | @top-center | @top-right | @top-right-corner | @bottom-left-corner | @bottom-left | @bottom-center | @bottom-right | @bottom-right-corner | @left-top | @left-middle | @left-bottom | @right-top | @right-middle | @right-bottom"
+  },
+  "page-selector-list": {
+    "syntax": "[ <page-selector># ]?"
+  },
+  "page-selector": {
+    "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+  },
+  "perspective()": {
+    "syntax": "perspective( <length> )"
+  },
+  "polygon()": {
+    "syntax": "polygon( <fill-rule>? , [ <length-percentage> <length-percentage> ]# )"
+  },
+  "position": {
+    "syntax": "[[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ]]"
+  },
+  "pseudo-page": {
+    "syntax": ": [ left | right | first | blank ]"
+  },
+  "quote": {
+    "syntax": "open-quote | close-quote | no-open-quote | no-close-quote"
+  },
+  "radial-gradient()": {
+    "syntax": "radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )"
+  },
+  "relative-size": {
+    "syntax": "larger | smaller"
+  },
+  "repeat-style": {
+    "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
+  },
+  "repeating-linear-gradient()": {
+    "syntax": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )"
+  },
+  "repeating-radial-gradient()": {
+    "syntax": "repeating-radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )"
+  },
+  "rgb()": {
+    "syntax": "rgb( [ [ <percentage>{3} | <number>{3} ] [ / <alpha-value> ]? ] | [ [ <percentage>#{3} | <number>#{3} ] , <alpha-value>? ] )"
+  },
+  "rgba()": {
+    "syntax": "rgba( [ [ <percentage>{3} | <number>{3} ] [ / <alpha-value> ]? ] | [ [ <percentage>#{3} | <number>#{3} ] , <alpha-value>? ] )"
+  },
+  "rotate()": {
+    "syntax": "rotate( <angle> )"
+  },
+  "rotate3d()": {
+    "syntax": "rotate3d( <number> , <number> , <number> , <angle> )"
+  },
+  "rotateX()": {
+    "syntax": "rotateX( <angle> )"
+  },
+  "rotateY()": {
+    "syntax": "rotateY( <angle> )"
+  },
+  "rotateZ()": {
+    "syntax": "rotateZ( <angle> )"
+  },
+  "saturate()": {
+    "syntax": "saturate( <number-percentage> )"
+  },
+  "scale()": {
+    "syntax": "scale( <number> [, <number> ]? )"
+  },
+  "scale3d()": {
+    "syntax": "scale3d( <number> , <number> , <number> )"
+  },
+  "scaleX()": {
+    "syntax": "scaleX( <number> )"
+  },
+  "scaleY()": {
+    "syntax": "scaleY( <number> )"
+  },
+  "scaleZ()": {
+    "syntax": "scaleZ( <number> )"
+  },
+  "shape-radius": {
+    "syntax": "<length-percentage> | closest-side | farthest-side"
+  },
+  "skew()": {
+    "syntax": "skew( <angle> [, <angle> ]? )"
+  },
+  "skewX()": {
+    "syntax": "skewX( <angle> )"
+  },
+  "skewY()": {
+    "syntax": "skewY( <angle> )"
+  },
+  "sepia()": {
+    "syntax": "sepia( <number-percentage> )"
+  },
+  "shadow": {
+    "syntax": "inset? && <length>{2,4} && <color>?"
+  },
+  "shadow-t": {
+    "syntax": "[ <length>{2,3} && <color>? ]"
+  },
+  "shape": {
+    "syntax": "rect(<top>, <right>, <bottom>, <left>)"
+  },
+  "shape-box": {
+    "syntax": "<box> | margin-box"
+  },
+  "side-or-corner": {
+    "syntax": "[ left | right ] || [ top | bottom ]"
+  },
+  "single-animation": {
+    "syntax": "<time> || <single-timing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
+  },
+  "single-animation-direction": {
+    "syntax": "normal | reverse | alternate | alternate-reverse"
+  },
+  "single-animation-fill-mode": {
+    "syntax": "none | forwards | backwards | both"
+  },
+  "single-animation-iteration-count": {
+    "syntax": "infinite | <number>"
+  },
+  "single-animation-play-state": {
+    "syntax": "running | paused"
+  },
+  "single-timing-function": {
+    "syntax": "<single-transition-timing-function>"
+  },
+  "single-transition": {
+    "syntax": "[ none | <single-transition-property> ] || <time> || <single-transition-timing-function> || <time>"
+  },
+  "single-transition-timing-function": {
+    "syntax": "ease | linear | ease-in | ease-out | ease-in-out | step-start | step-end | steps( <integer> [, [ start | end ] ]? ) | cubic-bezier( <number>, <number>, <number>, <number> )"
+  },
+  "single-transition-property": {
+    "syntax": "all | <custom-ident>"
+  },
+  "size": {
+    "syntax": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
+  },
+  "symbol": {
+    "syntax": "<string> | <image> | <ident>"
+  },
+  "target": {
+    "syntax": "<target-counter()> | <target-counters()> | <target-text()>"
+  },
+  "target-counter()": {
+    "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> [, <counter-style> ]? )"
+  },
+  "target-counters()": {
+    "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> [, <counter-style> ]? )"
+  },
+  "target-text()": {
+    "syntax": "target-text( [ <string> | <url> ] [, [ content | before | after | first-letter ] ]? )"
+  },
+  "time-percentage": {
+    "syntax": "<time> | <percentage>"
+  },
+  "track-breadth": {
+    "syntax": "<length-percentage> | <flex> | min-content | max-content | auto"
+  },
+  "track-list": {
+    "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
+  },
+  "track-repeat": {
+    "syntax": "repeat( [ <positive-integer> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
+  },
+  "track-size": {
+    "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( [ <length> | <percentage> ] )"
+  },
+  "transform-function": {
+    "syntax": "[ <matrix()> || <translate()> || <translateX()> || <translateY()> || <scale()> || <scaleX()> || <scaleY()> || <rotate()> || <skew()> || <skewX()> || <skewY()> || <matrix3d()> || <translate3d()> || <translateZ()> || <scale3d()> || <scaleZ()> || <rotate3d()> || <rotateX()> || <rotateY()> || <rotateZ()> || <perspective()> ]+"
+  },
+  "transform-list": {
+    "syntax": "<transform-function>+"
+  },
+  "translate()": {
+    "syntax": "translate( <length-percentage> [, <length-percentage> ]? )"
+  },
+  "translate3d()": {
+    "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
+  },
+  "translateX()": {
+    "syntax": "translateX( <length-percentage> )"
+  },
+  "translateY()": {
+    "syntax": "translateY( <length-percentage> )"
+  },
+  "translateZ()": {
+    "syntax": "translateZ( <length> )"
+  },
+  "type-or-unit": {
+    "syntax": "string | integer | color | url | integer | number | length | angle | time | frequency | em | ex | px | rem | vw | vh | vmin | vmax | mm | q | cm | in | pt | pc | deg | grad | rad | ms | s | Hz | kHz | %"
+  },
+  "var()": {
+    "syntax": "var( <custom-property-name> [, <declaration-value> ]? )"
+  },
+  "viewport-length": {
+    "syntax": "auto | <length-percentage>"
+  }
 }

--- a/css/syntaxes.schema.json
+++ b/css/syntaxes.schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "additionalProperties": {
-    "type": "string"
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "syntax"
+    ],
+    "properties": {
+      "syntax": {
+        "type": "string"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR makes `syntax.json` format uniform with other dictionaries. Also, this make it possible to extend the description of the syntaxes in the future.
Changes based on #41 
