### PR TITLE
Implementing JSON Schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: node_js
-before_script:
-  - npm install jsonlint -g
-script:
-  - find . -name \*.json  | xargs -I {} jsonlint -q {}
-notifications:
-email: false
+sudo: false
+script: "npm run travis"

--- a/css/at-rules.schema.json
+++ b/css/at-rules.schema.json
@@ -1,9 +1,19 @@
 {
     "definitions": {
-        "stringOrArrayOfString": {
+        "stringOrPropertyList": {
             "oneOf": [
-                { "type": "string" },
-                { "type": "array", "items": { "type": "string" } }
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "property-reference": { "$data": "3" }
+                    }
+                }
             ]
         }
     },
@@ -41,23 +51,21 @@
                             "type": "string"
                         },
                         "initial": {
-                            "$ref": "#/definitions/stringOrArrayOfString"
+                            "$ref": "#/definitions/stringOrPropertyList"
                         },
                         "percentages": {
-                            "$ref": "#/definitions/stringOrArrayOfString"
+                            "$ref": "#/definitions/stringOrPropertyList"
                         },
                         "computed": {
-                            "$ref": "#/definitions/stringOrArrayOfString"
+                            "$ref": "#/definitions/stringOrPropertyList"
                         },
                         "order": {
-                            "type": "string",
                             "enum": [
                                 "orderOfAppearance",
                                 "uniqueOrder"
                             ]
                         },
                         "status": {
-                            "type": "string",
                             "enum": [
                                 "standard",
                                 "nonstandard",
@@ -77,7 +85,6 @@
                 }
             },
             "status": {
-                "type": "string",
                 "enum": [
                     "standard",
                     "nonstandard",

--- a/css/at-rules.schema.json
+++ b/css/at-rules.schema.json
@@ -12,7 +12,7 @@
           "items": {
             "type": "string",
             "property-reference": {
-              "comment": "That's a non-standart extension to JSON Schema validator. It tests value is an existing key in `descriptors`. See test/validate-schema.js for extension implementation details",
+              "comment": "property-reference is an extension to the JSON schema validator. Here it jumps 3 levels up in the hierarchy and tests if a value is an existing key in descriptors. See test/validate-schema.js for implementation details.",
               "$data": "3"
             }
           }

--- a/css/at-rules.schema.json
+++ b/css/at-rules.schema.json
@@ -12,6 +12,7 @@
           "items": {
             "type": "string",
             "property-reference": {
+              "comment": "That's a non-standart extension to JSON Schema validator. It tests value is an existing key in `descriptors`. See test/validate-schema.js for extension implementation details",
               "$data": "3"
             }
           }

--- a/css/at-rules.schema.json
+++ b/css/at-rules.schema.json
@@ -1,0 +1,94 @@
+{
+    "definitions": {
+        "stringOrArrayOfString": {
+            "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        }
+    },
+
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "syntax": {
+                "type": "string"
+            },
+            "interfaces": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "groups": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "descriptors": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "syntax": {
+                            "type": "string"
+                        },
+                        "media": {
+                            "type": "string"
+                        },
+                        "initial": {
+                            "$ref": "#/definitions/stringOrArrayOfString"
+                        },
+                        "percentages": {
+                            "$ref": "#/definitions/stringOrArrayOfString"
+                        },
+                        "computed": {
+                            "$ref": "#/definitions/stringOrArrayOfString"
+                        },
+                        "order": {
+                            "type": "string",
+                            "enum": [
+                                "orderOfAppearance",
+                                "uniqueOrder"
+                            ]
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": [
+                                "standard",
+                                "nonstandard",
+                                "experimental"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "syntax",
+                        "media",
+                        "initial",
+                        "percentages",
+                        "computed",
+                        "order",
+                        "status"
+                    ]
+                }
+            },
+            "status": {
+                "type": "string",
+                "enum": [
+                    "standard",
+                    "nonstandard",
+                    "experimental"
+                ]
+            }
+        },
+        "required": [
+            "syntax",
+            "groups",
+            "status"
+        ]
+    }
+}

--- a/css/at-rules.schema.json
+++ b/css/at-rules.schema.json
@@ -1,101 +1,102 @@
 {
-    "definitions": {
-        "stringOrPropertyList": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "array",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "property-reference": { "$data": "3" }
-                    }
-                }
-            ]
+  "definitions": {
+    "stringOrPropertyList": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "property-reference": {
+              "$data": "3"
+            }
+          }
         }
-    },
-
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": {
     "type": "object",
-    "additionalProperties": {
+    "additionalProperties": false,
+    "properties": {
+      "syntax": {
+        "type": "string"
+      },
+      "interfaces": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "groups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "descriptors": {
         "type": "object",
-        "additionalProperties": false,
-        "properties": {
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
             "syntax": {
-                "type": "string"
+              "type": "string"
             },
-            "interfaces": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
+            "media": {
+              "type": "string"
             },
-            "groups": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
+            "initial": {
+              "$ref": "#/definitions/stringOrPropertyList"
             },
-            "descriptors": {
-                "type": "object",
-                "additionalProperties": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "syntax": {
-                            "type": "string"
-                        },
-                        "media": {
-                            "type": "string"
-                        },
-                        "initial": {
-                            "$ref": "#/definitions/stringOrPropertyList"
-                        },
-                        "percentages": {
-                            "$ref": "#/definitions/stringOrPropertyList"
-                        },
-                        "computed": {
-                            "$ref": "#/definitions/stringOrPropertyList"
-                        },
-                        "order": {
-                            "enum": [
-                                "orderOfAppearance",
-                                "uniqueOrder"
-                            ]
-                        },
-                        "status": {
-                            "enum": [
-                                "standard",
-                                "nonstandard",
-                                "experimental"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "syntax",
-                        "media",
-                        "initial",
-                        "percentages",
-                        "computed",
-                        "order",
-                        "status"
-                    ]
-                }
+            "percentages": {
+              "$ref": "#/definitions/stringOrPropertyList"
+            },
+            "computed": {
+              "$ref": "#/definitions/stringOrPropertyList"
+            },
+            "order": {
+              "enum": [
+                "orderOfAppearance",
+                "uniqueOrder"
+              ]
             },
             "status": {
-                "enum": [
-                    "standard",
-                    "nonstandard",
-                    "experimental"
-                ]
+              "enum": [
+                "standard",
+                "nonstandard",
+                "experimental"
+              ]
             }
-        },
-        "required": [
+          },
+          "required": [
             "syntax",
-            "groups",
+            "media",
+            "initial",
+            "percentages",
+            "computed",
+            "order",
             "status"
+          ]
+        }
+      },
+      "status": {
+        "enum": [
+          "standard",
+          "nonstandard",
+          "experimental"
         ]
-    }
+      }
+    },
+    "required": [
+      "syntax",
+      "groups",
+      "status"
+    ]
+  }
 }

