### PR TITLE
[DO NOT MERGE] Add __l10nkey: to CSS properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1,188 +1,173 @@
 {
   "--*": {
     "syntax": "<declaration-value>",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Variables"
     ],
-    "initial": "seeProse",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedWithVarsSubstituted",
-    "order": "perGrammar",
+    "initial": "__l10nkey:seeProse",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedWithVarsSubstituted",
+    "order": "__l10nkey:perGrammar",
     "status": "experimental"
-  },
-  "-ms-overflow-style": {
-    "syntax": "auto | none | scrollbar | -ms-autohiding-scrollbar",
-    "media": "interactive",
-    "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "Microsoft Extensions"
-    ],
-    "initial": "auto",
-    "appliesto": "nonReplacedBlockAndInlineBlockElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
-    "status": "nonstandard"
   },
   "-moz-appearance": {
     "syntax": "none | button | button-arrow-down | button-arrow-next | button-arrow-previous | button-arrow-up | button-bevel | button-focus | caret | checkbox | checkbox-container | checkbox-label | checkmenuitem | dualbutton | groupbox | listbox | listitem | menuarrow | menubar | menucheckbox | menuimage | menuitem | menuitemtext | menulist | menulist-button | menulist-text | menulist-textfield | menupopup | menuradio | menuseparator | meterbar | meterchunk | progressbar | progressbar-vertical | progresschunk | progresschunk-vertical | radio | radio-container | radio-label | radiomenuitem | range | range-thumb | resizer | resizerpanel | scale-horizontal | scalethumbend | scalethumb-horizontal | scalethumbstart | scalethumbtick | scalethumb-vertical | scale-vertical | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | separator | sheet | spinner | spinner-downbutton | spinner-textfield | spinner-upbutton | splitter | statusbar | statusbarpanel | tab | tabpanel | tabpanels | tab-scroll-arrow-back | tab-scroll-arrow-forward | textfield | textfield-multiline | toolbar | toolbarbutton | toolbarbutton-dropdown | toolbargripper | toolbox | tooltip | treeheader | treeheadercell | treeheadersortarrow | treeitem | treeline | treetwisty | treetwistyopen | treeview | -moz-mac-unified-toolbar | -moz-win-borderless-glass | -moz-win-browsertabbar-toolbox | -moz-win-communicationstext | -moz-win-communications-toolbox | -moz-win-exclude-glass | -moz-win-glass | -moz-win-mediatext | -moz-win-media-toolbox | -moz-window-button-box | -moz-window-button-box-maximized | -moz-window-button-close | -moz-window-button-maximize | -moz-window-button-minimize | -moz-window-button-restore | -moz-window-frame-bottom | -moz-window-frame-left | -moz-window-frame-right | -moz-window-titlebar | -moz-window-titlebar-maximized",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
-    "initial": "noneButOverriddenInUserAgentCSS",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:noneButOverriddenInUserAgentCSS",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-binding": {
     "syntax": "<url> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElementsExceptGeneratedContentOrPseudoElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptGeneratedContentOrPseudoElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-border-bottom-colors": {
     "syntax": "[ <color> ]* <color> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-border-left-colors": {
     "syntax": "[ <color> ]* <color> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-border-right-colors": {
     "syntax": "[ <color> ]* <color> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-border-top-colors": {
     "syntax": "[ <color> ]* <color> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-float-edge": {
     "syntax": "border-box | content-box | margin-box | padding-box",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "content-box",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-force-broken-image-icon": {
     "syntax": "<integer>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "0",
-    "appliesto": "images",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:images",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-image-region": {
     "syntax": "<shape> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "auto",
-    "appliesto": "xulImageElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:xulImageElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-orient": {
     "syntax": "inline | block | horizontal | vertical",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "inline",
-    "appliesto": "anyElementEffectOnProgressAndMeter",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:anyElementEffectOnProgressAndMeter",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-outline-radius": {
     "syntax": "<outline-radius>{1,4} [ / <outline-radius>{1,4} ]?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "-moz-outline-radius-topleft",
@@ -205,171 +190,186 @@
       "-moz-outline-radius-bottomright",
       "-moz-outline-radius-bottomleft"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "-moz-outline-radius-topleft",
       "-moz-outline-radius-topright",
       "-moz-outline-radius-bottomright",
       "-moz-outline-radius-bottomleft"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-outline-radius-bottomleft": {
     "syntax": "<outline-radius>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "yes",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:yes",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-outline-radius-bottomright": {
     "syntax": "<outline-radius>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "yes",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:yes",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-outline-radius-topleft": {
     "syntax": "<outline-radius>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "yes",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:yes",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-outline-radius-topright": {
     "syntax": "<outline-radius>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "yes",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:yes",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-stack-sizing": {
     "syntax": "ignore | stretch-to-fit",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "stretch-to-fit",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-text-blink": {
     "syntax": "none | blink",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-user-focus": {
     "syntax": "ignore | normal | select-after | select-before | select-menu | select-same | select-all | none",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-user-input": {
     "syntax": "auto | none | enabled | disabled",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-user-modify": {
     "syntax": "read-only | read-write | write-only",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "read-only",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-moz-window-shadow": {
     "syntax": "default | menu | tooltip | sheet | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "default",
-    "appliesto": "allElementsCreatingNativeWindows",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsCreatingNativeWindows",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-overflow-style": {
+    "syntax": "auto | none | scrollbar | -ms-autohiding-scrollbar",
+    "media": "__l10nkey:interactive",
+    "inherited": true,
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "__l10nkey:nonReplacedBlockAndInlineBlockElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-border-before": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "__l10nkey:discrete",
     "percentages": [
       "-webkit-border-before-width"
     ],
@@ -379,83 +379,83 @@
     "initial": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-border-before-color": {
     "syntax": "<'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
-    "computed": "computedColor",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:computedColor",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-border-before-style": {
     "syntax": "<'border-style'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-border-before-width": {
     "syntax": "<'border-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-box-reflect": {
     "syntax": "[ above | below | right | left ]? <length>? <image>?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-mask": {
     "syntax": "<mask-image> [ <mask-repeat> || <mask-attachment> || <mask-position> || <mask-origin> || <mask-clip> ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
@@ -467,7 +467,7 @@
       "-webkit-mask-origin",
       "-webkit-mask-clip"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "-webkit-mask-image",
       "-webkit-mask-repeat",
@@ -476,213 +476,213 @@
       "-webkit-mask-origin",
       "-webkit-mask-clip"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-mask-attachment": {
     "syntax": "<attachment> [, <attachment> ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "scroll",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-clip": {
     "syntax": "<clip-style> [, <clip-style> ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "border",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-composite": {
     "syntax": "<composite-style> [, <composite-style> ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "source-over",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-image": {
     "syntax": "<mask-image> [, <mask-image> ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "absoluteURIOrNone",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteURIOrNone",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-origin": {
     "syntax": "[ padding | border | content ] [, [ border | padding | content ] ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "padding",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-position": {
     "syntax": "<mask-position>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToSizeOfElement",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToSizeOfElement",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "0% 0%",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOrPercentage",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOrPercentage",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-position-x": {
     "syntax": "[ <length-percentage> | left | center | right ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToSizeOfElement",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToSizeOfElement",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "0%",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOrPercentage",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOrPercentage",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-position-y": {
     "syntax": "[ <length-percentage> | top | center | bottom ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToSizeOfElement",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToSizeOfElement",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "0%",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOrPercentage",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOrPercentage",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-repeat": {
     "syntax": "<repeat-style> [, <repeat-style> ]*",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "repeat",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-repeat-x": {
     "syntax": "repeat | no-repeat | space | round",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "repeat",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-mask-repeat-y": {
     "syntax": "repeat | no-repeat | space | round",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "repeat",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "nonstandard"
   },
   "-webkit-tap-highlight-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "black",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-text-fill-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-text-stroke": {
     "syntax": "<length> || <color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
     "animationType": [
       "-webkit-text-stroke-width",
       "-webkit-text-stroke-color"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
@@ -690,42 +690,42 @@
       "-webkit-text-stroke-width",
       "-webkit-text-stroke-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "-webkit-text-stroke-width",
       "-webkit-text-stroke-color"
     ],
-    "order": "canonicalOrder",
+    "order": "__l10nkey:canonicalOrder",
     "status": "nonstandard"
   },
   "-webkit-text-stroke-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-text-stroke-width": {
     "syntax": "<length>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "WebKit Extensions"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "absoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "-webkit-touch-callout": {
@@ -737,70 +737,70 @@
   },
   "align-content": {
     "syntax": "flex-start | flex-end | center | space-between | space-around | space-evenly | stretch",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "stretch",
-    "appliesto": "multilineFlexContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:multilineFlexContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "align-items": {
     "syntax": "flex-start | flex-end | center | baseline | stretch",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "stretch",
-    "appliesto": "flexContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "align-self": {
     "syntax": "auto | flex-start | flex-end | center | baseline | stretch",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "auto",
-    "appliesto": "flexItemsAndInFlowPseudos",
-    "computed": "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexItemsAndInFlowPseudos",
+    "computed": "__l10nkey:autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "all": {
     "syntax": "initial | inherit | unset",
-    "media": "noPracticalMedia",
+    "media": "__l10nkey:noPracticalMedia",
     "inherited": false,
-    "animationType": "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
-    "percentages": "no",
+    "animationType": "__l10nkey:eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Miscellaneous"
     ],
-    "initial": "noPracticalInitialValue",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedAppliesToEachProperty",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:noPracticalInitialValue",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedAppliesToEachProperty",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation": {
     "syntax": "<single-animation>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
@@ -814,7 +814,7 @@
       "animation-fill-mode",
       "animation-play-state"
     ],
-    "appliesto": "allElementsAndPseudos",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
     "computed": [
       "animation-name",
       "animation-duration",
@@ -825,140 +825,140 @@
       "animation-fill-mode",
       "animation-play-state"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "animation-delay": {
     "syntax": "<time>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "0s",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-direction": {
     "syntax": "<single-animation-direction>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "normal",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-duration": {
     "syntax": "<time>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "0s",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-fill-mode": {
     "syntax": "<single-animation-fill-mode>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "none",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-iteration-count": {
     "syntax": "<single-animation-iteration-count>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "1",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-name": {
     "syntax": "[ none | <keyframes-name> ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "none",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-play-state": {
     "syntax": "<single-animation-play-state>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "running",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "animation-timing-function": {
     "syntax": "<single-timing-function>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Animations"
     ],
     "initial": "ease",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "appearance": {
     "syntax": "auto | none",
-    "media": "all",
-    "inherited": "no",
-    "animationType": "discrete",
-    "percentages": "no",
+    "media": "__l10nkey:all",
+    "inherited": "__l10nkey:no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "As specified",
     "order": "per grammar",
     "status": "experimental"
@@ -967,50 +967,50 @@
     "syntax": "<angle> | [ [ left-side | far-left | left | center-left | center | center-right | right | far-right | right-side ] || behind ] | leftwards | rightwards",
     "media": "aural",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Speech"
     ],
     "initial": "center",
-    "appliesto": "allElements",
-    "computed": "normalizedAngle",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:normalizedAngle",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "obsolete"
   },
   "backdrop-filter": {
     "syntax": "none | <filter-function-list>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "filterList",
-    "percentages": "no",
+    "animationType": "__l10nkey:filterList",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Filter Effects"
     ],
     "initial": "none",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "backface-visibility": {
     "syntax": "visible | hidden",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "visible",
-    "appliesto": "transformableElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "background": {
     "syntax": "[ <bg-layer> , ]* <final-bg-layer>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "background-color",
@@ -1038,7 +1038,7 @@
       "background-attachment",
       "background-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "background-image",
       "background-position",
@@ -1049,7 +1049,7 @@
       "background-attachment",
       "background-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1059,17 +1059,17 @@
   },
   "background-attachment": {
     "syntax": "<attachment>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "scroll",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1081,15 +1081,15 @@
     "syntax": "<blend-mode>#",
     "media": "none",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Compositing and Blending"
     ],
     "initial": "normal",
-    "appliesto": "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1099,17 +1099,17 @@
   },
   "background-clip": {
     "syntax": "<box>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "border-box",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1119,17 +1119,17 @@
   },
   "background-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "transparent",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1139,17 +1139,17 @@
   },
   "background-image": {
     "syntax": "<bg-image>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedURIsAbsolute",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedURIsAbsolute",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1159,17 +1159,17 @@
   },
   "background-origin": {
     "syntax": "<box>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "padding-box",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1179,17 +1179,17 @@
   },
   "background-position": {
     "syntax": "<position>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "repeatableList simpleList lpc",
-    "percentages": "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
+    "percentages": "__l10nkey:referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "0% 0%",
-    "appliesto": "allElements",
-    "computed": "listEachItemTwoKeywordsOriginOffsets",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:listEachItemTwoKeywordsOriginOffsets",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1199,47 +1199,47 @@
   },
   "background-position-x": {
     "syntax": "[ center | [ left | right | x-start | x-end ]? <length-percentage>? ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToWidthOfBackgroundPositioningAreaMinusBackgroundImageHeight",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "left",
-    "appliesto": "allElements",
-    "computed": "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "background-position-y": {
     "syntax": "[ center | [ top | bottom | y-start | y-end ]? <length-percentage>? ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "top",
-    "appliesto": "allElements",
-    "computed": "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "background-repeat": {
     "syntax": "<repeat-style>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "repeat",
-    "appliesto": "allElements",
-    "computed": "listEachItemHasTwoKeywordsOnePerDimension",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:listEachItemHasTwoKeywordsOnePerDimension",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1249,17 +1249,17 @@
   },
   "background-size": {
     "syntax": "<bg-size>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "repeatableList simpleList lpc keywords",
-    "percentages": "relativeToBackgroundPositioningArea",
+    "percentages": "__l10nkey:relativeToBackgroundPositioningArea",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "auto auto",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -1269,29 +1269,29 @@
   },
   "block-size": {
     "syntax": "<'width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "blockSizeOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:blockSizeOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "auto",
-    "appliesto": "sameAsWidthAndHeight",
-    "computed": "sameAsWidthAndHeight",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsWidthAndHeight",
+    "computed": "__l10nkey:sameAsWidthAndHeight",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border": {
     "syntax": "<br-width> || <br-style> || <color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-color",
       "border-style",
       "border-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -1300,13 +1300,13 @@
       "border-style",
       "border-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-width",
       "border-style",
       "border-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1314,150 +1314,150 @@
   },
   "border-block-end": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-end-color": {
     "syntax": "<'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
-    "computed": "computedColor",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:computedColor",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-end-style": {
     "syntax": "<'border-style'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-end-width": {
     "syntax": "<'border-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-start": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-start-color": {
     "syntax": "<'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
-    "computed": "computedColor",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:computedColor",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-start-style": {
     "syntax": "<'border-style'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-block-start-width": {
     "syntax": "<'border-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-bottom": {
     "syntax": "<br-width> || <br-style> || <color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-bottom-color",
       "border-bottom-style",
       "border-bottom-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -1466,13 +1466,13 @@
       "border-bottom-style",
       "border-bottom-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-bottom-width",
       "border-bottom-style",
       "border-bottom-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1480,17 +1480,17 @@
   },
   "border-bottom-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1498,17 +1498,17 @@
   },
   "border-bottom-left-radius": {
     "syntax": "<length-percentage>{1,2}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToDimensionOfBorderBox",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToDimensionOfBorderBox",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "0",
-    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
-    "computed": "twoAbsoluteLengthOrPercentages",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsUAsNotRequiredWhenCollapse",
+    "computed": "__l10nkey:twoAbsoluteLengthOrPercentages",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1516,17 +1516,17 @@
   },
   "border-bottom-right-radius": {
     "syntax": "<length-percentage>{1,2}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToDimensionOfBorderBox",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToDimensionOfBorderBox",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "0",
-    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
-    "computed": "twoAbsoluteLengthOrPercentages",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsUAsNotRequiredWhenCollapse",
+    "computed": "__l10nkey:twoAbsoluteLengthOrPercentages",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1534,17 +1534,17 @@
   },
   "border-bottom-style": {
     "syntax": "<br-style>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1552,17 +1552,17 @@
   },
   "border-bottom-width": {
     "syntax": "<br-width>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1570,22 +1570,22 @@
   },
   "border-collapse": {
     "syntax": "collapse | separate",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Table"
     ],
     "initial": "separate",
-    "appliesto": "tableElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:tableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-color": {
     "syntax": "<color>{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-bottom-color",
@@ -1593,7 +1593,7 @@
       "border-right-color",
       "border-top-color"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -1603,14 +1603,14 @@
       "border-bottom-color",
       "border-left-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-bottom-color",
       "border-left-color",
       "border-right-color",
       "border-top-color"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1618,9 +1618,9 @@
   },
   "border-image": {
     "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "__l10nkey:discrete",
     "percentages": [
       "border-image-slice",
       "border-image-width"
@@ -1649,7 +1649,7 @@
       "border-image-source",
       "border-image-width"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1657,17 +1657,17 @@
   },
   "border-image-outset": {
     "syntax": "[ <length> | <number> ]{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "0s",
-    "appliesto": "allElementsExceptTableElementsWhenCollapse",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableElementsWhenCollapse",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1675,17 +1675,17 @@
   },
   "border-image-repeat": {
     "syntax": "[ stretch | repeat | round | space ]{1,2}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "stretch",
-    "appliesto": "allElementsExceptTableElementsWhenCollapse",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableElementsWhenCollapse",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1693,17 +1693,17 @@
   },
   "border-image-slice": {
     "syntax": "<number-percentage>{1,4} && fill?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToSizeOfBorderImage",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToSizeOfBorderImage",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "100%",
-    "appliesto": "allElementsExceptTableElementsWhenCollapse",
-    "computed": "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
-    "order": "percentagesOrLengthsFollowedByFill",
+    "appliesto": "__l10nkey:allElementsExceptTableElementsWhenCollapse",
+    "computed": "__l10nkey:oneToFourPercentagesOrAbsoluteLengthsPlusFill",
+    "order": "__l10nkey:percentagesOrLengthsFollowedByFill",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1711,17 +1711,17 @@
   },
   "border-image-source": {
     "syntax": "none | <image>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "none",
-    "appliesto": "allElementsExceptTableElementsWhenCollapse",
-    "computed": "noneOrImageWithAbsoluteURI",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableElementsWhenCollapse",
+    "computed": "__l10nkey:noneOrImageWithAbsoluteURI",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1729,17 +1729,17 @@
   },
   "border-image-width": {
     "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToWidthOrHeightOfBorderImageArea",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToWidthOrHeightOfBorderImageArea",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "1",
-    "appliesto": "allElementsExceptTableElementsWhenBorderCollapseCollapse",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableElementsWhenBorderCollapseCollapse",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1747,150 +1747,150 @@
   },
   "border-inline-end": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-end-color": {
     "syntax": "<'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
-    "computed": "computedColor",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:computedColor",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-end-style": {
     "syntax": "<'border-style'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-end-width": {
     "syntax": "<'border-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-start": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "__l10nkey:color"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-start-color": {
     "syntax": "<'color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
-    "computed": "computedColor",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:computedColor",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-start-style": {
     "syntax": "<'border-style'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-inline-start-width": {
     "syntax": "<'border-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-left": {
     "syntax": "<br-width> || <br-style> || <color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-left-color",
       "border-left-style",
       "border-left-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -1899,13 +1899,13 @@
       "border-left-style",
       "border-left-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-left-width",
       "border-left-style",
       "border-left-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1913,17 +1913,17 @@
   },
   "border-left-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1931,17 +1931,17 @@
   },
   "border-left-style": {
     "syntax": "<br-style>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1949,17 +1949,17 @@
   },
   "border-left-width": {
     "syntax": "<br-width>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -1967,7 +1967,7 @@
   },
   "border-radius": {
     "syntax": "<length-percentage>{1,4} [ / <length-percentage>{1,4} ]?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-top-left-radius",
@@ -1975,7 +1975,7 @@
       "border-bottom-right-radius",
       "border-bottom-left-radius"
     ],
-    "percentages": "referToDimensionOfBorderBox",
+    "percentages": "__l10nkey:referToDimensionOfBorderBox",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -1985,14 +1985,14 @@
       "border-bottom-right-radius",
       "border-bottom-left-radius"
     ],
-    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "appliesto": "__l10nkey:allElementsUAsNotRequiredWhenCollapse",
     "computed": [
       "border-bottom-left-radius",
       "border-bottom-right-radius",
       "border-top-left-radius",
       "border-top-right-radius"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2000,14 +2000,14 @@
   },
   "border-right": {
     "syntax": "<br-width> || <br-style> || <color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-right-color",
       "border-right-style",
       "border-right-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -2016,13 +2016,13 @@
       "border-right-style",
       "border-right-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-right-width",
       "border-right-style",
       "border-right-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2030,17 +2030,17 @@
   },
   "border-right-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2048,17 +2048,17 @@
   },
   "border-right-style": {
     "syntax": "<br-style>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2066,17 +2066,17 @@
   },
   "border-right-width": {
     "syntax": "<br-width>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2084,25 +2084,25 @@
   },
   "border-spacing": {
     "syntax": "<length> <length>?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Table"
     ],
     "initial": "0",
-    "appliesto": "tableElements",
-    "computed": "twoAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:tableElements",
+    "computed": "__l10nkey:twoAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "border-style": {
     "syntax": "<br-style>{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -2112,14 +2112,14 @@
       "border-bottom-style",
       "border-left-style"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-bottom-style",
       "border-left-style",
       "border-right-style",
       "border-top-style"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2127,14 +2127,14 @@
   },
   "border-top": {
     "syntax": "<br-width> || <br-style> || <color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-top-color",
       "border-top-style",
       "border-top-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -2143,13 +2143,13 @@
       "border-top-style",
       "border-top-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-top-width",
       "border-top-style",
       "border-top-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2157,17 +2157,17 @@
   },
   "border-top-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2175,17 +2175,17 @@
   },
   "border-top-left-radius": {
     "syntax": "<length-percentage>{1,2}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToDimensionOfBorderBox",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToDimensionOfBorderBox",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "0",
-    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
-    "computed": "twoAbsoluteLengthOrPercentages",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsUAsNotRequiredWhenCollapse",
+    "computed": "__l10nkey:twoAbsoluteLengthOrPercentages",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2193,17 +2193,17 @@
   },
   "border-top-right-radius": {
     "syntax": "<length-percentage>{1,2}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToDimensionOfBorderBox",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToDimensionOfBorderBox",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "0",
-    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
-    "computed": "twoAbsoluteLengthOrPercentages",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsUAsNotRequiredWhenCollapse",
+    "computed": "__l10nkey:twoAbsoluteLengthOrPercentages",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2211,17 +2211,17 @@
   },
   "border-top-style": {
     "syntax": "<br-style>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2229,17 +2229,17 @@
   },
   "border-top-width": {
     "syntax": "<br-width>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2247,7 +2247,7 @@
   },
   "border-width": {
     "syntax": "<br-width>{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "border-bottom-width",
@@ -2255,7 +2255,7 @@
       "border-right-width",
       "border-top-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Background and Borders"
     ],
@@ -2265,14 +2265,14 @@
       "border-bottom-width",
       "border-left-width"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "border-bottom-width",
       "border-left-width",
       "border-right-width",
       "border-top-width"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2280,175 +2280,175 @@
   },
   "bottom": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToContainingBlockHeight",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToContainingBlockHeight",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "box-align": {
     "syntax": "start | center | end | baseline | stretch",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "stretch",
-    "appliesto": "elementsWithDisplayBoxOrInlineBox",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:elementsWithDisplayBoxOrInlineBox",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-decoration-break": {
     "syntax": "slice | clone",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "slice",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "box-direction": {
     "syntax": "normal | reverse | inherit",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "normal",
-    "appliesto": "elementsWithDisplayBoxOrInlineBox",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:elementsWithDisplayBoxOrInlineBox",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-flex": {
     "syntax": "<number>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "0",
-    "appliesto": "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-flex-group": {
     "syntax": "<integer>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "1",
-    "appliesto": "inFlowChildrenOfBoxElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:inFlowChildrenOfBoxElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-lines": {
     "syntax": "single | multiple",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "single",
-    "appliesto": "boxElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:boxElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-ordinal-group": {
     "syntax": "<integer>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "1",
-    "appliesto": "childrenOfBoxElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:childrenOfBoxElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-orient": {
     "syntax": "horizontal | vertical | inline-axis | block-axis | inherit",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
-    "initial": "inlineAxisHorizontalInXUL",
-    "appliesto": "elementsWithDisplayBoxOrInlineBox",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:inlineAxisHorizontalInXUL",
+    "appliesto": "__l10nkey:elementsWithDisplayBoxOrInlineBox",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-pack": {
     "syntax": "start | center | end | justify",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions",
       "WebKit Extensions"
     ],
     "initial": "start",
-    "appliesto": "elementsWithDisplayMozBoxMozInlineBox",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:elementsWithDisplayMozBoxMozInlineBox",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "box-shadow": {
     "syntax": "none | <shadow>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "shadowList",
-    "percentages": "no",
+    "animationType": "__l10nkey:shadowList",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthsSpecifiedColorAsSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthsSpecifiedColorAsSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -2456,167 +2456,167 @@
   },
   "box-sizing": {
     "syntax": "content-box | border-box",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "content-box",
-    "appliesto": "allElementsAcceptingWidthOrHeight",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAcceptingWidthOrHeight",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "box-suppress": {
     "syntax": "show | discard | hide",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Display"
     ],
     "initial": "show",
-    "appliesto": "allElements",
-    "computed": "seeProse",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:seeProse",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "break-after": {
     "syntax": "auto | avoid | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
     "media": "paged",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "auto",
-    "appliesto": "blockLevelElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockLevelElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "break-before": {
     "syntax": "auto | avoid | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
     "media": "paged",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "auto",
-    "appliesto": "blockLevelElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockLevelElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "break-inside": {
     "syntax": "auto | avoid | avoid-page | avoid-column | avoid-region",
     "media": "paged",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "auto",
-    "appliesto": "blockLevelElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockLevelElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "caption-side": {
     "syntax": "top | bottom | block-start | block-end | inline-start | inline-end",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Table"
     ],
     "initial": "top",
-    "appliesto": "tableCaptionElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:tableCaptionElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "caret-color": {
     "syntax": "auto | <color>",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": true,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asAutoOrColor",
-    "order": "perGrammar",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asAutoOrColor",
+    "order": "__l10nkey:perGrammar",
     "status": "standard"
   },
   "clear": {
     "syntax": "none | left | right | both | inline-start | inline-end",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "none",
-    "appliesto": "blockLevelElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockLevelElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "clip": {
     "syntax": "<shape> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "rectangle",
-    "percentages": "no",
+    "animationType": "__l10nkey:rectangle",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Miscellaneous"
     ],
     "initial": "auto",
-    "appliesto": "absolutelyPositionedElements",
-    "computed": "autoOrRectangle",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:absolutelyPositionedElements",
+    "computed": "__l10nkey:autoOrRectangle",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "clip-path": {
     "syntax": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "basicShapeOtherwiseNo",
-    "percentages": "asSpecified",
+    "animationType": "__l10nkey:basicShapeOtherwiseNo",
+    "percentages": "__l10nkey:asSpecified",
     "groups": [
       "CSS Miscellaneous"
     ],
     "initial": "none",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecifiedURLsAbsolute",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecifiedURLsAbsolute",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Colors"
     ],
-    "initial": "variesFromBrowserToBrowser",
-    "appliesto": "allElements",
-    "computed": "translucentValuesRGBAOtherwiseRGB",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:variesFromBrowserToBrowser",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:translucentValuesRGBAOtherwiseRGB",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -2626,59 +2626,59 @@
   },
   "column-count": {
     "syntax": "<number> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "integer",
-    "percentages": "no",
+    "animationType": "__l10nkey:integer",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "auto",
-    "appliesto": "nonReplacedBlockElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:nonReplacedBlockElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-fill": {
     "syntax": "auto | balance",
-    "media": "visualInContinuousMediaNoEffectInOverflowColumns",
+    "media": "__l10nkey:visualInContinuousMediaNoEffectInOverflowColumns",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "balance",
-    "appliesto": "multicolElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:multicolElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-gap": {
     "syntax": "<length> | normal",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "normal",
-    "appliesto": "multicolElements",
-    "computed": "absoluteLengthOrNormal",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:multicolElements",
+    "computed": "__l10nkey:absoluteLengthOrNormal",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-rule": {
     "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "column-rule-color",
       "column-rule-style",
       "column-rule-width"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
@@ -2687,99 +2687,99 @@
       "column-rule-style",
       "column-rule-color"
     ],
-    "appliesto": "multicolElements",
+    "appliesto": "__l10nkey:multicolElements",
     "computed": [
       "column-rule-color",
       "column-rule-style",
       "column-rule-width"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "column-rule-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "currentcolor",
-    "appliesto": "multicolElements",
+    "appliesto": "__l10nkey:multicolElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-rule-style": {
     "syntax": "<br-style>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "none",
-    "appliesto": "multicolElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:multicolElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-rule-width": {
     "syntax": "<br-width>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "medium",
-    "appliesto": "multicolElements",
-    "computed": "absoluteLength0IfColumnRuleStyleNoneOrHidden",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:multicolElements",
+    "computed": "__l10nkey:absoluteLength0IfColumnRuleStyleNoneOrHidden",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-span": {
     "syntax": "none | all",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "none",
-    "appliesto": "inFlowBlockLevelElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:inFlowBlockLevelElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "column-width": {
     "syntax": "<length> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
     "initial": "auto",
-    "appliesto": "nonReplacedBlockElements",
-    "computed": "absoluteLengthZeroOrLarger",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:nonReplacedBlockElements",
+    "computed": "__l10nkey:absoluteLengthZeroOrLarger",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "columns": {
     "syntax": "<'column-width'> || <'column-count'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "column-width",
       "column-count"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Columns"
     ],
@@ -2787,204 +2787,204 @@
       "column-width",
       "column-count"
     ],
-    "appliesto": "nonReplacedBlockElements",
+    "appliesto": "__l10nkey:nonReplacedBlockElements",
     "computed": [
       "column-width",
       "column-count"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "contain": {
     "syntax": "none | strict | content | [ size || layout || style || paint ]",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": "false",
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Containment"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
     "order": "per grammar",
     "status": "experimental"
   },
   "content": {
     "syntax": "[ <image> , ]* [ normal | none | <content-list> ] [/ <string> ]?",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Generated Content"
     ],
     "initial": "normal",
-    "appliesto": "beforeAndAfterPseudos",
-    "computed": "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:beforeAndAfterPseudos",
+    "computed": "__l10nkey:normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "counter-increment": {
     "syntax": "[ <custom-ident> <integer>? ]+ | none",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Lists and Counters"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "counter-reset": {
     "syntax": "[ <custom-ident> <integer>? ]+ | none",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Lists and Counters"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "cursor": {
     "syntax": "[ [ <url> [ <x> <y> ]? , ]* [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing ] ]",
     "media": "visual, interactive",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedURIsAbsolute",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedURIsAbsolute",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "direction": {
     "syntax": "ltr | rtl",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Writing Modes"
     ],
     "initial": "ltr",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "display": {
     "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Miscellaneous"
     ],
     "initial": "inline",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "display-inside": {
     "syntax": "auto | block | table | flex | grid | ruby",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Display"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "display-list": {
     "syntax": "none | list-item",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Display"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "display-outside": {
     "syntax": "block-level | inline-level | run-in | contents | none | table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Display"
     ],
     "initial": "inline-level",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "empty-cells": {
     "syntax": "show | hide",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Table"
     ],
     "initial": "show",
-    "appliesto": "tableCellElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:tableCellElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "filter": {
     "syntax": "none | <filter-function-list>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "filterList",
-    "percentages": "no",
+    "animationType": "__l10nkey:filterList",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Filter Effects"
     ],
     "initial": "none",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "flex": {
     "syntax": "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "flex-grow",
       "flex-shrink",
       "flex-basis"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
@@ -2993,51 +2993,51 @@
       "flex-shrink",
       "flex-basis"
     ],
-    "appliesto": "flexItemsAndInFlowPseudos",
+    "appliesto": "__l10nkey:flexItemsAndInFlowPseudos",
     "computed": [
       "flex-grow",
       "flex-shrink",
       "flex-basis"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "flex-basis": {
     "syntax": "content | <'width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToFlexContainersInnerMainSize",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToFlexContainersInnerMainSize",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "auto",
-    "appliesto": "flexItemsAndInFlowPseudos",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "lengthOrPercentageBeforeKeywordIfBothPresent",
+    "appliesto": "__l10nkey:flexItemsAndInFlowPseudos",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:lengthOrPercentageBeforeKeywordIfBothPresent",
     "status": "standard"
   },
   "flex-direction": {
     "syntax": "row | row-reverse | column | column-reverse",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "row",
-    "appliesto": "flexContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "flex-flow": {
     "syntax": "<'flex-direction'> || <'flex-wrap'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
@@ -3045,77 +3045,77 @@
       "flex-direction",
       "flex-wrap"
     ],
-    "appliesto": "flexContainers",
+    "appliesto": "__l10nkey:flexContainers",
     "computed": [
       "flex-direction",
       "flex-wrap"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "flex-grow": {
     "syntax": "<number>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "number",
-    "percentages": "no",
+    "animationType": "__l10nkey:number",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "0",
-    "appliesto": "flexItemsAndInFlowPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexItemsAndInFlowPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "flex-shrink": {
     "syntax": "<number>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "number",
-    "percentages": "no",
+    "animationType": "__l10nkey:number",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "1",
-    "appliesto": "flexItemsAndInFlowPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexItemsAndInFlowPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "flex-wrap": {
     "syntax": "nowrap | wrap | wrap-reverse",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "nowrap",
-    "appliesto": "flexContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "float": {
     "syntax": "left | right | none | inline-start | inline-end",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "none",
-    "appliesto": "allElementsNoEffectIfDisplayNone",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsNoEffectIfDisplayNone",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "font": {
     "syntax": "[ [ <'font-style'> || <font-variant-css21> || <'font-weight'> || <'font-stretch'> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'> ] | caption | icon | menu | message-box | small-caption | status-bar",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
     "animationType": [
       "font-style",
@@ -3142,7 +3142,7 @@
       "line-height",
       "font-family"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "font-style",
       "font-variant",
@@ -3152,7 +3152,7 @@
       "line-height",
       "font-family"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3162,17 +3162,17 @@
   },
   "font-family": {
     "syntax": "[ <family-name> | <generic-family> ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
-    "initial": "dependsOnUserAgent",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:dependsOnUserAgent",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3182,17 +3182,17 @@
   },
   "font-feature-settings": {
     "syntax": "normal | <feature-tag-value>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3202,17 +3202,17 @@
   },
   "font-kerning": {
     "syntax": "auto | normal | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3222,17 +3222,17 @@
   },
   "font-language-override": {
     "syntax": "normal | <string>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3240,39 +3240,19 @@
     ],
     "status": "standard"
   },
-  "font-variation-settings": {
-    "syntax": "normal | [ <string> <number> ]#",
-    "media": "visual",
-    "inherited": true,
-    "animationType": "asTransform",
-    "percentages": "no",
-    "groups": [
-      "CSS Fonts"
-    ],
-    "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "perGrammar",
-    "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line",
-      "::placeholder"
-    ],
-    "status": "experimental"
-  },
   "font-size": {
     "syntax": "<absolute-size> | <relative-size> | <length-percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "length",
-    "percentages": "referToParentElementsFontSize",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToParentElementsFontSize",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3282,17 +3262,17 @@
   },
   "font-size-adjust": {
     "syntax": "none | <number>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "number",
-    "percentages": "no",
+    "animationType": "__l10nkey:number",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3302,17 +3282,17 @@
   },
   "font-stretch": {
     "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "fontStretch",
-    "percentages": "no",
+    "animationType": "__l10nkey:fontStretch",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3322,17 +3302,17 @@
   },
   "font-style": {
     "syntax": "normal | italic | oblique",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3342,17 +3322,17 @@
   },
   "font-synthesis": {
     "syntax": "none | [ weight || style ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "weight style",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3362,17 +3342,17 @@
   },
   "font-variant": {
     "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3382,17 +3362,17 @@
   },
   "font-variant-alternates": {
     "syntax": "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3402,17 +3382,17 @@
   },
   "font-variant-caps": {
     "syntax": "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3422,17 +3402,17 @@
   },
   "font-variant-east-asian": {
     "syntax": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3442,17 +3422,17 @@
   },
   "font-variant-ligatures": {
     "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3462,17 +3442,17 @@
   },
   "font-variant-numeric": {
     "syntax": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3482,17 +3462,17 @@
   },
   "font-variant-position": {
     "syntax": "normal | sub | super",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3500,19 +3480,39 @@
     ],
     "status": "standard"
   },
-  "font-weight": {
-    "syntax": "normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
-    "media": "visual",
+  "font-variation-settings": {
+    "syntax": "normal | [ <string> <number> ]#",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "fontWeight",
-    "percentages": "no",
+    "animationType": "__l10nkey:asTransform",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "keywordOrNumericalValueBolderLighterTransformedToRealValue",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "experimental"
+  },
+  "font-weight": {
+    "syntax": "normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+    "media": "__l10nkey:visual",
+    "inherited": true,
+    "animationType": "__l10nkey:fontWeight",
+    "percentages": "__l10nkey:no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:keywordOrNumericalValueBolderLighterTransformedToRealValue",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -3522,9 +3522,9 @@
   },
   "grid": {
     "syntax": "<'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "__l10nkey:discrete",
     "percentages": [
       "grid-template-rows",
       "grid-template-columns",
@@ -3544,7 +3544,7 @@
       "grid-column-gap",
       "grid-row-gap"
     ],
-    "appliesto": "gridContainers",
+    "appliesto": "__l10nkey:gridContainers",
     "computed": [
       "grid-template-rows",
       "grid-template-columns",
@@ -3555,15 +3555,15 @@
       "grid-column-gap",
       "grid-row-gap"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-area": {
     "syntax": "<grid-line> [ / <grid-line> ]{0,3}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
@@ -3573,67 +3573,67 @@
       "grid-row-end",
       "grid-column-end"
     ],
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
     "computed": [
       "grid-row-start",
       "grid-column-start",
       "grid-row-end",
       "grid-column-end"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-auto-columns": {
     "syntax": "<track-size>+",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "seeGridTemplateRowsColumns",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:seeGridTemplateRowsColumns",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "auto",
-    "appliesto": "gridContainers",
-    "computed": "seeGridTemplateRowsColumns",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:seeGridTemplateRowsColumns",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-auto-flow": {
     "syntax": "[ row | column ] || dense",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "row",
-    "appliesto": "gridContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-auto-rows": {
     "syntax": "<track-size>+",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "seeGridTemplateRowsColumns",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:seeGridTemplateRowsColumns",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "auto",
-    "appliesto": "gridContainers",
-    "computed": "seeGridTemplateRowsColumns",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:seeGridTemplateRowsColumns",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-column": {
     "syntax": "<grid-line> [ / <grid-line> ]?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
@@ -3641,68 +3641,68 @@
       "grid-column-start",
       "grid-column-end"
     ],
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
     "computed": [
       "grid-column-start",
       "grid-column-end"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-column-end": {
     "syntax": "<grid-line>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "auto",
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-column-gap": {
     "syntax": "<length-percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "__l10nkey:length",
     "percentages": "yes, as the dimension of the element",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "0",
-    "appliesto": "gridContainers",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-column-start": {
     "syntax": "<grid-line>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "auto",
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-gap": {
     "syntax": "<'grid-row-gap'> <'grid-column-gap'>?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "grid-row-gap",
       "grid-column-gap"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
@@ -3710,20 +3710,20 @@
       "grid-row-gap",
       "grid-column-gap"
     ],
-    "appliesto": "gridContainers",
+    "appliesto": "__l10nkey:gridContainers",
     "computed": [
       "grid-row-gap",
       "grid-column-gap"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-row": {
     "syntax": "<grid-line> [ / <grid-line> ]?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
@@ -3731,64 +3731,64 @@
       "grid-row-start",
       "grid-row-end"
     ],
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
     "computed": [
       "grid-row-start",
       "grid-row-end"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-row-end": {
     "syntax": "<grid-line>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "auto",
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-row-gap": {
     "syntax": "<length-percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "__l10nkey:length",
     "percentages": "yes, as the dimension of the element",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "0",
-    "appliesto": "gridContainers",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-row-start": {
     "syntax": "<grid-line>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "auto",
-    "appliesto": "gridItemsAndBoxesWithinGridContainer",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridItemsAndBoxesWithinGridContainer",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-template": {
     "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "__l10nkey:discrete",
     "percentages": [
       "grid-template-columns",
       "grid-template-rows"
@@ -3801,253 +3801,253 @@
       "grid-template-rows",
       "grid-template-areas"
     ],
-    "appliesto": "gridContainers",
+    "appliesto": "__l10nkey:gridContainers",
     "computed": [
       "grid-template-columns",
       "grid-template-rows",
       "grid-template-areas"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-template-areas": {
     "syntax": "none | <string>+",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "none",
-    "appliesto": "gridContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-template-columns": {
     "syntax": "none | <track-list> | <auto-track-list>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToDimensionOfContentArea",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToDimensionOfContentArea",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "none",
-    "appliesto": "gridContainers",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "grid-template-rows": {
     "syntax": "none | <track-list> | <auto-track-list>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "referToDimensionOfContentArea",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToDimensionOfContentArea",
     "groups": [
       "CSS Grid Layout"
     ],
     "initial": "none",
-    "appliesto": "gridContainers",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:gridContainers",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "height": {
     "syntax": "[ <length> | <percentage> ] && [ border-box | content-box ]? | available | min-content | max-content | fit-content | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "auto",
-    "appliesto": "allElementsButNonReplacedAndTableColumns",
-    "computed": "percentageAutoOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsButNonReplacedAndTableColumns",
+    "computed": "__l10nkey:percentageAutoOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "hyphens": {
     "syntax": "none | manual | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "manual",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "image-orientation": {
     "syntax": "from-image | <angle> | [ <angle>? flip ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Images"
     ],
     "initial": "0deg",
-    "appliesto": "allElements",
-    "computed": "angleRoundedToNextQuarter",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:angleRoundedToNextQuarter",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "image-rendering": {
     "syntax": "auto | crisp-edges | pixelated",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Images"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "image-resolution": {
     "syntax": "[ from-image || <resolution> ] && snap?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Images"
     ],
     "initial": "1dppx",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedWithExceptionOfResolution",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedWithExceptionOfResolution",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "ime-mode": {
     "syntax": "auto | normal | active | inactive | disabled",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Miscellaneous"
     ],
     "initial": "auto",
-    "appliesto": "textFields",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:textFields",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "initial-letter": {
     "syntax": "normal | [ <number> <integer>? ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Inline"
     ],
     "initial": "normal",
-    "appliesto": "firstLetterPseudoElementsAndInlineLevelFirstChildren",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:firstLetterPseudoElementsAndInlineLevelFirstChildren",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "initial-letter-align": {
     "syntax": "[ auto | alphabetic | hanging | ideographic ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Inline"
     ],
     "initial": "auto",
-    "appliesto": "firstLetterPseudoElementsAndInlineLevelFirstChildren",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:firstLetterPseudoElementsAndInlineLevelFirstChildren",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "inline-size": {
     "syntax": "<'width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "inlineSizeOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:inlineSizeOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "auto",
-    "appliesto": "sameAsWidthAndHeight",
-    "computed": "sameAsWidthAndHeight",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsWidthAndHeight",
+    "computed": "__l10nkey:sameAsWidthAndHeight",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "isolation": {
     "syntax": "auto | isolate",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Compositing and Blending"
     ],
     "initial": "auto",
-    "appliesto": "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "justify-content": {
     "syntax": "flex-start | flex-end | center | space-between | space-around | space-evenly",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "flex-start",
-    "appliesto": "flexContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "left": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "letter-spacing": {
     "syntax": "normal | <length>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "optimumValueOfAbsoluteLengthOrNormal",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:optimumValueOfAbsoluteLengthOrNormal",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line"
@@ -4056,32 +4056,32 @@
   },
   "line-break": {
     "syntax": "auto | loose | normal | strict",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "line-height": {
     "syntax": "normal | <number> | <length> | <percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
     "animationType": "number length",
-    "percentages": "referToElementFontSize",
+    "percentages": "__l10nkey:referToElementFontSize",
     "groups": [
       "CSS Fonts"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "absoluteLengthOrAsSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLengthOrAsSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -4091,10 +4091,10 @@
   },
   "list-style": {
     "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Lists and Counters"
     ],
@@ -4103,66 +4103,66 @@
       "list-style-position",
       "list-style-image"
     ],
-    "appliesto": "listItems",
+    "appliesto": "__l10nkey:listItems",
     "computed": [
       "list-style-image",
       "list-style-position",
       "list-style-type"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "list-style-image": {
     "syntax": "<url> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Lists and Counters"
     ],
     "initial": "none",
-    "appliesto": "listItems",
-    "computed": "noneOrImageWithAbsoluteURI",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:listItems",
+    "computed": "__l10nkey:noneOrImageWithAbsoluteURI",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "list-style-position": {
     "syntax": "inside | outside",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Lists and Counters"
     ],
     "initial": "outside",
-    "appliesto": "listItems",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:listItems",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "list-style-type": {
     "syntax": "<counter-style> | <string> | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Lists and Counters"
     ],
     "initial": "disc",
-    "appliesto": "listItems",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:listItems",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "margin": {
     "syntax": "[ <length> | <percentage> | auto ]{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
@@ -4172,14 +4172,14 @@
       "margin-right",
       "margin-top"
     ],
-    "appliesto": "allElementsExceptTableDisplayTypes",
+    "appliesto": "__l10nkey:allElementsExceptTableDisplayTypes",
     "computed": [
       "margin-bottom",
       "margin-left",
       "margin-right",
       "margin-top"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -4187,47 +4187,47 @@
   },
   "margin-block-end": {
     "syntax": "<'margin-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "dependsOnLayoutModel",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:dependsOnLayoutModel",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsMargin",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsMargin",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "margin-block-start": {
     "syntax": "<'margin-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "dependsOnLayoutModel",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:dependsOnLayoutModel",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsMargin",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsMargin",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "margin-bottom": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -4235,47 +4235,47 @@
   },
   "margin-inline-end": {
     "syntax": "<'margin-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "dependsOnLayoutModel",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:dependsOnLayoutModel",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsMargin",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsMargin",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "margin-inline-start": {
     "syntax": "<'margin-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "dependsOnLayoutModel",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:dependsOnLayoutModel",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsMargin",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsMargin",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "margin-left": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -4283,17 +4283,17 @@
   },
   "margin-right": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -4301,17 +4301,17 @@
   },
   "margin-top": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -4319,22 +4319,22 @@
   },
   "marker-offset": {
     "syntax": "<length> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Generated Content"
     ],
     "initial": "auto",
-    "appliesto": "elementsWithDisplayMarker",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:elementsWithDisplayMarker",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "mask": {
     "syntax": "<mask-layer>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "mask-position",
@@ -4350,319 +4350,319 @@
       "mask-origin",
       "mask-clip"
     ],
-    "appliesto": "allElementsSVGContainerElements",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
     "computed": [
       "mask-origin",
       "mask-clip"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   },
   "mask-clip": {
     "syntax": "[ <geometry-box> | no-clip ]#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "border-box",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-composite": {
     "syntax": "<compositing-operator>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "add",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-image": {
     "syntax": "<mask-reference>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "none",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecifiedURIsAbsolute",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecifiedURIsAbsolute",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-mode": {
     "syntax": "<masking-mode>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "match-source",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-origin": {
     "syntax": "<geometry-box>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "border-box",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-position": {
     "syntax": "<position>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "repeatableList simpleList lpc",
-    "percentages": "referToSizeOfMaskPaintingArea",
+    "percentages": "__l10nkey:referToSizeOfMaskPaintingArea",
     "groups": [
       "CSS Masks"
     ],
     "initial": "0% 0%",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "consistsOfTwoKeywordsForOriginAndOffsets",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:consistsOfTwoKeywordsForOriginAndOffsets",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-repeat": {
     "syntax": "<repeat-style>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "repeat",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "consistsOfTwoDimensionKeywords",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:consistsOfTwoDimensionKeywords",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-size": {
     "syntax": "<bg-size>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "repeatableList simpleList lpc",
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "auto",
-    "appliesto": "allElementsSVGContainerElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSVGContainerElements",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mask-type": {
     "syntax": "luminance | alpha",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Masks"
     ],
     "initial": "luminance",
-    "appliesto": "maskElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:maskElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "max-block-size": {
     "syntax": "<'max-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "blockSizeOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:blockSizeOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsWidthAndHeight",
-    "computed": "sameAsMaxWidthAndMaxHeight",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsWidthAndHeight",
+    "computed": "__l10nkey:sameAsMaxWidthAndMaxHeight",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "max-height": {
     "syntax": "<length> | <percentage> | none | max-content | min-content | fit-content | fill-available",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "none",
-    "appliesto": "allElementsButNonReplacedAndTableColumns",
-    "computed": "percentageAsSpecifiedAbsoluteLengthOrNone",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsButNonReplacedAndTableColumns",
+    "computed": "__l10nkey:percentageAsSpecifiedAbsoluteLengthOrNone",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "max-inline-size": {
     "syntax": "<'max-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "inlineSizeOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:inlineSizeOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsWidthAndHeight",
-    "computed": "sameAsMaxWidthAndMaxHeight",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsWidthAndHeight",
+    "computed": "__l10nkey:sameAsMaxWidthAndMaxHeight",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "max-width": {
     "syntax": "<length> | <percentage> | none | max-content | min-content | fit-content | fill-available",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "none",
-    "appliesto": "allElementsButNonReplacedAndTableRows",
-    "computed": "percentageAsSpecifiedAbsoluteLengthOrNone",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsButNonReplacedAndTableRows",
+    "computed": "__l10nkey:percentageAsSpecifiedAbsoluteLengthOrNone",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "min-block-size": {
     "syntax": "<'min-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "blockSizeOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:blockSizeOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsWidthAndHeight",
-    "computed": "sameAsMinWidthAndMinHeight",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsWidthAndHeight",
+    "computed": "__l10nkey:sameAsMinWidthAndMinHeight",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "min-height": {
     "syntax": "<length> | <percentage> | auto | max-content | min-content | fit-content | fill-available",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:regardingHeightOfGeneratedBoxContainingBlockPercentages0",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsButNonReplacedAndTableColumns",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsButNonReplacedAndTableColumns",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "min-inline-size": {
     "syntax": "<'min-width'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "inlineSizeOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:inlineSizeOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "sameAsWidthAndHeight",
-    "computed": "sameAsMinWidthAndMinHeight",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:sameAsWidthAndHeight",
+    "computed": "__l10nkey:sameAsMinWidthAndMinHeight",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "min-width": {
     "syntax": "<length> | <percentage> | auto | max-content | min-content | fit-content | fill-available",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsButNonReplacedAndTableRows",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsButNonReplacedAndTableRows",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "mix-blend-mode": {
     "syntax": "<blend-mode>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Compositing and Blending"
     ],
     "initial": "normal",
-    "appliesto": "allHTMLElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allHTMLElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   },
   "object-fit": {
     "syntax": "fill | contain | cover | none | scale-down",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Images"
     ],
     "initial": "fill",
-    "appliesto": "replacedElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:replacedElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "object-position": {
     "syntax": "<position>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
     "animationType": "repeatableList simpleList lpc",
-    "percentages": "referToWidthAndHeightOfElement",
+    "percentages": "__l10nkey:referToWidthAndHeightOfElement",
     "groups": [
       "CSS Images"
     ],
     "initial": "50% 50%",
-    "appliesto": "replacedElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:replacedElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "offset": {
     "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "offset-position",
@@ -4686,7 +4686,7 @@
       "offset-anchor",
       "offset-rotate"
     ],
-    "appliesto": "transformableElements",
+    "appliesto": "__l10nkey:transformableElements",
     "computed": [
       "offset-position",
       "offset-path",
@@ -4694,159 +4694,159 @@
       "offset-anchor",
       "offset-rotate"
     ],
-    "order": "perGrammar",
+    "order": "__l10nkey:perGrammar",
     "stacking": true,
     "status": "experimental"
   },
   "offset-anchor": {
     "syntax": "auto | <position>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "position",
+    "animationType": "__l10nkey:position",
     "percentages": "relativeToWidthAndHeight",
     "groups": [
       "CSS Motion"
     ],
     "initial": "auto",
-    "appliesto": "transformableElements",
-    "computed": "forLengthAbsoluteValueOtherwisePercentage",
-    "order": "perGrammar",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:forLengthAbsoluteValueOtherwisePercentage",
+    "order": "__l10nkey:perGrammar",
     "status": "experimental"
   },
   "offset-block-end": {
     "syntax": "<'left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalHeightOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalHeightOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:sameAsBoxOffsets",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "offset-block-start": {
     "syntax": "<'left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalHeightOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalHeightOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
-    "status": "standard"
-  },
-  "offset-inline-end": {
-    "syntax": "<'left'>",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
-    "groups": [
-      "CSS Logical Properties"
-    ],
-    "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
-    "status": "standard"
-  },
-  "offset-inline-start": {
-    "syntax": "<'left'>",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
-    "groups": [
-      "CSS Logical Properties"
-    ],
-    "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:sameAsBoxOffsets",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "offset-distance": {
     "syntax": "<length-percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToTotalPathLength",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToTotalPathLength",
     "groups": [
       "CSS Motion"
     ],
     "initial": "0",
-    "appliesto": "transformableElements",
-    "computed": "forLengthAbsoluteValueOtherwisePercentage",
-    "order": "perGrammar",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:forLengthAbsoluteValueOtherwisePercentage",
+    "order": "__l10nkey:perGrammar",
     "status": "experimental"
+  },
+  "offset-inline-end": {
+    "syntax": "<'left'>",
+    "media": "__l10nkey:visual",
+    "inherited": false,
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "auto",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:sameAsBoxOffsets",
+    "order": "__l10nkey:uniqueOrder",
+    "status": "standard"
+  },
+  "offset-inline-start": {
+    "syntax": "<'left'>",
+    "media": "__l10nkey:visual",
+    "inherited": false,
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "auto",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:sameAsBoxOffsets",
+    "order": "__l10nkey:uniqueOrder",
+    "status": "standard"
   },
   "offset-path": {
     "syntax": "none | ray( [ <angle> && <size>? && contain? ] ) | <path()> | <url> | [ <basic-shape> || <geometry-box> ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "AsAngleBasicshapeOrPath",
-    "percentages": "no",
+    "animationType": "__l10nkey:AsAngleBasicshapeOrPath",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Motion"
     ],
     "initial": "none",
-    "appliesto": "transformableElements",
-    "computed": "asSpecified",
-    "order": "perGrammar",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:perGrammar",
     "stacking": true,
     "status": "experimental"
   },
   "offset-position": {
     "syntax": "auto | <position>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "position",
+    "animationType": "__l10nkey:position",
     "percentages": "referToSizeOfContainingBlock",
     "groups": [
       "CSS Motion"
     ],
     "initial": "auto",
-    "appliesto": "transformableElements",
-    "computed": "forLengthAbsoluteValueOtherwisePercentage",
-    "order": "perGrammar",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:forLengthAbsoluteValueOtherwisePercentage",
+    "order": "__l10nkey:perGrammar",
     "status": "experimental"
   },
   "offset-rotate": {
     "syntax": "[ auto | reverse ] || <angle>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "angle",
-    "percentages": "no",
+    "animationType": "__l10nkey:angle",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Motion"
     ],
     "initial": "auto",
-    "appliesto": "transformableElements",
-    "computed": "asSpecified",
-    "order": "perGrammar",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:perGrammar",
     "status": "experimental"
   },
   "opacity": {
     "syntax": "<number>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "number",
-    "percentages": "no",
+    "animationType": "__l10nkey:number",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Colors"
     ],
     "initial": "1.0",
-    "appliesto": "allElements",
-    "computed": "specifiedValueClipped0To1",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:specifiedValueClipped0To1",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::placeholder"
     ],
@@ -4854,32 +4854,32 @@
   },
   "order": {
     "syntax": "<integer>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "integer",
-    "percentages": "no",
+    "animationType": "__l10nkey:integer",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Flexible Box Layout"
     ],
     "initial": "0",
-    "appliesto": "flexItemsAndAbsolutelyPositionedFlexContainerChildren",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:flexItemsAndAbsolutelyPositionedFlexContainerChildren",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "orphans": {
     "syntax": "<integer>",
     "media": "visual, paged",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Pages"
     ],
     "initial": "2",
-    "appliesto": "blockContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "outline": {
@@ -4891,7 +4891,7 @@
       "outline-width",
       "outline-style"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
@@ -4900,156 +4900,156 @@
       "outline-style",
       "outline-width"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "outline-color",
       "outline-width",
       "outline-style"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "outline-color": {
     "syntax": "<color> | invert",
     "media": "visual, interactive",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
-    "initial": "invertOrCurrentColor",
-    "appliesto": "allElements",
-    "computed": "invertForTranslucentColorRGBAOtherwiseRGB",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:invertOrCurrentColor",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:invertForTranslucentColorRGBAOtherwiseRGB",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "outline-offset": {
     "syntax": "<length>",
     "media": "visual, interactive",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "outline-style": {
     "syntax": "auto | <br-style>",
     "media": "visual, interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "outline-width": {
     "syntax": "<br-width>",
     "media": "visual, interactive",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "medium",
-    "appliesto": "allElements",
-    "computed": "absoluteLength0ForNone",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:absoluteLength0ForNone",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "overflow": {
     "syntax": "visible | hidden | scroll | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "visible",
-    "appliesto": "nonReplacedBlockAndInlineBlockElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:nonReplacedBlockAndInlineBlockElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "overflow-clip-box": {
     "syntax": "padding-box | content-box",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "padding-box",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "overflow-wrap": {
     "syntax": "normal | break-word",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "overflow-x": {
     "syntax": "visible | hidden | scroll | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "visible",
-    "appliesto": "nonReplacedBlockAndInlineBlockElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:nonReplacedBlockAndInlineBlockElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "overflow-y": {
     "syntax": "visible | hidden | scroll | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "visible",
-    "appliesto": "nonReplacedBlockAndInlineBlockElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:nonReplacedBlockAndInlineBlockElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "padding": {
     "syntax": "[ <length> | <percentage> ]{1,4}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
@@ -5059,14 +5059,14 @@
       "padding-right",
       "padding-top"
     ],
-    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "appliesto": "__l10nkey:allElementsExceptInternalTableDisplayTypes",
     "computed": [
       "padding-bottom",
       "padding-left",
       "padding-right",
       "padding-top"
     ],
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -5074,47 +5074,47 @@
   },
   "padding-block-end": {
     "syntax": "<'padding-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "padding-block-start": {
     "syntax": "<'padding-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "padding-bottom": {
     "syntax": "<length> | <percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptInternalTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptInternalTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -5122,47 +5122,47 @@
   },
   "padding-inline-end": {
     "syntax": "<'padding-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "padding-inline-start": {
     "syntax": "<'padding-left'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "padding-left": {
     "syntax": "<length> | <percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptInternalTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptInternalTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -5170,17 +5170,17 @@
   },
   "padding-right": {
     "syntax": "<length> | <percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptInternalTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptInternalTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -5188,17 +5188,17 @@
   },
   "padding-top": {
     "syntax": "<length> | <percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "0",
-    "appliesto": "allElementsExceptInternalTableDisplayTypes",
-    "computed": "percentageAsSpecifiedOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptInternalTableDisplayTypes",
+    "computed": "__l10nkey:percentageAsSpecifiedOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
     ],
@@ -5208,407 +5208,407 @@
     "syntax": "auto | always | avoid | left | right",
     "media": "visual, paged",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Pages"
     ],
     "initial": "auto",
-    "appliesto": "blockElementsInNormalFlow",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockElementsInNormalFlow",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "page-break-before": {
     "syntax": "auto | always | avoid | left | right",
     "media": "visual, paged",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Pages"
     ],
     "initial": "auto",
-    "appliesto": "blockElementsInNormalFlow",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockElementsInNormalFlow",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "page-break-inside": {
     "syntax": "auto | avoid",
     "media": "visual, paged",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Pages"
     ],
     "initial": "auto",
-    "appliesto": "blockElementsInNormalFlow",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockElementsInNormalFlow",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "perspective": {
     "syntax": "none | <length>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "none",
-    "appliesto": "transformableElements",
-    "computed": "absoluteLengthOrNone",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:absoluteLengthOrNone",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   },
   "perspective-origin": {
     "syntax": "<position>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "simpleList lpc",
-    "percentages": "referToSizeOfBoundingBox",
+    "percentages": "__l10nkey:referToSizeOfBoundingBox",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "50% 50%",
-    "appliesto": "transformableElements",
-    "computed": "forLengthAbsoluteValueOtherwisePercentage",
-    "order": "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:forLengthAbsoluteValueOtherwisePercentage",
+    "order": "__l10nkey:oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
     "status": "standard"
   },
   "pointer-events": {
     "syntax": "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Pointer Events"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "position": {
     "syntax": "static | relative | absolute | sticky | fixed",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "static",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   },
   "quotes": {
     "syntax": "[ <string> <string> ]+ | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Generated Content"
     ],
-    "initial": "dependsOnUserAgent",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:dependsOnUserAgent",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "resize": {
     "syntax": "none | both | horizontal | vertical",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "none",
-    "appliesto": "elementsWithOverflowNotVisibleAndReplacedElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:elementsWithOverflowNotVisibleAndReplacedElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "right": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "ruby-align": {
     "syntax": "start | center | space-between | space-around",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Ruby"
     ],
     "initial": "space-around",
-    "appliesto": "rubyBasesAnnotationsBaseAnnotationContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:rubyBasesAnnotationsBaseAnnotationContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "ruby-merge": {
     "syntax": "separate | collapse | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Ruby"
     ],
     "initial": "separate",
-    "appliesto": "rubyAnnotationsContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:rubyAnnotationsContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "ruby-position": {
     "syntax": "over | under | inter-character",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Ruby"
     ],
     "initial": "over",
-    "appliesto": "rubyAnnotationsContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:rubyAnnotationsContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "scroll-behavior": {
     "syntax": "auto | smooth",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSSOM View"
     ],
     "initial": "auto",
-    "appliesto": "scrollingBoxes",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollingBoxes",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "scroll-snap-coordinate": {
     "syntax": "none | <position>#",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "position",
-    "percentages": "referToBorderBox",
+    "animationType": "__l10nkey:position",
+    "percentages": "__l10nkey:referToBorderBox",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "scroll-snap-destination": {
     "syntax": "<position>",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "position",
-    "percentages": "relativeToScrollContainerPaddingBoxAxis",
+    "animationType": "__l10nkey:position",
+    "percentages": "__l10nkey:relativeToScrollContainerPaddingBoxAxis",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "0px 0px",
-    "appliesto": "scrollContainers",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollContainers",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "scroll-snap-points-x": {
     "syntax": "none | repeat( <length-percentage> )",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "relativeToScrollContainerPaddingBoxAxis",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:relativeToScrollContainerPaddingBoxAxis",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "none",
-    "appliesto": "scrollContainers",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollContainers",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "obsolete"
   },
   "scroll-snap-points-y": {
     "syntax": "none | repeat( <length-percentage> )",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "relativeToScrollContainerPaddingBoxAxis",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:relativeToScrollContainerPaddingBoxAxis",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "none",
-    "appliesto": "scrollContainers",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollContainers",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "obsolete"
   },
   "scroll-snap-type": {
     "syntax": "none | mandatory | proximity",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "none",
-    "appliesto": "scrollContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "scroll-snap-type-x": {
     "syntax": "none | mandatory | proximity",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "none",
-    "appliesto": "scrollContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "scroll-snap-type-y": {
     "syntax": "none | mandatory | proximity",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Scroll Snap Points"
     ],
     "initial": "none",
-    "appliesto": "scrollContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:scrollContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "shape-image-threshold": {
     "syntax": "<number>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "number",
-    "percentages": "no",
+    "animationType": "__l10nkey:number",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Shapes"
     ],
     "initial": "0.0",
-    "appliesto": "floats",
-    "computed": "specifiedValueNumberClipped0To1",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:floats",
+    "computed": "__l10nkey:specifiedValueNumberClipped0To1",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "shape-margin": {
     "syntax": "<length-percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Shapes"
     ],
     "initial": "0",
-    "appliesto": "floats",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:floats",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "shape-outside": {
     "syntax": "none | <shape-box> || <basic-shape> | <image>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "basic-shape",
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Shapes"
     ],
     "initial": "none",
-    "appliesto": "floats",
-    "computed": "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:floats",
+    "computed": "__l10nkey:asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "tab-size": {
     "syntax": "<integer> | <length>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "length",
-    "percentages": "no",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "8",
-    "appliesto": "blockContainers",
-    "computed": "specifiedIntegerOrAbsoluteLength",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockContainers",
+    "computed": "__l10nkey:specifiedIntegerOrAbsoluteLength",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "table-layout": {
     "syntax": "auto | fixed",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Table"
     ],
     "initial": "auto",
-    "appliesto": "tableElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:tableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-align": {
     "syntax": "start | end | left | right | center | justify | match-parent",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
-    "initial": "startOrNamelessValueIfLTRRightIfRTL",
-    "appliesto": "blockContainers",
-    "computed": "asSpecifiedExceptMatchParent",
-    "order": "orderOfAppearance",
+    "initial": "__l10nkey:startOrNamelessValueIfLTRRightIfRTL",
+    "appliesto": "__l10nkey:blockContainers",
+    "computed": "__l10nkey:asSpecifiedExceptMatchParent",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::placeholder"
     ],
@@ -5616,44 +5616,44 @@
   },
   "text-align-last": {
     "syntax": "auto | start | end | left | right | center | justify",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "auto",
-    "appliesto": "blockContainers",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockContainers",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-combine-upright": {
     "syntax": "none | all | [ digits <integer>? ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Writing Modes"
     ],
     "initial": "none",
-    "appliesto": "nonReplacedInlineElements",
-    "computed": "keywordPlusIntegerIfDigits",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:nonReplacedInlineElements",
+    "computed": "__l10nkey:keywordPlusIntegerIfDigits",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-decoration": {
     "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "text-decoration-color",
       "text-decoration-style",
       "text-decoration-line"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
@@ -5662,13 +5662,13 @@
       "text-decoration-style",
       "text-decoration-line"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "text-decoration-line",
       "text-decoration-style",
       "text-decoration-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -5678,17 +5678,17 @@
   },
   "text-decoration-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -5698,17 +5698,17 @@
   },
   "text-decoration-line": {
     "syntax": "none | [ underline || overline || line-through || blink ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -5718,32 +5718,32 @@
   },
   "text-decoration-skip": {
     "syntax": "none | [ objects || spaces || ink || edges || box-decoration ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "objects",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "experimental"
   },
   "text-decoration-style": {
     "syntax": "solid | double | dotted | dashed | wavy",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "solid",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -5753,13 +5753,13 @@
   },
   "text-emphasis": {
     "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": [
       "text-emphasis-color",
       "text-emphasis-style"
     ],
-    "percentages": "no",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
@@ -5767,115 +5767,117 @@
       "text-emphasis-style",
       "text-emphasis-color"
     ],
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": [
       "text-emphasis-style",
       "text-emphasis-color"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "text-emphasis-color": {
     "syntax": "<color>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "color",
-    "percentages": "no",
+    "animationType": "__l10nkey:color",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "currentcolor",
-    "appliesto": "allElements",
+    "appliesto": "__l10nkey:allElements",
     "computed": "'color'",
-    "order": "uniqueOrder",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-emphasis-position": {
     "syntax": "[ over | under ] && [ right | left ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "over right",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-emphasis-style": {
     "syntax": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": ["CSS Text Decoration"],
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-indent": {
     "syntax": "<length-percentage> && hanging? && each-line?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Text"
     ],
     "initial": "0",
-    "appliesto": "blockContainers",
-    "computed": "percentageOrAbsoluteLengthPlusKeywords",
-    "order": "lengthOrPercentageBeforeKeywords",
+    "appliesto": "__l10nkey:blockContainers",
+    "computed": "__l10nkey:percentageOrAbsoluteLengthPlusKeywords",
+    "order": "__l10nkey:lengthOrPercentageBeforeKeywords",
     "status": "standard"
   },
   "text-justify": {
     "syntax": "auto | inter-character | inter-word | none",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "auto",
-    "appliesto": "inlineLevelAndTableCellElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:inlineLevelAndTableCellElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-orientation": {
     "syntax": "mixed | upright | sideways",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Writing Modes"
     ],
     "initial": "mixed",
-    "appliesto": "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-overflow": {
     "syntax": "[ clip | ellipsis | <string> ]{1,2}",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS User Interface"
     ],
     "initial": "clip",
-    "appliesto": "blockContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::placeholder"
     ],
@@ -5883,32 +5885,32 @@
   },
   "text-rendering": {
     "syntax": "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Miscellaneous"
     ],
     "initial": "auto",
-    "appliesto": "textElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:textElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "text-shadow": {
     "syntax": "none | <shadow-t>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "shadowList",
-    "percentages": "no",
+    "animationType": "__l10nkey:shadowList",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "colorPlusThreeAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:colorPlusThreeAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -5918,32 +5920,32 @@
   },
   "text-size-adjust": {
     "syntax": "none | auto | <percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "referToSizeOfFont",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:referToSizeOfFont",
     "groups": [
       "CSS Text"
     ],
-    "initial": "autoForSmartphoneBrowsersSupportingInflation",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:autoForSmartphoneBrowsersSupportingInflation",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "experimental"
   },
   "text-transform": {
     "syntax": "none | capitalize | uppercase | lowercase | full-width",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "none",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -5953,117 +5955,117 @@
   },
   "text-underline-position": {
     "syntax": "auto | [ under || [ left | right ] ]",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text Decoration"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "orderOfAppearance",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "top": {
     "syntax": "<length> | <percentage> | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToContainingBlockHeight",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToContainingBlockHeight",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "touch-action": {
     "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Pointer Events"
     ],
     "initial": "auto",
-    "appliesto": "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "transform": {
     "syntax": "none | <transform-list>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "transform",
-    "percentages": "referToSizeOfBoundingBox",
+    "animationType": "__l10nkey:transform",
+    "percentages": "__l10nkey:referToSizeOfBoundingBox",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "none",
-    "appliesto": "transformableElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:asSpecifiedRelativeToAbsoluteLengths",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   },
   "transform-box": {
     "syntax": "border-box | fill-box | view-box",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "border-box ",
-    "appliesto": "transformableElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "transform-origin": {
     "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
     "animationType": "simpleList lpc",
-    "percentages": "referToSizeOfBoundingBox",
+    "percentages": "__l10nkey:referToSizeOfBoundingBox",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "50% 50% 0",
-    "appliesto": "transformableElements",
-    "computed": "forLengthAbsoluteValueOtherwisePercentage",
-    "order": "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:forLengthAbsoluteValueOtherwisePercentage",
+    "order": "__l10nkey:oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
     "status": "standard"
   },
   "transform-style": {
     "syntax": "flat | preserve-3d",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transforms"
     ],
     "initial": "flat",
-    "appliesto": "transformableElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:transformableElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   },
   "transition": {
     "syntax": "<single-transition>#",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transitions"
     ],
@@ -6073,119 +6075,119 @@
       "transition-property",
       "transition-timing-function"
     ],
-    "appliesto": "allElementsAndPseudos",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
     "computed": [
       "transition-delay",
       "transition-duration",
       "transition-property",
       "transition-timing-function"
     ],
-    "order": "orderOfAppearance",
+    "order": "__l10nkey:orderOfAppearance",
     "status": "standard"
   },
   "transition-delay": {
     "syntax": "<time>#",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transitions"
     ],
     "initial": "0s",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "transition-duration": {
     "syntax": "<time>#",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transitions"
     ],
     "initial": "0s",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "transition-property": {
     "syntax": "none | <single-transition-property>#",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transitions"
     ],
-    "initial": "all",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "initial": "__l10nkey:all",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "transition-timing-function": {
     "syntax": "<single-transition-timing-function>#",
-    "media": "interactive",
+    "media": "__l10nkey:interactive",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Transitions"
     ],
     "initial": "ease",
-    "appliesto": "allElementsAndPseudos",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsAndPseudos",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "unicode-bidi": {
     "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Writing Modes"
     ],
     "initial": "normal",
-    "appliesto": "allElementsSomeValuesNoEffectOnNonInlineElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsSomeValuesNoEffectOnNonInlineElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "user-select": {
     "syntax": "auto | text | none | contain | all",
-    "media": "visual",
-    "inherited": "no",
-    "animationType": "discrete",
-    "percentages": "no",
+    "media": "__l10nkey:visual",
+    "inherited": "__l10nkey:no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "Mozilla Extensions"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "nonstandard"
   },
   "vertical-align": {
     "syntax": "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "length",
-    "percentages": "referToLineHeight",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToLineHeight",
     "groups": [
       "CSS Table"
     ],
     "initial": "baseline",
-    "appliesto": "inlineLevelAndTableCellElements",
-    "computed": "absoluteLengthOrKeyword",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:inlineLevelAndTableCellElements",
+    "computed": "__l10nkey:absoluteLengthOrKeyword",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -6195,107 +6197,107 @@
   },
   "visibility": {
     "syntax": "visible | hidden | collapse",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "visibility",
-    "percentages": "no",
+    "animationType": "__l10nkey:visibility",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "visible",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "white-space": {
     "syntax": "normal | pre | nowrap | pre-wrap | pre-line",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "widows": {
     "syntax": "<integer>",
     "media": "visual, paged",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Pages"
     ],
     "initial": "2",
-    "appliesto": "blockContainerElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:blockContainerElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "width": {
     "syntax": "[ <length> | <percentage> ] && [ border-box | content-box ]? | available | min-content | max-content | fit-content | auto",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "lpc",
-    "percentages": "referToWidthOfContainingBlock",
+    "animationType": "__l10nkey:lpc",
+    "percentages": "__l10nkey:referToWidthOfContainingBlock",
     "groups": [
       "CSS Box Model"
     ],
     "initial": "auto",
-    "appliesto": "allElementsButNonReplacedAndTableRows",
-    "computed": "percentageAutoOrAbsoluteLength",
-    "order": "lengthOrPercentageBeforeKeywordIfBothPresent",
+    "appliesto": "__l10nkey:allElementsButNonReplacedAndTableRows",
+    "computed": "__l10nkey:percentageAutoOrAbsoluteLength",
+    "order": "__l10nkey:lengthOrPercentageBeforeKeywordIfBothPresent",
     "status": "standard"
   },
   "will-change": {
     "syntax": "auto | <animateable-feature>#",
-    "media": "all",
+    "media": "__l10nkey:all",
     "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Miscellaneous"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "word-break": {
     "syntax": "normal | break-all | keep-all",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "word-spacing": {
     "syntax": "normal | <length-percentage>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "length",
-    "percentages": "referToWidthOfAffectedGlyph",
+    "animationType": "__l10nkey:length",
+    "percentages": "__l10nkey:referToWidthOfAffectedGlyph",
     "groups": [
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
+    "order": "__l10nkey:uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",
       "::first-line",
@@ -6305,47 +6307,47 @@
   },
   "word-wrap": {
     "syntax": "normal | break-word",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "writing-mode": {
     "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
+    "animationType": "__l10nkey:discrete",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Writing Modes"
     ],
     "initial": "horizontal-tb",
-    "appliesto": "allElementsExceptTableRowColumnGroupsTableRowsColumns",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:allElementsExceptTableRowColumnGroupsTableRowsColumns",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "status": "standard"
   },
   "z-index": {
     "syntax": "auto | <integer>",
-    "media": "visual",
+    "media": "__l10nkey:visual",
     "inherited": false,
-    "animationType": "integer",
-    "percentages": "no",
+    "animationType": "__l10nkey:integer",
+    "percentages": "__l10nkey:no",
     "groups": [
       "CSS Positioning"
     ],
     "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "appliesto": "__l10nkey:positionedElements",
+    "computed": "__l10nkey:asSpecified",
+    "order": "__l10nkey:uniqueOrder",
     "stacking": true,
     "status": "standard"
   }


### PR DESCRIPTION
Add a prefix of ``__l10nkey`` to values that are look-ups in the l10n/css.json file. See issue #61.  File was generated using [this Python script](https://gist.github.com/jwhitlock/4ea1a1d36a308dd5688119ae50b9fc38).