### PR TITLE
here is my docs copyedit

### DIFF
--- a/css/at-rules.md
+++ b/css/at-rules.md
@@ -26,7 +26,7 @@ The 3 properties seen above are all required:
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
 
 There are 2 more properties that are optional:
-* `interfaces` (array of strings): These are the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) interfaces that belong the the at-rule.
+* `interfaces` (array of strings): These are the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) interfaces that belong to the at-rule.
 * `descriptors` (object): see below
 
 ## Structure for at-rules with descriptors

--- a/css/at-rules.md
+++ b/css/at-rules.md
@@ -3,7 +3,7 @@
 [data](https://github.com/mdn/data/blob/master/css/at-rules.json) |
 [schema](https://github.com/mdn/data/blob/master/css/at-rules.schema.json)
 
-An [at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule) is a CSS statement beginning with an at sign (@) and instructs CSS how to behave. There are several available identifiers for what CSS should do in certain situations. 
+An [at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule) is a CSS statement beginning with an at sign (@) that instructs CSS how to behave. There are several available identifiers defining what CSS should do in certain situations.
 
 ## Structure for simple at-rules
 
@@ -19,18 +19,20 @@ A simple at-rule object might look like this:
 },
 ```
 
-The 3 properties `syntax`, `groups` and `status` are required.
-* `syntax` (string): This is the formal syntax of the at-rule and is usually given in the specification.
-* `groups` (array of strings): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well.
+The 3 properties seen above are all required:
+
+* `syntax` (string): This is the formal syntax of the at-rule and is usually found in the specification.
+* `groups` (array of strings): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the at-rule is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
 
 There are 2 more properties that are optional:
-* `interfaces` (array of strings): These are the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) interfaces that belong the the at-rule. 
+* `interfaces` (array of strings): These are the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) interfaces that belong the the at-rule.
 * `descriptors` (object): see below
 
 ## Structure for at-rules with descriptors
 
-An at-rule with a `descriptors` object is `@font-face`, for example.
+The `descriptors` object (when included) contains one or more objects that describe the different descriptors available on the at-rule. Look at `@font-face`, for example:
+
 ```json
 "@font-face": {
   "syntax": "...",
@@ -59,16 +61,17 @@ An at-rule with a `descriptors` object is `@font-face`, for example.
   "status": "standard"
 }
 ```
-The `descriptors` object consists of 7 required properties:
+
+Each `descriptors` object consists of 7 required properties:
 * `syntax` (string): The syntax / possible values of the descriptor.
-* `media` (string): The media groups like "all, visual" (multiple are comma separated).
-* `percentages` (string or array of strings): 
-  * If an array, the elements are other descriptors this descriptor is taking the percentages from (array elements must be in descriptors list).
-  * If a string, it indicates the percentage value of the descriptor.
+* `media` (string): The media groups the descriptor applies to, e.g. "all, visual" (multiple values are comma-separated).
+* `percentages` (string or array of strings):
+  * If it is an array, the elements are the other descriptors this descriptor is taking the percentages from (array elements must be in a descriptors list).
+  * If it is a string, it indicates the percentage value of the descriptor.
 * `initial` (string or array of strings):
-  * If an array, the elements are other descriptors this descriptor is taking the initial values from (array elements must be in descriptors list).
-  * If a string, it indicates the initial value of the descriptor.
+  * If it is an array, the elements are the other descriptors this descriptor is taking the initial values from (array elements must be in a descriptors list).
+  * If it is a string, it indicates the initial value of the descriptor.
 * `computed` (string or array of strings):
-  * If an array, the elements are other descriptors this descriptor is computed from (array elements must be in descriptors list).
-  * If a string, it indicates the computed value of the descriptor.
+  * If it is an array, the elements are the other descriptors this descriptor is computed from (array elements must be in a descriptors list).
+  * If it is a string, it indicates the computed value of the descriptor.
 * `order` (enum string): Either `orderOfAppearance` or `uniqueOrder`.

--- a/css/properties.md
+++ b/css/properties.md
@@ -3,7 +3,7 @@
 [data](https://github.com/mdn/data/blob/master/css/properties.json) |
 [schema](https://github.com/mdn/data/blob/master/css/properties.schema.json)
 
-In its core, CSS consists of [properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference#Keyword_index).
+At its core, CSS consists of [properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference#Keyword_index).
 
 ## Structure for long-hand properties
 A long-hand property might look like this:
@@ -33,31 +33,31 @@ A long-hand property might look like this:
 ## Properties of a `Property` object
 
 There are 11 required properties in this object:
-* `syntax` (string): This is the formal syntax of the property and is usually given in the specification. It might contain references to [syntax data](https://github.com/mdn/data/blob/master/css/syntaxes.md).
+* `syntax` (string): This is the formal syntax of the property and is usually found in the specification. It might contain references to [syntax data](https://github.com/mdn/data/blob/master/css/syntaxes.md).
 For more information see also
 [Value definition syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax)
 on MDN and the [CSS Values and Units](https://www.w3.org/TR/css3-values/#value-defs) specification.
-* `media` (string): The media groups like "all, visual" (multiple are comma separated).
+* `media` (string): The media groups this property applies to, e.g. "all, visual" (multiple values are comma-separated).
 * `inherited` (boolean): Whether or not the property is inherited. See [inheritance](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance) for details.
-* `animationType`(enum or array of property names):
-  * If an enum (for long-hand properties), this is the animation type of the property.
-  * If an array (for short-hand properties), these are the properties the animation type taken from.
-* `percentages`(enum or array of property names):
-  * If an enum (for long-hand properties), this is what the percentage of the property refers to.
-  * If an array (for short-hand properties), these are the properties the percentages refer to.
-* `groups` (array of unique strings with at least 1 entry): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well.
-* `initial`(string or array of property names):
-  * If a string (for long-hand properties), this is the initial value of the property.
-  * If an array (for short-hand properties), these are the properties the initial value is taken from.
-* `appliesto`(enum): To which elements the property applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L153)
-* `computed`(enum or array of property names):
-  * If an enum (for long-hand properties), this is the computed value of the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L87).
-  * If an array (for short-hand properties), these are the properties the value computed from.
-* `order`(enum): The canonical order. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L234).
+* `animationType` (enum or array of property names):
+  * If it is an enum (appropriate for long-hand properties), this is the animation type of the property.
+  * If it is an array (appropriate for short-hand properties), these are the properties the animation type is taken from.
+* `percentages` (enum or array of property names):
+  * If it is an enum (appropriate for long-hand properties), this is what the percentage of the property refers to.
+  * If it is an array (appropriate for short-hand properties), these are the properties the percentages refer to.
+* `groups` (array of unique strings with at least 1 entry): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the property is defined in.
+* `initial` (string or array of property names):
+  * If it is a string (appropriate for long-hand properties), this is the initial value of the property.
+  * If it is an array (appropriate for short-hand properties), these are the properties the initial value is taken from.
+* `appliesto` (enum): To which elements the property can be applied to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L153)
+* `computed` (enum or array of property names):
+  * If it is an enum (appropriate for long-hand properties), this is the computed value of the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L87).
+  * If it is an array (appropriate for short-hand properties), these are the properties the value is computed from.
+* `order` (enum): The canonical order. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L234).
 * `status` (enum): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
 
 There are 2 more properties that are optional:
-* `stacking` (boolean): Whether or not the property is creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) for details.
+* `stacking` (boolean): Whether or not the property creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) for details.
 * `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L222)
 
 ## Structure for short-hand properties