--- a/css/properties.json
+++ b/css/properties.json
@@ -2581,7 +2581,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "basicShapeOtherwiseNo",
-    "percentages": "referenceBoxWhenSpecifiedOtherwiseBorderBox",
+    "percentages": "referToReferenceBoxWhenSpecifiedOtherwiseBorderBox",
     "groups": [
       "CSS Miscellaneous"
     ],

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -1,324 +1,341 @@
 {
-    "definitions": {
-        "propertyList": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "property-reference": { "$data": "/" }
-            }
-        },
-        "stringList": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "type": "string"
-            }
-        },
-        "animationType": {
-            "enum": [
-                "angle",
-                "angleOrBasicShapeOrPath",
-                "basicShapeOtherwiseNo",
-                "color",
-                "discrete",
-                "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
-                "filterList",
-                "fontStretch",
-                "fontWeight",
-                "integer",
-                "length",
-                "lpc",
-                "numberOrLength",
-                "number",
-                "position",
-                "rectangle",
-                "repeatableListOfSimpleListOfLpc",
-                "shadowList",
-                "simpleListOfLpc",
-                "transform",
-                "visibility"
-            ]
-        },
-        "percentages": {
-            "enum": [
-                "blockSizeOfContainingBlock",
-                "dependsOnLayoutModel",
-                "inlineSizeOfContainingBlock",
-                "logicalHeightOfContainingBlock",
-                "logicalWidthOfContainingBlock",
-                "no",
-                "referToBorderBox",
-                "referToContainingBlockHeight",
-                "referToDimensionOfBorderBox",
-                "referToDimensionOfContentArea",
-                "referToElementFontSize",
-                "referToFlexContainersInnerMainSize",
-                "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
-                "referToLineHeight",
-                "referToParentElementsFontSize",
-                "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
-                "referToSizeOfBorderImage",
-                "referToSizeOfBoundingBox",
-                "referToSizeOfContainingBlock",
-                "referToSizeOfElement",
-                "referToSizeOfFont",
-                "referToSizeOfMaskPaintingArea",
-                "referToTotalPathLength",
-                "referToWidthAndHeightOfElement",
-                "referToWidthOfAffectedGlyph",
-                "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageHeight",
-                "referToWidthOfContainingBlock",
-                "referToWidthOrHeightOfBorderImageArea",
-                "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
-                "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
-                "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
-                "relativeToBackgroundPositioningArea",
-                "relativeToScrollContainerPaddingBoxAxis",
-                "relativeToWidthAndHeight"
-            ]
-        },
-        "computed": {
-            "enum": [
-                "absoluteLength",
-                "absoluteLength0ForNone",
-                "absoluteLength0IfColumnRuleStyleNoneOrHidden",
-                "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
-                "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
-                "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
-                "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
-                "absoluteLengthOrAsSpecified",
-                "absoluteLengthOrKeyword",
-                "absoluteLengthOrNone",
-                "absoluteLengthOrNormal",
-                "absoluteLengthOrPercentage",
-                "absoluteLengthsSpecifiedColorAsSpecified",
-                "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-                "absoluteLengthZeroOrLarger",
-                "absoluteURIOrNone",
-                "angleRoundedToNextQuarter",
-                "asAutoOrColor",
-                "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
-                "asLength",
-                "asSpecified",
-                "asSpecifiedAppliesToEachProperty",
-                "asSpecifiedExceptMatchParent",
-                "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
-                "asSpecifiedRelativeToAbsoluteLengths",
-                "asSpecifiedURIsAbsolute",
-                "asSpecifiedURLsAbsolute",
-                "asSpecifiedWithExceptionOfResolution",
-                "asSpecifiedWithVarsSubstituted",
-                "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
-                "autoOrRectangle",
-                "colorPlusThreeAbsoluteLengths",
-                "computedColor",
-                "consistsOfTwoDimensionKeywords",
-                "consistsOfTwoKeywordsForOriginAndOffsets",
-                "forLengthAbsoluteValueOtherwisePercentage",
-                "invertForTranslucentColorRGBAOtherwiseRGB",
-                "keywordOrNumericalValueBolderLighterTransformedToRealValue",
-                "keywordPlusIntegerIfDigits",
-                "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-                "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
-                "listEachItemHasTwoKeywordsOnePerDimension",
-                "listEachItemTwoKeywordsOriginOffsets",
-                "noneOrImageWithAbsoluteURI",
-                "normalizedAngle",
-                "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
-                "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
-                "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
-                "optimumValueOfAbsoluteLengthOrNormal",
-                "percentageAsSpecifiedAbsoluteLengthOrNone",
-                "percentageAsSpecifiedOrAbsoluteLength",
-                "percentageAutoOrAbsoluteLength",
-                "percentageOrAbsoluteLengthPlusKeywords",
-                "sameAsBoxOffsets",
-                "sameAsMaxWidthAndMaxHeight",
-                "sameAsMinWidthAndMinHeight",
-                "sameAsWidthAndHeight",
-                "specifiedIntegerOrAbsoluteLength",
-                "specifiedValueClipped0To1",
-                "specifiedValueNumberClipped0To1",
-                "translucentValuesRGBAOtherwiseRGB",
-                "twoAbsoluteLengthOrPercentages",
-                "twoAbsoluteLengths"
-            ]
-        },
-        "appliesto": {
-            "enum": [
-                "absolutelyPositionedElements",
-                "allElements",
-                "allElementsAcceptingWidthOrHeight",
-                "allElementsAndPseudos",
-                "allElementsButNonReplacedAndTableColumns",
-                "allElementsButNonReplacedAndTableRows",
-                "allElementsCreatingNativeWindows",
-                "allElementsExceptGeneratedContentOrPseudoElements",
-                "allElementsExceptInternalTableDisplayTypes",
-                "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
-                "allElementsExceptTableDisplayTypes",
-                "allElementsExceptTableElementsWhenCollapse",
-                "allElementsExceptTableRowColumnGroupsTableRowsColumns",
-                "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
-                "allElementsNoEffectIfDisplayNone",
-                "allElementsSomeValuesNoEffectOnNonInlineElements",
-                "allElementsSVGContainerElements",
-                "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
-                "allElementsUAsNotRequiredWhenCollapse",
-                "anyElementEffectOnProgressAndMeter",
-                "beforeAndAfterPseudos",
-                "blockContainerElements",
-                "blockContainers",
-                "blockElementsInNormalFlow",
-                "blockLevelElements",
-                "boxElements",
-                "childrenOfBoxElements",
-                "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
-                "elementsWithDisplayBoxOrInlineBox",
-                "elementsWithDisplayMarker",
-                "elementsWithDisplayMozBoxMozInlineBox",
-                "elementsWithOverflowNotVisibleAndReplacedElements",
-                "firstLetterPseudoElementsAndInlineLevelFirstChildren",
-                "flexContainers",
-                "flexItemsAndAbsolutelyPositionedFlexContainerChildren",
-                "flexItemsAndInFlowPseudos",
-                "floats",
-                "gridContainers",
-                "gridItemsAndBoxesWithinGridContainer",
-                "images",
-                "inFlowBlockLevelElements",
-                "inFlowChildrenOfBoxElements",
-                "inlineLevelAndTableCellElements",
-                "listItems",
-                "maskElements",
-                "multicolElements",
-                "multilineFlexContainers",
-                "nonReplacedBlockAndInlineBlockElements",
-                "nonReplacedBlockElements",
-                "nonReplacedInlineElements",
-                "positionedElements",
-                "replacedElements",
-                "rubyAnnotationsContainers",
-                "rubyBasesAnnotationsBaseAnnotationContainers",
-                "sameAsMargin",
-                "sameAsWidthAndHeight",
-                "scrollContainers",
-                "scrollingBoxes",
-                "tableCaptionElements",
-                "tableCellElements",
-                "tableElements",
-                "textElements",
-                "textFields",
-                "transformableElements",
-                "xulImageElements"
-            ]
-        },
-        "alsoApplyTo": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "enum": [
-                    "::first-letter",
-                    "::first-line",
-                    "::placeholder"
-                ]
-            }
-        },
-        "order": {
-            "enum": [
-                "canonicalOrder",
-                "lengthOrPercentageBeforeKeywordIfBothPresent",
-                "lengthOrPercentageBeforeKeywords",
-                "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
-                "orderOfAppearance",
-                "percentagesOrLengthsFollowedByFill",
-                "perGrammar",
-                "uniqueOrder"
-            ]
-        },
-        "status": {
-            "enum": [
-                "standard",
-                "nonstandard",
-                "experimental",
-                "obsolete"
-            ]
+  "definitions": {
+    "propertyList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "property-reference": {
+          "$data": "/"
         }
+      }
     },
