### PR TITLE
Remove <'box-suppress'>

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2471,21 +2471,6 @@
     "order": "uniqueOrder",
     "status": "standard"
   },
-  "box-suppress": {
-    "syntax": "show | discard | hide",
-    "media": "all",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "CSS Display"
-    ],
-    "initial": "show",
-    "appliesto": "allElements",
-    "computed": "seeProse",
-    "order": "uniqueOrder",
-    "status": "experimental"
-  },
   "break-after": {
     "syntax": "auto | avoid | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
     "media": "paged",


### PR DESCRIPTION
`box-suppress` was removed from CSS Display Module Level 3 (see [changes](https://drafts.csswg.org/css-display/#changes)):

> Deferred the box-suppress/display-or-not property to the next level of Display, in order to provide time for futher discussion of use cases.

According to https://developer.mozilla.org/en-US/docs/Web/CSS/box-suppress there is no any browser support. Property [should be removed](https://github.com/mdn/data/pull/71#issuecomment-302516509) for now.