### PR TITLE
Add `filter-function` data type

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -17,6 +17,7 @@
       "CSS Counter Styles",
       "CSS Device Adaptation",
       "CSS Display",
+      "CSS Filter Effects",
       "CSS Flexible Box Layout",
       "CSS Fonts",
       "CSS Frequencies",

--- a/css/definitions.json
+++ b/css/definitions.json
@@ -17,7 +17,6 @@
       "CSS Counter Styles",
       "CSS Device Adaptation",
       "CSS Display",
-      "CSS Filter Effects",
       "CSS Flexible Box Layout",
       "CSS Fonts",
       "CSS Frequencies",

--- a/css/types.json
+++ b/css/types.json
@@ -41,6 +41,12 @@
     ],
     "status": "standard"
   },
+  "filter-function": {
+    "groups": [
+      "CSS Filter Effects"
+    ],
+    "status": "standard"
+  },
   "flex": {
     "groups": [
       "CSS Grid Layout",

--- a/css/types.json
+++ b/css/types.json
@@ -43,7 +43,7 @@
   },
   "filter-function": {
     "groups": [
-      "CSS Filter Effects"
+      "Filter Effects"
     ],
     "status": "standard"
   },


### PR DESCRIPTION
This data type is used in the `filter` and `backdrop-filter` properties. https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function

cf. bug 1312712: https://bugzilla.mozilla.org/show_bug.cgi?id=1312712