### PR TITLE
Fix "inherited" field to contain a boolean values only

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -951,7 +951,7 @@
   "appearance": {
     "syntax": "auto | none",
     "media": "all",
-    "inherited": "no",
+    "inherited": false,
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
@@ -2798,7 +2798,7 @@
   "contain": {
     "syntax": "none | strict | content | [ size || layout || style || paint ]",
     "media": "all",
-    "inherited": "false",
+    "inherited": false,
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
@@ -6161,7 +6161,7 @@
   "user-select": {
     "syntax": "auto | text | none | contain | all",
     "media": "visual",
-    "inherited": "no",
+    "inherited": false,
     "animationType": "discrete",
     "percentages": "no",
     "groups": [


### PR DESCRIPTION
There are a few properties that contain non-boolean values. I think it's by incident. This PR fixes those properties.