-
-    "type": "object",
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-            "syntax",
-            "media",
-            "inherited",
-            "animationType",
-            "percentages",
-            "groups",
-            "initial",
-            "appliesto",
-            "computed",
-            "order",
-            "status"
-        ],
-        "properties": {
-            "syntax": {
-                "type": "string"
-            },
-            "media": {
-                "type": "string"
-            },
-            "inherited": {
-                "type": "boolean"
-            },
-            "animationType": {
-                "oneOf": [
-                    { "$ref": "#/definitions/animationType" },
-                    { "$ref": "#/definitions/propertyList" }
-                ]
-            },
-            "percentages": {
-                "oneOf": [
-                    { "$ref": "#/definitions/percentages" },
-                    { "$ref": "#/definitions/propertyList" }
-                ]
-            },
-            "groups": {
-                "$ref": "#/definitions/stringList"
-            },
-            "initial": {
-                "oneOf": [
-                    { "type": "string" },
-                    { "$ref": "#/definitions/propertyList" }
-                ]
-            },
-            "appliesto": {
-                "$ref": "#/definitions/appliesto"
-            },
-            "alsoAppliesTo": {
-                "$ref": "#/definitions/alsoApplyTo"
-            },
-            "computed": {
-                "oneOf": [
-                    { "$ref": "#/definitions/computed" },
-                    { "$ref": "#/definitions/propertyList" }
-                ]
-            },
-            "order": {
-                "$ref": "#/definitions/order"
-            },
-            "stacking": {
-                "type": "boolean"
-            },
-            "status": {
-                "$ref": "#/definitions/status"
-            }
-        }
+    "stringList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "animationType": {
+      "enum": [
+        "angle",
+        "angleOrBasicShapeOrPath",
+        "basicShapeOtherwiseNo",
+        "color",
+        "discrete",
+        "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
+        "filterList",
+        "fontStretch",
+        "fontWeight",
+        "integer",
+        "length",
+        "lpc",
+        "numberOrLength",
+        "number",
+        "position",
+        "rectangle",
+        "repeatableListOfSimpleListOfLpc",
+        "shadowList",
+        "simpleListOfLpc",
+        "transform",
+        "visibility"
+      ]
+    },
+    "percentages": {
+      "enum": [
+        "blockSizeOfContainingBlock",
+        "dependsOnLayoutModel",
+        "inlineSizeOfContainingBlock",
+        "logicalHeightOfContainingBlock",
+        "logicalWidthOfContainingBlock",
+        "no",
+        "referToBorderBox",
+        "referToContainingBlockHeight",
+        "referToDimensionOfBorderBox",
+        "referToDimensionOfContentArea",
+        "referToElementFontSize",
+        "referToFlexContainersInnerMainSize",
+        "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+        "referToLineHeight",
+        "referToParentElementsFontSize",
+        "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
+        "referToSizeOfBorderImage",
+        "referToSizeOfBoundingBox",
+        "referToSizeOfContainingBlock",
+        "referToSizeOfElement",
+        "referToSizeOfFont",
+        "referToSizeOfMaskPaintingArea",
+        "referToTotalPathLength",
+        "referToWidthAndHeightOfElement",
+        "referToWidthOfAffectedGlyph",
+        "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+        "referToWidthOfContainingBlock",
+        "referToWidthOrHeightOfBorderImageArea",
+        "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
+        "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
+        "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
+        "relativeToBackgroundPositioningArea",
+        "relativeToScrollContainerPaddingBoxAxis",
+        "relativeToWidthAndHeight"
+      ]
+    },
+    "computed": {
+      "enum": [
+        "absoluteLength",
+        "absoluteLength0ForNone",
+        "absoluteLength0IfColumnRuleStyleNoneOrHidden",
+        "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
+        "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
+        "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
+        "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
+        "absoluteLengthOrAsSpecified",
+        "absoluteLengthOrKeyword",
+        "absoluteLengthOrNone",
+        "absoluteLengthOrNormal",
+        "absoluteLengthOrPercentage",
+        "absoluteLengthsSpecifiedColorAsSpecified",
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+        "absoluteLengthZeroOrLarger",
+        "absoluteURIOrNone",
+        "angleRoundedToNextQuarter",
+        "asAutoOrColor",
+        "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
+        "asLength",
+        "asSpecified",
+        "asSpecifiedAppliesToEachProperty",
+        "asSpecifiedExceptMatchParent",
+        "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
+        "asSpecifiedRelativeToAbsoluteLengths",
+        "asSpecifiedURIsAbsolute",
+        "asSpecifiedURLsAbsolute",
+        "asSpecifiedWithExceptionOfResolution",
+        "asSpecifiedWithVarsSubstituted",
+        "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
+        "autoOrRectangle",
+        "colorPlusThreeAbsoluteLengths",
+        "computedColor",
+        "consistsOfTwoDimensionKeywords",
+        "consistsOfTwoKeywordsForOriginAndOffsets",
+        "forLengthAbsoluteValueOtherwisePercentage",
+        "invertForTranslucentColorRGBAOtherwiseRGB",
+        "keywordOrNumericalValueBolderLighterTransformedToRealValue",
+        "keywordPlusIntegerIfDigits",
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+        "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
+        "listEachItemHasTwoKeywordsOnePerDimension",
+        "listEachItemTwoKeywordsOriginOffsets",
+        "noneOrImageWithAbsoluteURI",
+        "normalizedAngle",
+        "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
+        "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
+        "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
+        "optimumValueOfAbsoluteLengthOrNormal",
+        "percentageAsSpecifiedAbsoluteLengthOrNone",
+        "percentageAsSpecifiedOrAbsoluteLength",
+        "percentageAutoOrAbsoluteLength",
+        "percentageOrAbsoluteLengthPlusKeywords",
+        "sameAsBoxOffsets",
+        "sameAsMaxWidthAndMaxHeight",
+        "sameAsMinWidthAndMinHeight",
+        "sameAsWidthAndHeight",
+        "specifiedIntegerOrAbsoluteLength",
+        "specifiedValueClipped0To1",
+        "specifiedValueNumberClipped0To1",
+        "translucentValuesRGBAOtherwiseRGB",
+        "twoAbsoluteLengthOrPercentages",
+        "twoAbsoluteLengths"
+      ]
+    },
+    "appliesto": {
+      "enum": [
+        "absolutelyPositionedElements",
+        "allElements",
+        "allElementsAcceptingWidthOrHeight",
+        "allElementsAndPseudos",
+        "allElementsButNonReplacedAndTableColumns",
+        "allElementsButNonReplacedAndTableRows",
+        "allElementsCreatingNativeWindows",
+        "allElementsExceptGeneratedContentOrPseudoElements",
+        "allElementsExceptInternalTableDisplayTypes",
+        "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
+        "allElementsExceptTableDisplayTypes",
+        "allElementsExceptTableElementsWhenCollapse",
+        "allElementsExceptTableRowColumnGroupsTableRowsColumns",
+        "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
+        "allElementsNoEffectIfDisplayNone",
+        "allElementsSomeValuesNoEffectOnNonInlineElements",
+        "allElementsSVGContainerElements",
+        "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+        "allElementsUAsNotRequiredWhenCollapse",
+        "anyElementEffectOnProgressAndMeter",
+        "beforeAndAfterPseudos",
+        "blockContainerElements",
+        "blockContainers",
+        "blockElementsInNormalFlow",
+        "blockLevelElements",
+        "boxElements",
+        "childrenOfBoxElements",
+        "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
+        "elementsWithDisplayBoxOrInlineBox",
+        "elementsWithDisplayMarker",
+        "elementsWithDisplayMozBoxMozInlineBox",
+        "elementsWithOverflowNotVisibleAndReplacedElements",
+        "firstLetterPseudoElementsAndInlineLevelFirstChildren",
+        "flexContainers",
+        "flexItemsAndAbsolutelyPositionedFlexContainerChildren",
+        "flexItemsAndInFlowPseudos",
+        "floats",
+        "gridContainers",
+        "gridItemsAndBoxesWithinGridContainer",
+        "images",
+        "inFlowBlockLevelElements",
+        "inFlowChildrenOfBoxElements",
+        "inlineLevelAndTableCellElements",
+        "listItems",
+        "maskElements",
+        "multicolElements",
+        "multilineFlexContainers",
+        "nonReplacedBlockAndInlineBlockElements",
+        "nonReplacedBlockElements",
+        "nonReplacedInlineElements",
+        "positionedElements",
+        "replacedElements",
+        "rubyAnnotationsContainers",
+        "rubyBasesAnnotationsBaseAnnotationContainers",
+        "sameAsMargin",
+        "sameAsWidthAndHeight",
+        "scrollContainers",
+        "scrollingBoxes",
+        "tableCaptionElements",
+        "tableCellElements",
+        "tableElements",
+        "textElements",
+        "textFields",
+        "transformableElements",
+        "xulImageElements"
+      ]
+    },
+    "alsoApplyTo": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "::first-letter",
+          "::first-line",
+          "::placeholder"
+        ]
+      }
+    },
+    "order": {
+      "enum": [
+        "canonicalOrder",
+        "lengthOrPercentageBeforeKeywordIfBothPresent",
+        "lengthOrPercentageBeforeKeywords",
+        "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+        "orderOfAppearance",
+        "percentagesOrLengthsFollowedByFill",
+        "perGrammar",
+        "uniqueOrder"
+      ]
+    },
+    "status": {
+      "enum": [
+        "standard",
+        "nonstandard",
+        "experimental",
+        "obsolete"
+      ]
     }
