### PR TITLE
Add ::cue pseudo-element to selectors.json

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -526,5 +526,12 @@
       "Pseudo-elements"
     ],
     "status": "standard"
+  },
+  "::cue": {
+    "syntax": "::cue | ::cue( <selector> )",
+    "groups": [
+      "Pseudo-elements"
+    ],
+    "status": "standard"
   }
 }


### PR DESCRIPTION
Adds the ::cue selector to the selectors.json store. This
pseudo-element has an optional parameter list which can contain a
selector to match against. Part of WebVTT.