### PR TITLE
Fix computed value for border-{block,inline}-{start,end} shorthands

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1330,7 +1330,7 @@
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "border-block-end-color"
     ],
     "order": "uniqueOrder",
     "status": "standard"
@@ -1398,7 +1398,7 @@
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "border-block-start-color"
     ],
     "order": "uniqueOrder",
     "status": "standard"
@@ -1763,7 +1763,7 @@
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "border-inline-end-color"
     ],
     "order": "uniqueOrder",
     "status": "standard"
@@ -1831,7 +1831,7 @@
     "computed": [
       "border-width",
       "border-style",
-      "color"
+      "border-inline-start-color"
     ],
     "order": "uniqueOrder",
     "status": "standard"


### PR DESCRIPTION
Fix issue #101 

The computed value is the one from border-{block,inline}-{start,end}-color.