+  },
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "syntax",
+      "media",
+      "inherited",
+      "animationType",
+      "percentages",
+      "groups",
+      "initial",
+      "appliesto",
+      "computed",
+      "order",
+      "status"
+    ],
+    "properties": {
+      "syntax": {
+        "type": "string"
+      },
+      "media": {
+        "type": "string"
+      },
+      "inherited": {
+        "type": "boolean"
+      },
+      "animationType": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/animationType"
+          },
+          {
+            "$ref": "#/definitions/propertyList"
+          }
+        ]
+      },
+      "percentages": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/percentages"
+          },
+          {
+            "$ref": "#/definitions/propertyList"
+          }
+        ]
+      },
+      "groups": {
+        "$ref": "#/definitions/stringList"
+      },
+      "initial": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/definitions/propertyList"
+          }
+        ]
+      },
+      "appliesto": {
+        "$ref": "#/definitions/appliesto"
+      },
+      "alsoAppliesTo": {
+        "$ref": "#/definitions/alsoApplyTo"
+      },
+      "computed": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/computed"
+          },
+          {
+            "$ref": "#/definitions/propertyList"
+          }
+        ]
+      },
+      "order": {
+        "$ref": "#/definitions/order"
+      },
+      "stacking": {
+        "type": "boolean"
+      },
+      "status": {
+        "$ref": "#/definitions/status"
+      }
+    }
+  }
 }

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -9,10 +9,243 @@
                 "property-reference": { "$data": "/" }
             }
         },