--- a/css/properties.md
+++ b/css/properties.md
@@ -30,35 +30,7 @@ A long-hand property might look like this:
   "status": "standard"
 },
 ```
-## Properties of a `Property` object
 
-There are 11 required properties in this object:
-* `syntax` (string): This is the formal syntax of the property and is usually found in the specification. It might contain references to [syntax data](https://github.com/mdn/data/blob/master/css/syntaxes.md).
-For more information see also
-[Value definition syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax)
-on MDN and the [CSS Values and Units](https://www.w3.org/TR/css3-values/#value-defs) specification.
-* `media` (string): The media groups this property applies to, e.g. "all, visual" (multiple values are comma-separated).
-* `inherited` (boolean): Whether or not the property is inherited. See [inheritance](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance) for details.
-* `animationType` (enum or array of property names):
-  * If it is an enum (appropriate for long-hand properties), this is the animation type of the property.
-  * If it is an array (appropriate for short-hand properties), these are the properties the animation type is taken from.
-* `percentages` (enum or array of property names):
-  * If it is an enum (appropriate for long-hand properties), this is what the percentage of the property refers to.
-  * If it is an array (appropriate for short-hand properties), these are the properties the percentages refer to.
-* `groups` (array of unique strings with at least 1 entry): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the property is defined in.
-* `initial` (string or array of property names):
-  * If it is a string (appropriate for long-hand properties), this is the initial value of the property.
-  * If it is an array (appropriate for short-hand properties), these are the properties the initial value is taken from.
-* `appliesto` (enum): To which elements the property can be applied to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L153)
-* `computed` (enum or array of property names):
-  * If it is an enum (appropriate for long-hand properties), this is the computed value of the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L87).
-  * If it is an array (appropriate for short-hand properties), these are the properties the value is computed from.
-* `order` (enum): The canonical order. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L234).
-* `status` (enum): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
-
-There are 2 more properties that are optional:
-* `stacking` (boolean): Whether or not the property creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) for details.
-* `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L222)
 
 ## Structure for short-hand properties
 A short-hand property might look like this:
