### PR TITLE
Fix "animationType" values

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1181,7 +1181,7 @@
     "syntax": "<position>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableList simpleList lpc",
+    "animationType": "repeatableListOfSimpleListOfLpc",
     "percentages": "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
     "groups": [
       "CSS Background and Borders"
@@ -1251,7 +1251,7 @@
     "syntax": "<bg-size>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableList simpleList lpc keywords",
+    "animationType": "repeatableListOfSimpleListOfLpc",
     "percentages": "relativeToBackgroundPositioningArea",
     "groups": [
       "CSS Background and Borders"
@@ -3244,7 +3244,7 @@
     "syntax": "normal | [ <string> <number> ]#",
     "media": "visual",
     "inherited": true,
-    "animationType": "asTransform",
+    "animationType": "transform",
     "percentages": "no",
     "groups": [
       "CSS Fonts"
@@ -4073,7 +4073,7 @@
     "syntax": "normal | <number> | <length> | <percentage>",
     "media": "visual",
     "inherited": true,
-    "animationType": "number length",
+    "animationType": "numberOrLength",
     "percentages": "referToElementFontSize",
     "groups": [
       "CSS Fonts"
@@ -4438,7 +4438,7 @@
     "syntax": "<position>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableList simpleList lpc",
+    "animationType": "repeatableListOfSimpleListOfLpc",
     "percentages": "referToSizeOfMaskPaintingArea",
     "groups": [
       "CSS Masks"
@@ -4468,7 +4468,7 @@
     "syntax": "<bg-size>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableList simpleList lpc",
+    "animationType": "repeatableListOfSimpleListOfLpc",
     "percentages": "no",
     "groups": [
       "CSS Masks"
@@ -4649,7 +4649,7 @@
     "syntax": "<position>",
     "media": "visual",
     "inherited": true,
-    "animationType": "repeatableList simpleList lpc",
+    "animationType": "repeatableListOfSimpleListOfLpc",
     "percentages": "referToWidthAndHeightOfElement",
     "groups": [
       "CSS Images"
@@ -4792,7 +4792,7 @@
     "syntax": "none | ray( [ <angle> && <size>? && contain? ] ) | <path()> | <url> | [ <basic-shape> || <geometry-box> ]",
     "media": "visual",
     "inherited": false,
-    "animationType": "AsAngleBasicshapeOrPath",
+    "animationType": "angleOrBasicShapeOrPath",
     "percentages": "no",
     "groups": [
       "CSS Motion"
@@ -5269,7 +5269,7 @@
     "syntax": "<position>",
     "media": "visual",
     "inherited": false,
-    "animationType": "simpleList lpc",
+    "animationType": "simpleListOfLpc",
     "percentages": "referToSizeOfBoundingBox",
     "groups": [
       "CSS Transforms"
@@ -5555,7 +5555,7 @@
     "syntax": "none | <shape-box> || <basic-shape> | <image>",
     "media": "visual",
     "inherited": false,
-    "animationType": "basic-shape",
+    "animationType": "basicShapeOtherwiseNo",
     "percentages": "no",
     "groups": [
       "CSS Shapes"
@@ -6031,7 +6031,7 @@
     "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
     "media": "visual",
     "inherited": false,
-    "animationType": "simpleList lpc",
+    "animationType": "simpleListOfLpc",
     "percentages": "referToSizeOfBoundingBox",
     "groups": [
       "CSS Transforms"

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -11,9 +11,6 @@
     "fr": "tous",
     "ru": "всё"
   },
-  "asTransform" : {
-    "en-US": "Animating <code>font-variation-settings</code> is possible using a mechanism similar to animating <a href=\"/en-US/docs/Web/CSS/transform\">transform</a>: Two declarations can be animated if they feature the same set of items."
-  },
   "visual": {
     "en-US": "visual",
     "de": "visuell",
@@ -1433,7 +1430,7 @@
     "fr": "Crée un <a href=\"/fr/docs/Web/CSS/Comprendre_z-index/L'empilement_de_couches\">contexte d'empilement</a>",
     "ru": "Создаёт <a href=\"/ru/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context\">контекст наложения</a>"
   },
-  "AsAngleBasicshapeOrPath": {
+  "angleOrBasicShapeOrPath": {
     "en-US": "as &lt;angle&gt;, &lt;basic-shape&gt; or &lt;path()&gt;",
     "de": "als &lt;angle&gt;, &lt;basic-shape&gt; oder &lt;path()&gt;",
     "fr": "comme &lt;angle&gt;, &lt;basic-shape&gt; ou &lt;path()&gt;",
@@ -1444,5 +1441,15 @@
     "de": "Winkel",
     "fr": "angle",
     "ru": "угол"
+  },
+  "numberOrLength": {
+    "en-US": "either number or length",
+    "ru": "число или длина"
+  },
+  "simpleListOfLpc": {
+    "en-US": "simple list of length, percentage, or calc"
+  },
+  "repeatableListOfSimpleListOfLpc": {
+    "en-US": "repeatable list of simple list of length, percentage, or calc"
   }
 }


### PR DESCRIPTION
- `font-variation-settings`
    - `asTransform` changed to `transform` since `as` is never used in other cases (l10n key removed)
- `shape-outside`
    - `basic-shape` changed to `basicShapeOtherwiseNo` per spec (https://www.w3.org/TR/css-shapes-1/#shape-outside-property)
- `line-height`
    - `number length` changed to `numberOrLength` as more correct (l10n added)
- `offset-path`
    - `AsAngleBasicshapeOrPath` changed to `angleOrBasicShapeOrPath` as more correct (l10n key fixed)
- `perspective-origin`, `transform-origin`
    - `simpleList lpc` changed to `simpleListOfLpc` as more correct (l10n added)
- `background-position`, `mask-position`, `mask-size`, `object-position`
    - `repeatableList simpleList lpc` changed to `repeatableListOfSimpleListOfLpc` as more correct (l10n added)
- `background-size`
    - `repeatableList simpleList lpc keywords` changed to `repeatableListOfSimpleListOfLpc` as more correct (l10n key is missed). That's complicated one. Spec from [20140909](https://www.w3.org/TR/2014/CR-css3-background-20140909/#the-background-size) claims `as repeatable list of simple list of length, percentage, or calc (This means keyword values are not animatable.)` but [latest version](https://drafts.csswg.org/css-backgrounds-3/) claims `as repeatable list of simple list of length, percentage, or calc and keywords`. This changes doesn't reflected at [changes](https://drafts.csswg.org/css-backgrounds-3/#changes-2014-09) section and there is no clarification about `and keywords` meaning. I think something is wrong here, but didn't find a way to fill an issue. Believe `keywords` should be removed since looks wrong until confirmation.

As I noticed, values like `foo bar` is used for a composition of several l10n tokens. Changes in this PR breaks this. At the same time, composition did not work properly:
- `number length` [renders](https://developer.mozilla.org/en/docs/Web/CSS/line-height?v=example) as `a number, a length` but should be `a number or length`
- `simpleList lpc` [renders](https://developer.mozilla.org/en/docs/Web/CSS/transform-origin?v=example) as `a simple list of , a length, percentage or calc();` but should be `a simple list of a length, percentage or calc()` (with no comma after "of")