-        "stringOrPropertyList": {
-            "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/definitions/propertyList" }
+        "stringList": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "animationType": {
+            "enum": [
+                "angle",
+                "angleOrBasicShapeOrPath",
+                "basicShapeOtherwiseNo",
+                "color",
+                "discrete",
+                "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
+                "filterList",
+                "fontStretch",
+                "fontWeight",
+                "integer",
+                "length",
+                "lpc",
+                "numberOrLength",
+                "number",
+                "position",
+                "rectangle",
+                "repeatableListOfSimpleListOfLpc",
+                "shadowList",
+                "simpleListOfLpc",
+                "transform",
+                "visibility"
+            ]
+        },
+        "percentages": {
+            "enum": [
+                "blockSizeOfContainingBlock",
+                "dependsOnLayoutModel",
+                "inlineSizeOfContainingBlock",
+                "logicalHeightOfContainingBlock",
+                "logicalWidthOfContainingBlock",
+                "no",
+                "referToBorderBox",
+                "referToContainingBlockHeight",
+                "referToDimensionOfBorderBox",
+                "referToDimensionOfContentArea",
+                "referToElementFontSize",
+                "referToFlexContainersInnerMainSize",
+                "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+                "referToLineHeight",
+                "referToParentElementsFontSize",
+                "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
+                "referToSizeOfBorderImage",
+                "referToSizeOfBoundingBox",
+                "referToSizeOfContainingBlock",
+                "referToSizeOfElement",
+                "referToSizeOfFont",
+                "referToSizeOfMaskPaintingArea",
+                "referToTotalPathLength",
+                "referToWidthAndHeightOfElement",
+                "referToWidthOfAffectedGlyph",
+                "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+                "referToWidthOfContainingBlock",
+                "referToWidthOrHeightOfBorderImageArea",
+                "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
+                "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
+                "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
+                "relativeToBackgroundPositioningArea",
+                "relativeToScrollContainerPaddingBoxAxis",
+                "relativeToWidthAndHeight"
+            ]
+        },
+        "computed": {
+            "enum": [
+                "absoluteLength",
+                "absoluteLength0ForNone",
+                "absoluteLength0IfColumnRuleStyleNoneOrHidden",
+                "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
+                "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
+                "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
+                "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
+                "absoluteLengthOrAsSpecified",
+                "absoluteLengthOrKeyword",
+                "absoluteLengthOrNone",
+                "absoluteLengthOrNormal",
+                "absoluteLengthOrPercentage",
+                "absoluteLengthsSpecifiedColorAsSpecified",
+                "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+                "absoluteLengthZeroOrLarger",
+                "absoluteURIOrNone",
+                "angleRoundedToNextQuarter",
+                "asAutoOrColor",
+                "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
+                "asLength",
+                "asSpecified",
+                "asSpecifiedAppliesToEachProperty",
+                "asSpecifiedExceptMatchParent",
+                "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
+                "asSpecifiedRelativeToAbsoluteLengths",
+                "asSpecifiedURIsAbsolute",
+                "asSpecifiedURLsAbsolute",
+                "asSpecifiedWithExceptionOfResolution",
+                "asSpecifiedWithVarsSubstituted",
+                "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
+                "autoOrRectangle",
+                "colorPlusThreeAbsoluteLengths",
+                "computedColor",
+                "consistsOfTwoDimensionKeywords",
+                "consistsOfTwoKeywordsForOriginAndOffsets",
+                "forLengthAbsoluteValueOtherwisePercentage",
+                "invertForTranslucentColorRGBAOtherwiseRGB",
+                "keywordOrNumericalValueBolderLighterTransformedToRealValue",
+                "keywordPlusIntegerIfDigits",
+                "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+                "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
+                "listEachItemHasTwoKeywordsOnePerDimension",
+                "listEachItemTwoKeywordsOriginOffsets",
+                "noneOrImageWithAbsoluteURI",
+                "normalizedAngle",
+                "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
+                "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
+                "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
+                "optimumValueOfAbsoluteLengthOrNormal",
+                "percentageAsSpecifiedAbsoluteLengthOrNone",
+                "percentageAsSpecifiedOrAbsoluteLength",
+                "percentageAutoOrAbsoluteLength",
+                "percentageOrAbsoluteLengthPlusKeywords",
+                "sameAsBoxOffsets",
+                "sameAsMaxWidthAndMaxHeight",
+                "sameAsMinWidthAndMinHeight",
+                "sameAsWidthAndHeight",
+                "specifiedIntegerOrAbsoluteLength",
+                "specifiedValueClipped0To1",
+                "specifiedValueNumberClipped0To1",
+                "translucentValuesRGBAOtherwiseRGB",
+                "twoAbsoluteLengthOrPercentages",
+                "twoAbsoluteLengths"
+            ]
+        },
+        "appliesto": {
+            "enum": [
+                "absolutelyPositionedElements",
+                "allElements",
+                "allElementsAcceptingWidthOrHeight",
+                "allElementsAndPseudos",
+                "allElementsButNonReplacedAndTableColumns",
+                "allElementsButNonReplacedAndTableRows",
+                "allElementsCreatingNativeWindows",
+                "allElementsExceptGeneratedContentOrPseudoElements",
+                "allElementsExceptInternalTableDisplayTypes",
+                "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
+                "allElementsExceptTableDisplayTypes",
+                "allElementsExceptTableElementsWhenCollapse",
+                "allElementsExceptTableRowColumnGroupsTableRowsColumns",
+                "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
+                "allElementsNoEffectIfDisplayNone",
+                "allElementsSomeValuesNoEffectOnNonInlineElements",
+                "allElementsSVGContainerElements",
+                "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+                "allElementsUAsNotRequiredWhenCollapse",
+                "anyElementEffectOnProgressAndMeter",
+                "beforeAndAfterPseudos",
+                "blockContainerElements",
+                "blockContainers",
+                "blockElementsInNormalFlow",
+                "blockLevelElements",
+                "boxElements",
+                "childrenOfBoxElements",
+                "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
+                "elementsWithDisplayBoxOrInlineBox",
+                "elementsWithDisplayMarker",
+                "elementsWithDisplayMozBoxMozInlineBox",
+                "elementsWithOverflowNotVisibleAndReplacedElements",
+                "firstLetterPseudoElementsAndInlineLevelFirstChildren",
+                "flexContainers",
+                "flexItemsAndAbsolutelyPositionedFlexContainerChildren",
+                "flexItemsAndInFlowPseudos",
+                "floats",
+                "gridContainers",
+                "gridItemsAndBoxesWithinGridContainer",
+                "images",
+                "inFlowBlockLevelElements",
+                "inFlowChildrenOfBoxElements",
+                "inlineLevelAndTableCellElements",
+                "listItems",
+                "maskElements",
+                "multicolElements",
+                "multilineFlexContainers",
+                "nonReplacedBlockAndInlineBlockElements",
+                "nonReplacedBlockElements",
+                "nonReplacedInlineElements",
+                "positionedElements",
+                "replacedElements",
+                "rubyAnnotationsContainers",
+                "rubyBasesAnnotationsBaseAnnotationContainers",
+                "sameAsMargin",
+                "sameAsWidthAndHeight",
+                "scrollContainers",
+                "scrollingBoxes",
+                "tableCaptionElements",
+                "tableCellElements",
+                "tableElements",
+                "textElements",
+                "textFields",
+                "transformableElements",
+                "xulImageElements"
+            ]
+        },
+        "alsoApplyTo": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "enum": [
+                    "::first-letter",
+                    "::first-line",
+                    "::placeholder"
+                ]
+            }
+        },
+        "order": {
+            "enum": [
+                "canonicalOrder",
+                "lengthOrPercentageBeforeKeywordIfBothPresent",
+                "lengthOrPercentageBeforeKeywords",
+                "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+                "orderOfAppearance",
+                "percentagesOrLengthsFollowedByFill",
+                "perGrammar",
+                "uniqueOrder"
+            ]
+        },
+        "status": {
+            "enum": [
+                "standard",
+                "nonstandard",
+                "experimental",
+                "obsolete"
             ]
         }
     },
