### PR TITLE
Change `ime-mode` status to "obsolete"

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3978,7 +3978,7 @@
     "appliesto": "textFields",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "standard"
+    "status": "obsolete"
   },
   "initial-letter": {
     "syntax": "normal | [ <number> <integer>? ]",


### PR DESCRIPTION
Per the spec, this property is "officially obsoleted." cf. https://drafts.csswg.org/css-ui-3/#input-method-editor