### PR TITLE
Fix `symbol` syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -549,7 +549,7 @@
     "syntax": "step-start | step-end | steps(<integer>[, [ start | end ] ]?)"
   },
   "symbol": {
-    "syntax": "<string> | <image> | <ident>"
+    "syntax": "<string> | <image> | <custom-ident>"
   },
   "target": {
     "syntax": "<target-counter()> | <target-counters()> | <target-text()>"


### PR DESCRIPTION
This is used in the `symbols` descriptor, part of the `@counter-style` at-rule.