### PR TITLE
Fill missed fields for <'-webkit-touch-callout'>

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -730,9 +730,17 @@
   },
   "-webkit-touch-callout": {
     "syntax": "default | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
     "groups": [
       "WebKit Extensions"
     ],
+    "initial": "default",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
     "status": "nonstandard"
   },
   "align-content": {


### PR DESCRIPTION
There is no any spec or full description. Values are filled by [implementation patch](https://trac.webkit.org/changeset/156347/webkit) and similar properties.