### PR TITLE
Fix <'box-shadow'> groups

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2443,7 +2443,7 @@
     "animationType": "shadowList",
     "percentages": "no",
     "groups": [
-      "CSS Box Model"
+      "CSS Background and Borders"
     ],
     "initial": "none",
     "appliesto": "allElements",


### PR DESCRIPTION
`box-shadow` belongs to `background and borders` not to `box model`: https://www.w3.org/TR/css3-background/#the-box-shadow