@@ -21,94 +254,6 @@
     "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "properties": {
-            "syntax": {
-                "type": "string"
-            },
-            "media": {
-                "type": "string"
-            },
-            "inherited": {
-                "type": "boolean"
-            },
-            "animationType": {
-                "oneOf": [
-                    {
-                        "enum": [
-                            "angle",
-                            "angleOrBasicShapeOrPath",
-                            "basicShapeOtherwiseNo",
-                            "color",
-                            "discrete",
-                            "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
-                            "filterList",
-                            "fontStretch",
-                            "fontWeight",
-                            "integer",
-                            "length",
-                            "lpc",
-                            "numberOrLength",
-                            "number",
-                            "position",
-                            "rectangle",
-                            "repeatableListOfSimpleListOfLpc",
-                            "shadowList",
-                            "simpleListOfLpc",
-                            "transform",
-                            "visibility"
-                        ]
-                    },
-                    { "$ref": "#/definitions/propertyList" }
-                ]
-            },
-            "percentages": {
-                "$ref": "#/definitions/stringOrPropertyList"
-            },
-            "groups": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "initial": {
-                "$ref": "#/definitions/stringOrPropertyList"
-            },
-            "appliesto": {
-                "$ref": "#/definitions/stringOrPropertyList"
-            },
-            "alsoAppliesTo": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "computed": {
-                "$ref": "#/definitions/stringOrPropertyList"
-            },
-            "order": {
-                "enum": [
-                    "canonicalOrder",
-                    "lengthOrPercentageBeforeKeywordIfBothPresent",
-                    "lengthOrPercentageBeforeKeywords",
-                    "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
-                    "orderOfAppearance",
-                    "percentagesOrLengthsFollowedByFill",
-                    "perGrammar",
-                    "uniqueOrder"
-                ]
-            },
-            "stacking": {
-                "type": "boolean"
-            },
-            "status": {
-                "enum": [
-                    "standard",
-                    "nonstandard",
-                    "experimental",
-                    "obsolete"
-                ]
-            }
-        },
         "required": [
             "syntax",
             "media",
@@ -121,6 +266,59 @@
             "computed",
             "order",
             "status"
-        ]
+        ],
+        "properties": {
+            "syntax": {
+                "type": "string"
+            },
+            "media": {
+                "type": "string"
+            },
+            "inherited": {
+                "type": "boolean"
+            },
+            "animationType": {
+                "oneOf": [
+                    { "$ref": "#/definitions/animationType" },
+                    { "$ref": "#/definitions/propertyList" }
+                ]
+            },
+            "percentages": {
+                "oneOf": [
+                    { "$ref": "#/definitions/percentages" },
+                    { "$ref": "#/definitions/propertyList" }
+                ]
+            },
+            "groups": {
+                "$ref": "#/definitions/stringList"
+            },
+            "initial": {
+                "oneOf": [
+                    { "type": "string" },
+                    { "$ref": "#/definitions/propertyList" }
+                ]
+            },
+            "appliesto": {
+                "$ref": "#/definitions/appliesto"
+            },
+            "alsoAppliesTo": {
+                "$ref": "#/definitions/alsoApplyTo"
+            },
+            "computed": {
+                "oneOf": [
+                    { "$ref": "#/definitions/computed" },
+                    { "$ref": "#/definitions/propertyList" }
+                ]
+            },
+            "order": {
+                "$ref": "#/definitions/order"
+            },
+            "stacking": {
+                "type": "boolean"
+            },
+            "status": {
+                "$ref": "#/definitions/status"
+            }
+        }
     }
 }

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -1,9 +1,18 @@
 {
     "definitions": {
-        "stringOrArrayOfString": {
+        "propertyList": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "property-reference": { "$data": "/" }
+            }
+        },
+        "stringOrPropertyList": {
             "oneOf": [
                 { "type": "string" },
-                { "type": "array", "items": { "type": "string" } }
+                { "$ref": "#/definitions/propertyList" }
             ]
         }
     },
