### PR TITLE
Fix some "appliesto" values

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1635,13 +1635,7 @@
       "border-image-outset",
       "border-image-repeat"
     ],
-    "appliesto": [
-      "border-image-outset",
-      "border-image-repeat",
-      "border-image-slice",
-      "border-image-source",
-      "border-image-width"
-    ],
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
     "computed": [
       "border-image-outset",
       "border-image-repeat",
@@ -1737,7 +1731,7 @@
       "CSS Background and Borders"
     ],
     "initial": "1",
-    "appliesto": "allElementsExceptTableElementsWhenBorderCollapseCollapse",
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
@@ -4624,7 +4618,7 @@
       "Compositing and Blending"
     ],
     "initial": "normal",
-    "appliesto": "allHTMLElements",
+    "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "stacking": true,

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -508,12 +508,6 @@
     "fr": "voir {{cssxref(\"grid-template-rows\")}} ou {{cssxref(\"grid-template-columns\")}}",
     "ru": "смотрите {{cssxref(\"grid-template-rows\")}} или {{cssxref(\"grid-template-columns\")}}"
   },
-  "allElementsExceptTableElementsWhenBorderCollapseCollapse": {
-    "en-US": "all elements, except table elements when {{cssxref(\"border-collapse\")}} is <code>collapse<\/code>",
-    "de": "Alle Elemente außer Tabellenelemente, falls {{cssxref(\"border-collapse\")}} <code>collapse<\/code> ist",
-    "fr": "tous les \u00e9l\u00e9ments sauf les \u00e9l\u00e9ments de table lorsque {{cssxref(\"border-collapse\")}} vaut <code>collapse<\/code>",
-    "ru": "все элементы, кроме табличных, когда {{cssxref(\"border-collapse\")}}:<code>collapse<\/code>"
-  },
   "allElementsAcceptingWidthOrHeight": {
     "en-US": "all elements that accept width or height",
     "de": "alle Elemente, die Breite oder Höhe akzeptieren",


### PR DESCRIPTION
- `border-image`
    - the single property with an array value, changed to "allElementsExceptTableElementsWhenCollapse" as its longhand properties
- `border-image-width`
    - `allElementsExceptTableElementsWhenBorderCollapseCollapse` -> `allElementsExceptTableElementsWhenCollapse` like other `border-image-*` properties; The single difference is missed `internal` word in first description. I guess it's [a mistake in spec](https://drafts.csswg.org/css-backgrounds-3/#the-border-image-width) because there is no reasons to differ from other `border-image-*` properties.
- `mix-blend-mode`
    - `allHTMLElements` -> `allElements` (see https://drafts.fxtf.org/compositing-1/#mix-blend-mode)