@@ -114,3 +86,33 @@ A short-hand property might look like this:
   "status": "standard"
 },
 ```
+
+## Properties of a `Property` object
+
+There are 11 required properties in this object:
+* `syntax` (string): This is the formal syntax of the property and is usually found in the specification. It might contain references to [syntax data](https://github.com/mdn/data/blob/master/css/syntaxes.md).
+For more information see also
+[Value definition syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax)
+on MDN and the [CSS Values and Units](https://www.w3.org/TR/css3-values/#value-defs) specification.
+* `media` (string): The media groups this property applies to, e.g. "all, visual" (multiple values are comma-separated).
+* `inherited` (boolean): Whether or not the property is inherited. See [inheritance](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance) for details.
+* `animationType` (enum or array of property names):
+  * If it is an enum (appropriate for long-hand properties), this is the animation type of the property.
+  * If it is an array (appropriate for short-hand properties), these are the properties the animation type is taken from.
+* `percentages` (enum or array of property names):
+  * If it is an enum (appropriate for long-hand properties), this defines what the percentage actually refers to when a percentage is set as a value on the property ("no" means that the property can't accept a percentage as a value).
+  * If it is an array (appropriate for short-hand properties), these are the long-hand properties making up part of the short-hand value that percentages can be set as values for.
+* `groups` (array of unique strings with at least 1 entry): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the property is defined in.
+* `initial` (string or array of property names):
+  * If it is a string (appropriate for long-hand properties), this is the initial value of the property.
+  * If it is an array (appropriate for short-hand properties), these are the properties the initial value is taken from.
+* `appliesto` (enum): To which elements the property can be applied to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L153)
+* `computed` (enum or array of property names):
+  * If it is an enum (appropriate for long-hand properties), this is the computed value of the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L87).
+  * If it is an array (appropriate for short-hand properties), these are the properties the value is computed from.
+* `order` (enum): The [canonical order](https://developer.mozilla.org/en-US/docs/Glossary/Canonical_order) for the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L235).
+* `status` (enum): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
+
+There are 2 more properties that are optional:
+* `stacking` (boolean): Whether or not the property creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) for details.
+* `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L153).

--- a/css/readme.md
+++ b/css/readme.md
@@ -1,12 +1,12 @@
 # MDN CSS data
 
-This folder contains data about [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS).
+This folder contains data about the different features of the [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) language.
 
 ## Different types of CSS data
 
 The CSS data is split into these parts:
 