@@ -23,10 +32,37 @@
                 "type": "boolean"
             },
             "animationType": {
-                "$ref": "#/definitions/stringOrArrayOfString"
+                "oneOf": [
+                    {
+                        "enum": [
+                            "angle",
+                            "angleOrBasicShapeOrPath",
+                            "basicShapeOtherwiseNo",
+                            "color",
+                            "discrete",
+                            "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
+                            "filterList",
+                            "fontStretch",
+                            "fontWeight",
+                            "integer",
+                            "length",
+                            "lpc",
+                            "numberOrLength",
+                            "number",
+                            "position",
+                            "rectangle",
+                            "repeatableListOfSimpleListOfLpc",
+                            "shadowList",
+                            "simpleListOfLpc",
+                            "transform",
+                            "visibility"
+                        ]
+                    },
+                    { "$ref": "#/definitions/propertyList" }
+                ]
             },
             "percentages": {
-                "$ref": "#/definitions/stringOrArrayOfString"
+                "$ref": "#/definitions/stringOrPropertyList"
             },
             "groups": {
                 "type": "array",
@@ -35,10 +71,10 @@
                 }
             },
             "initial": {
-                "$ref": "#/definitions/stringOrArrayOfString"
+                "$ref": "#/definitions/stringOrPropertyList"
             },
             "appliesto": {
-                "$ref": "#/definitions/stringOrArrayOfString"
+                "$ref": "#/definitions/stringOrPropertyList"
             },
             "alsoAppliesTo": {
                 "type": "array",
@@ -47,10 +83,9 @@
                 }
             },
             "computed": {
-                "$ref": "#/definitions/stringOrArrayOfString"
+                "$ref": "#/definitions/stringOrPropertyList"
             },
             "order": {
-                "type": "string",
                 "enum": [
                     "canonicalOrder",
                     "lengthOrPercentageBeforeKeywordIfBothPresent",
@@ -66,7 +101,6 @@
                 "type": "boolean"
             },
             "status": {
-                "type": "string",
                 "enum": [
                     "standard",
                     "nonstandard",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -7,6 +7,7 @@
       "items": {
         "type": "string",
         "property-reference": {
+          "comment": "That's a non-standart extension to JSON Schema validator. It tests value is an existing key in root object (i.e. defined property). See test/validate-schema.js for extension implementation details",
           "$data": "/"
         }
       }

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -1,0 +1,92 @@
+{
+    "definitions": {
+        "stringOrArrayOfString": {
+            "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        }
+    },
+
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "syntax": {
+                "type": "string"
+            },
+            "media": {
+                "type": "string"
+            },
+            "inherited": {
+                "type": "boolean"
+            },
+            "animationType": {
+                "$ref": "#/definitions/stringOrArrayOfString"
+            },
+            "percentages": {
+                "$ref": "#/definitions/stringOrArrayOfString"
+            },
+            "groups": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "initial": {
+                "$ref": "#/definitions/stringOrArrayOfString"
+            },
+            "appliesto": {
+                "$ref": "#/definitions/stringOrArrayOfString"
+            },
+            "alsoAppliesTo": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "computed": {
+                "$ref": "#/definitions/stringOrArrayOfString"
+            },
+            "order": {
+                "type": "string",
+                "enum": [
+                    "canonicalOrder",
+                    "lengthOrPercentageBeforeKeywordIfBothPresent",
+                    "lengthOrPercentageBeforeKeywords",
+                    "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+                    "orderOfAppearance",
+                    "percentagesOrLengthsFollowedByFill",
+                    "perGrammar",
+                    "uniqueOrder"
+                ]
+            },
+            "stacking": {
+                "type": "boolean"
+            },
+            "status": {
+                "type": "string",
+                "enum": [
+                    "standard",
+                    "nonstandard",
+                    "experimental",
+                    "obsolete"
+                ]
+            }
+        },
+        "required": [
+            "syntax",
+            "media",
+            "inherited",
+            "animationType",
+            "percentages",
+            "groups",
+            "initial",
+            "appliesto",
+            "computed",
+            "order",
+            "status"
+        ]
+    }
+}

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -7,7 +7,7 @@
       "items": {
         "type": "string",
         "property-reference": {
-          "comment": "That's a non-standart extension to JSON Schema validator. It tests value is an existing key in root object (i.e. defined property). See test/validate-schema.js for extension implementation details",
+          "comment": "property-reference is an extension to the JSON schema validator. Here it jumps to the root level of the hierarchy and tests if a value is an existing key there (i.e a defined property). See test/validate-schema.js for implementation details.",
           "$data": "/"
         }
       }
@@ -75,6 +75,7 @@
         "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageHeight",
         "referToWidthOfContainingBlock",
         "referToWidthOrHeightOfBorderImageArea",
+        "referToReferenceBoxWhenSpecifiedOtherwiseBorderBox",
         "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
         "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
         "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
@@ -110,7 +111,6 @@
         "asSpecifiedExceptMatchParent",
         "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
         "asSpecifiedRelativeToAbsoluteLengths",
-        "asSpecifiedURIsAbsolute",
         "asSpecifiedURLsAbsolute",
         "asSpecifiedWithExceptionOfResolution",
         "asSpecifiedWithVarsSubstituted",

--- a/css/selectors.schema.json
+++ b/css/selectors.schema.json
@@ -1,0 +1,31 @@
+{
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "syntax": {
+                "type": "string"
+            },
+            "groups": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "status": {
+                "type": "string",
+                "enum": [
+                    "standard",
+                    "nonstandard",
+                    "experimental"
+                ]
+            }
+        },
+        "required": [
+            "syntax",
+            "groups",
+            "status"
+        ]
+    }
+}

--- a/css/selectors.schema.json
+++ b/css/selectors.schema.json
@@ -14,7 +14,6 @@
                 }
             },
             "status": {
-                "type": "string",
                 "enum": [
                     "standard",
                     "nonstandard",

--- a/css/selectors.schema.json
+++ b/css/selectors.schema.json
@@ -1,30 +1,30 @@
 {
+  "type": "object",
+  "additionalProperties": {
     "type": "object",
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-            "syntax": {
-                "type": "string"
-            },
-            "groups": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "status": {
-                "enum": [
-                    "standard",
-                    "nonstandard",
-                    "experimental"
-                ]
-            }
-        },
-        "required": [
-            "syntax",
-            "groups",
-            "status"
+    "additionalProperties": false,
+    "properties": {
+      "syntax": {
+        "type": "string"
+      },
+      "groups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "status": {
+        "enum": [
+          "standard",
+          "nonstandard",
+          "experimental"
         ]
-    }
+      }
+    },
+    "required": [
+      "syntax",
+      "groups",
+      "status"
+    ]
+  }
 }

--- a/css/syntaxes.schema.json
+++ b/css/syntaxes.schema.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "additionalProperties": {
+        "type": "string"
+    }
+}

--- a/css/syntaxes.schema.json
+++ b/css/syntaxes.schema.json
@@ -1,6 +1,6 @@
 {
-    "type": "object",
-    "additionalProperties": {
-        "type": "string"
-    }
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
 }

--- a/css/types.schema.json
+++ b/css/types.schema.json
@@ -1,0 +1,27 @@
+{
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "groups": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "status": {
+                "type": "string",
+                "enum": [
+                    "standard",
+                    "nonstandard",
+                    "experimental"
+                ]
+            }
+        },
+        "required": [
+            "groups",
+            "status"
+        ]
+    }
+}

