### PR TITLE
Fix <'-webkit-mask'> and <'-webkit-mask-clip'> syntaxes

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -510,7 +510,7 @@
     "status": "nonstandard"
   },
   "-webkit-mask-clip": {
-    "syntax": "<-webkit-mask-clip-style> [, <-webkit-mask-clip-style> ]*",
+    "syntax": "[ border | border-box | padding | padding-box | content | content-box | text ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -466,7 +466,7 @@
     "status": "nonstandard"
   },
   "-webkit-mask": {
-    "syntax": "<mask-image> [ <mask-repeat> || <mask-attachment> || <mask-position> || <mask-origin> || <mask-clip> ]*",
+    "syntax": "<mask-image> [ <'-webkit-mask-repeat'> || <'-webkit-mask-attachment'> || <'-webkit-mask-position'> || <'-webkit-mask-origin'> || <'-webkit-mask-clip'> ]*",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -510,7 +510,7 @@
     "status": "nonstandard"
   },
   "-webkit-mask-clip": {
-    "syntax": "<clip-style> [, <clip-style> ]*",
+    "syntax": "<-webkit-mask-clip-style> [, <-webkit-mask-clip-style> ]*",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
Working on syntaxes checking, I found `-webkit-mask` and `-webkit-mask-clip` are broken, because are using non-exists syntaxes. This PR fixes them:
- `-webkit-mask`: replace `<mask-repeat>`, `<mask-attachment>`, `<mask-position>`, `<mask-origin>` and `<mask-clip>` for corresponding property references, since these syntaxes aren't defined.
- `-webkit-mask-clip`: there is no enough information about `-webkit-mask-clip` property, but looks like comma separated list of keywords can be used as a value. I avoid of adding `clip-style` to reduce pollution syntaxes dictionary by non-standard syntaxes.

MDN redirects `-webkit-mask` and `-webkit-mask-clip` to vendor free articles, but unprefixed properties have a new syntax. I think we should keep `-webkit-` version, but fix old syntaxes to be linked correctly.