-* **at-rules**: 
+* **at-rules**:
 [data](https://github.com/mdn/data/blob/master/css/at-rules.json) |
 [schema](https://github.com/mdn/data/blob/master/css/at-rules.schema.json) |
 [docs](https://github.com/mdn/data/blob/master/css/at-rules.md)
@@ -27,6 +27,6 @@ The CSS data is split into these parts:
 [schema](https://github.com/mdn/data/blob/master/css/types.schema.json) |
 [docs](https://github.com/mdn/data/blob/master/css/types.md)
 * **units**:
-[data](https://github.com/mdn/data/blob/master/css/units.json) | 
+[data](https://github.com/mdn/data/blob/master/css/units.json) |
 [schema](https://github.com/mdn/data/blob/master/css/units.schema.json) |
 [docs](https://github.com/mdn/data/blob/master/css/units,md)

--- a/css/selectors.md
+++ b/css/selectors.md
@@ -3,7 +3,7 @@
 [data](https://github.com/mdn/data/blob/master/css/selectors.json) |
 [schema](https://github.com/mdn/data/blob/master/css/selectors.schema.json)
 
-[CSS Selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) define to which elements a set of CSS rules apply.
+[CSS Selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) define which elements CSS rulesets will be applied to.
 
 ## Structure for selectors
 
@@ -19,7 +19,7 @@ A selector object looks like this:
 }
 ```
 
-The 3 properties `syntax`, `groups` and `status` are required.
-* `syntax` (string): The syntax of the selector (e.g. `::after` with two colons indicating a pseudo-class or `A ~ B` indicating the combinator syntax).
-* `groups` (array of strings): CSS is organized in modules like "CSS Units" or "CSS Lengths". MDN organizes features in these groups as well.
+The three properties shown above are all required:
+* `syntax` (string): The syntax of the selector (e.g. `::after` with two colons indicating a [pseudo-element](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Pseudo-classes_and_pseudo-elements#Pseudo-elements), `:hover` with one colon indicating a [pseudo-class](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Pseudo-classes_and_pseudo-elements#Pseudo-classes), or `A ~ B` indicating a [combinator](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Combinators_and_multiple_selectors#Combinators)).
+* `groups` (array of strings): CSS is organized in modules like "CSS Units" or "CSS Lengths". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the selector is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.

--- a/css/types.md
+++ b/css/types.md
@@ -7,10 +7,10 @@
 
 ## Structure for types
 
-A type object looks like the following example. The angle brackets are required. _(update if #81 gets merged)_
+A type object looks like the following example.
 
 ```json
-"<length>": {
+"length": {
   "groups": [
     "CSS Types"
   ],

--- a/css/types.md
+++ b/css/types.md
@@ -7,7 +7,7 @@
 
 ## Structure for types
 
-A type object looks like the following. The angle brackets are required. _(update if #81 gets merged)_
+A type object looks like the following example. The angle brackets are required. _(update if #81 gets merged)_
 
 ```json
 "<length>": {
@@ -18,6 +18,6 @@ A type object looks like the following. The angle brackets are required. _(updat
 },
 ```
 
-The 2 properties `groups` and `status` are required.
-* `groups` (array of strings): CSS is organized in modules like "CSS Types" or "CSS Color". MDN organizes features in these groups as well.
+The 2 properties are both required.
+* `groups` (array of strings): CSS is organized in modules like "CSS Types" or "CSS Color". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the type is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.

--- a/css/units.md
+++ b/css/units.md
@@ -3,7 +3,7 @@
 [data](https://github.com/mdn/data/blob/master/css/units.json) |
 [schema](https://github.com/mdn/data/blob/master/css/units.schema.json)
 
-Units are CSS units like `em` or `px`. Most of them are defined in the 
+Units are CSS units like `em` or `px`. Most of them are defined in the
 [CSS Values and Units specification](https://drafts.csswg.org/css-values/).
 
 ## Structure for units
@@ -20,6 +20,6 @@ A unit object looks like this:
 }
 ```
 
-The 2 properties `groups` and `status` are required.
-* `groups` (array of strings): CSS is organized in modules like "CSS Units" or "CSS Lengths". MDN organizes features in these groups as well.
+The 2 properties are both required.
+* `groups` (array of strings): CSS is organized in modules like "CSS Units" or "CSS Lengths". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the unit is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.


### PR DESCRIPTION
I had a few comments too:

## properties.md

* If it is an enum (appropriate for long-hand properties), this is what the percentage of the property refers to.
* If it is an array (appropriate for short-hand properties), these are the properties the percentages refer to.

-- I find these definitions a bit confusing. Percentages are percentages. The value in the example above is "no" - how does a percentage refer to "no"? Could we try to rephrase this to make it a bit less confusing, masybe show some other examples to give you more of an idea?

* `order` (enum): The canonical order. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L234).

-- It's not very obvious what this is, from this definition; can you expand this a bit? Also, is this the right link? The linked file doesn't seem to contain a list of enums for order.

* `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/syntaxes.schema.json#L222)

-- again, is this the correct link?

-- GENERAL COMMENT - the property descriptions section is in between the sample short-hand and long-hand structures, which is a bit odd, as they apply to both. It almost looks like they only apply to the long-hand structure. Why don't you put both samples first, and then property descriptions afterwards?

## syntaxes.md

Looks somewhat unfinished, with a placeholder. I'm assuming you are aware of this, but mentioning just in case. Also, it contains exactly the same intro paragraph as types.md:

[CSS basic data types](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Types) define the kinds of values (keywords and units) accepted by CSS properties and functions.