--- a/css/types.schema.json
+++ b/css/types.schema.json
@@ -11,7 +11,6 @@
                 }
             },
             "status": {
-                "type": "string",
                 "enum": [
                     "standard",
                     "nonstandard",

--- a/css/types.schema.json
+++ b/css/types.schema.json
@@ -1,26 +1,26 @@
 {
+  "type": "object",
+  "additionalProperties": {
     "type": "object",
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-            "groups": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "status": {
-                "enum": [
-                    "standard",
-                    "nonstandard",
-                    "experimental"
-                ]
-            }
-        },
-        "required": [
-            "groups",
-            "status"
+    "additionalProperties": false,
+    "properties": {
+      "groups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "status": {
+        "enum": [
+          "standard",
+          "nonstandard",
+          "experimental"
         ]
-    }
+      }
+    },
+    "required": [
+      "groups",
+      "status"
+    ]
+  }
 }

--- a/css/units.schema.json
+++ b/css/units.schema.json
@@ -1,0 +1,27 @@
+{
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "groups": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "status": {
+                "type": "string",
+                "enum": [
+                    "standard",
+                    "nonstandard",
+                    "experimental"
+                ]
+            }
+        },
+        "required": [
+            "groups",
+            "status"
+        ]
+    }
+}

--- a/css/units.schema.json
+++ b/css/units.schema.json
@@ -11,7 +11,6 @@
                 }
             },
             "status": {
-                "type": "string",
                 "enum": [
                     "standard",
                     "nonstandard",

--- a/css/units.schema.json
+++ b/css/units.schema.json
@@ -1,26 +1,26 @@
 {
+  "type": "object",
+  "additionalProperties": {
     "type": "object",
-    "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-            "groups": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            },
-            "status": {
-                "enum": [
-                    "standard",
-                    "nonstandard",
-                    "experimental"
-                ]
-            }
-        },
-        "required": [
-            "groups",
-            "status"
+    "additionalProperties": false,
+    "properties": {
+      "groups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "status": {
+        "enum": [
+          "standard",
+          "nonstandard",
+          "experimental"
         ]
-    }
+      }
+    },
+    "required": [
+      "groups",
+      "status"
+    ]
+  }
 }

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1434,7 +1434,7 @@
   "repeatableListOfSimpleListOfLpc": {
     "en-US": "repeatable list of simple list of length, percentage, or calc"
   },
-  "referenceBoxWhenSpecifiedOtherwiseBorderBox": {
+  "referToReferenceBoxWhenSpecifiedOtherwiseBorderBox": {
     "en-US": "refer to reference box when specified, otherwise border-box"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
   "bugs": {
     "url": "https://github.com/mdn/data/issues"
   },
-  "homepage": "https://developer.mozilla.org"
+  "homepage": "https://developer.mozilla.org",
+  "devDependencies": {
+    "ajv": "^5.0.1"
+  },
+  "scripts": {
+    "test": "node test/validate-schema"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
   },
   "homepage": "https://developer.mozilla.org",
   "devDependencies": {
-    "ajv": "^5.0.1"
+    "ajv": "^5.0.1",
+    "jsonlint": "~1.6.2"
   },
   "scripts": {
-    "test": "node test/validate-schema"
+    "validate-schema": "node test/validate-schema",
+    "lint-json": "find css l10n -name \\*.json | xargs -I {} jsonlint -q {}",
+    "travis": "npm test",
+    "test": "npm run lint-json && npm run validate-schema"
   }
 }

--- a/test/validate-schema.js
+++ b/test/validate-schema.js
@@ -1,0 +1,45 @@
+var fs = require('fs');
+var path = require('path');
+var Ajv = require('ajv');
+var ajv = new Ajv({ allErrors: true });
+var dictPaths = ['css'];
+var hasErrors = false;
+
+function validateDir(dir) {
+    var absDir = path.resolve(path.join(__dirname, '..', dir));
+
+    fs.readdirSync(absDir).forEach(function(filename) {
+        if (/\.schema\.json$/.test(filename)) {
+            var dataFilename = filename.replace(/\.schema\.json$/, '.json');
+            var absSchemaFilename = path.join(absDir, filename);
+            var absDataFilename = path.join(absDir, dataFilename);
+            var header = dir + '/' + dataFilename;
+
+            var valid = ajv.validate(
+                require(absSchemaFilename),
+                require(absDataFilename)
+            );
+
+            if (valid) {
+                console.log(header + ' - OK');
+            } else {
+                hasErrors = true;
+                console.log(
+                    header + ' errors:\n  ' +
+                    ajv.errorsText(ajv.errors, {
+                        separator: '\n  ',
+                        dataVar: 'item'
+                    })
+                );
+            }
+
+            console.log();
+        }
+    });
+}
+
+dictPaths.forEach(validateDir);
+
+if (hasErrors) {
+    process.exit(1);
+}

--- a/test/validate-schema.js
+++ b/test/validate-schema.js
@@ -1,11 +1,24 @@
 var fs = require('fs');
 var path = require('path');
 var Ajv = require('ajv');
-var ajv = new Ajv({ allErrors: true });
+var ajv = new Ajv({ $data: true, allErrors: true });
 var dictPaths = ['css'];
 var hasErrors = false;
 
-function validateDir(dir) {
+ajv.addKeyword('property-reference', {
+    $data: true,
+    metaSchema: { type: 'object' },
+    validate: function(schema, data, parentSchema) {
+        var valid = schema.hasOwnProperty(data);
+        if (!valid) {
+            // TODO: make a verbose message when invalid
+            // throw new Error('wrong reference')
+        }
+        return valid;
+    }
+});
+
+dictPaths.forEach(function(dir) {
     var absDir = path.resolve(path.join(__dirname, '..', dir));
 
     fs.readdirSync(absDir).forEach(function(filename) {
@@ -36,9 +49,7 @@ function validateDir(dir) {
             console.log();
         }
     });
-}
-
-dictPaths.forEach(validateDir);
+});
 
 if (hasErrors) {
     process.exit(1);


### PR DESCRIPTION
Initial implementation of JSON Schema validation (fixes #19).

At the moment all `css/*.json` files are correct except `properties.json`. Last one has several issues that were addressed by PRs ~#62~, ~#64~, ~#65~, ~#68~, ~#70~, ~#73~, ~#74~, ~#75~, ~#76~, ~#82~ and ~#85~.

Also I added `npm test` script. I'm going to integrate it to travis and merge its current script with it later.