### PR TITLE
Add inheritance file (from {{InterfaceData}}) and its schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ There's a top-level directory for each broad area covered: for example, "api",
 "css", "svg". Inside each of these directories is one or more
 JSON files containing the data.
 
+### api
+Contains information about inheritance hierarchy, and about which interfaces implement which mixins.
 
 ### css
  Contains data about:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ There's a top-level directory for each broad area covered: for example, "api",
 JSON files containing the data.
 
 ### api
-Contains information about inheritance hierarchy, and about which interfaces implement which mixins.
+Contains data about Web APIs:
+* API inheritance (interface inheritance and mixin implementations)
 
 ### css
  Contains data about:

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  inheritance: require('./inheritance'),
+}

--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -29,13 +29,13 @@
     "implements": []
   },
   "CSSStyleDeclaration": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "Selection": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -60,7 +60,7 @@
     "implements": []
   },
   "BrowserElement": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "BrowserElementCommon",
       "BrowserElementPrivileged"
@@ -157,7 +157,7 @@
     "implements": []
   },
   "Exception": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "ExceptionMembers"
     ]
@@ -185,7 +185,7 @@
     "implements": []
   },
   "PseudoElement": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "GeometryUtils"
     ]
@@ -195,13 +195,13 @@
     "implements": []
   },
   "MutationObserver": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "NodeList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -226,7 +226,7 @@
     "implements": []
   },
   "SVGPathSegList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -244,7 +244,7 @@
     ]
   },
   "Performance": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -338,7 +338,7 @@
     "implements": []
   },
   "SVGPoint": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -348,7 +348,7 @@
     "implements": []
   },
   "Window": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface",
       "GlobalEventHandlers",
@@ -458,7 +458,7 @@
     "implements": []
   },
   "InstallTrigger": {
-    "inherits": "",
+    "inherits": null,
     "implements": []
   },
   "MutationEvent": {
@@ -484,7 +484,7 @@
     "implements": []
   },
   "SVGAnimatedInteger": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -504,13 +504,13 @@
     "implements": []
   },
   "Crypto": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "Response": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "Body"
     ]
@@ -540,7 +540,7 @@
     "implements": []
   },
   "DOMStringMap": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -574,7 +574,7 @@
     "implements": []
   },
   "NodeIterator": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -602,7 +602,7 @@
     ]
   },
   "FileList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -621,7 +621,7 @@
     ]
   },
   "SVGAnimatedEnumeration": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -704,7 +704,7 @@
     "implements": []
   },
   "WorkerNavigator": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "NavigatorID",
       "NavigatorLanguage",
@@ -754,7 +754,7 @@
     "implements": []
   },
   "SVGPointList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -790,13 +790,13 @@
     "implements": []
   },
   "Plugin": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "SVGStringList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -810,7 +810,7 @@
     "implements": []
   },
   "History": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -832,7 +832,7 @@
     "implements": []
   },
   "Range": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -872,7 +872,7 @@
     "implements": []
   },
   "SVGLengthList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -912,7 +912,7 @@
     "implements": []
   },
   "XPathEvaluator": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -954,7 +954,7 @@
     ]
   },
   "ValidityState": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -982,13 +982,13 @@
     "implements": []
   },
   "StyleSheet": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "URL": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "URLUtils",
       "URLUtilsSearchParams"
@@ -1051,7 +1051,7 @@
     "implements": []
   },
   "NamedNodeMap": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1164,7 +1164,7 @@
     "implements": []
   },
   "SVGPreserveAspectRatio": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1216,7 +1216,7 @@
     "implements": []
   },
   "BoxObject": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1232,7 +1232,7 @@
     ]
   },
   "PaintRequestList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1278,7 +1278,7 @@
     "implements": []
   },
   "SVGAnimatedString": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1296,7 +1296,7 @@
     "implements": []
   },
   "MutationRecord": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1336,7 +1336,7 @@
     "implements": []
   },
   "HTMLCollection": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1362,7 +1362,7 @@
     "implements": []
   },
   "Navigator": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface",
       "NavigatorID",
@@ -1386,7 +1386,7 @@
     "implements": []
   },
   "SVGAnimatedPreserveAspectRatio": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1415,7 +1415,7 @@
     "implements": []
   },
   "SVGTransformList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1473,7 +1473,7 @@
     ]
   },
   "Event": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1583,7 +1583,7 @@
     "implements": []
   },
   "TreeColumns": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1649,7 +1649,7 @@
     "implements": []
   },
   "WorkerLocation": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "URLUtilsReadOnly"
     ]
@@ -1681,7 +1681,7 @@
     "implements": []
   },
   "TouchList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1699,7 +1699,7 @@
     "implements": []
   },
   "DOMParser": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1739,7 +1739,7 @@
     "implements": []
   },
   "DOMException": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "ExceptionMembers"
     ]
@@ -1782,7 +1782,7 @@
     "implements": []
   },
   "Location": {
-    "inherits": "",
+    "inherits": null,
     "implements": []
   },
   "FontFaceSet": {
@@ -1794,7 +1794,7 @@
     "implements": []
   },
   "Touch": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1912,7 +1912,7 @@
     "implements": []
   },
   "PluginArray": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1928,7 +1928,7 @@
     "implements": []
   },
   "SVGNumberList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1944,7 +1944,7 @@
     ]
   },
   "CaretPosition": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1954,13 +1954,13 @@
     "implements": []
   },
   "Request": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "Body"
     ]
   },
   "SVGAnimatedNumber": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -1972,13 +1972,13 @@
     ]
   },
   "TreeWalker": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "BarProp": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2073,7 +2073,7 @@
     "implements": []
   },
   "SVGAnimatedNumberList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2083,7 +2083,7 @@
     "implements": []
   },
   "PaintRequest": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2127,13 +2127,13 @@
     "implements": []
   },
   "UndoManager": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
   "XMLSerializer": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2153,7 +2153,7 @@
     "implements": []
   },
   "DOMImplementation": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2177,7 +2177,7 @@
     "implements": []
   },
   "Rect": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2287,7 +2287,7 @@
     ]
   },
   "MimeTypeArray": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2300,7 +2300,7 @@
     ]
   },
   "FormData": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2320,7 +2320,7 @@
     "implements": []
   },
   "DOMTokenList": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -2376,7 +2376,7 @@
     "implements": []
   },
   "SVGRect": {
-    "inherits": "",
+    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]

--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -1,0 +1,2509 @@
+{
+  "SVGSymbolElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGTests"
+    ]
+  },
+  "TVChannel": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGPolygonElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": [
+      "SVGAnimatedPoints"
+    ]
+  },
+  "HTMLDataElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MozCdmaIccInfo": {
+    "inherits": "MozIccInfo",
+    "implements": []
+  },
+  "TreeBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "CSSStyleDeclaration": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Selection": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XULElement": {
+    "inherits": "Element",
+    "implements": [
+      "GlobalEventHandlers",
+      "TouchEventHandlers",
+      "MozFrameLoaderOwner",
+      "OnErrorEventHandlerForNodes"
+    ]
+  },
+  "XMLHttpRequestUpload": {
+    "inherits": "XMLHttpRequestEventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "WindowRoot": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "BrowserElement": {
+    "inherits": "",
+    "implements": [
+      "BrowserElementCommon",
+      "BrowserElementPrivileged"
+    ]
+  },
+  "IDBTransaction": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TVTuner": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ScrollViewChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPathSegCurvetoCubicSmoothAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "CameraControl": {
+    "inherits": "MediaStream",
+    "implements": []
+  },
+  "SVGFEMorphologyElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "FetchEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DeviceOrientationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLBRElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MozWifiConnectionInfoEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BroadcastChannel": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "IDBDatabase": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLFormControlsCollection": {
+    "inherits": "HTMLCollection",
+    "implements": []
+  },
+  "WebSocket": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGDescElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGCircleElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SVGCursorElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "DOMDownload": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGPathSegArcAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "ArchiveRequest": {
+    "inherits": "DOMRequest",
+    "implements": []
+  },
+  "SharedWorkerGlobalScope": {
+    "inherits": "WorkerGlobalScope",
+    "implements": []
+  },
+  "Exception": {
+    "inherits": "",
+    "implements": [
+      "ExceptionMembers"
+    ]
+  },
+  "BluetoothAdapterEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLParagraphElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "AudioDestinationNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "ProcessingInstruction": {
+    "inherits": "CharacterData",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "BeforeUnloadEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PseudoElement": {
+    "inherits": "",
+    "implements": [
+      "GeometryUtils"
+    ]
+  },
+  "NetworkInformation": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MutationObserver": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "NodeList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "CloseEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLAreaElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "HTMLHyperlinkElementUtils",
+      "URLUtilsSearchParams"
+    ]
+  },
+  "HTMLLegendElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGMetadataElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGPathSegList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGForeignObjectElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGPatternElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGURIReference",
+      "SVGUnitTypes"
+    ]
+  },
+  "Performance": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLElement": {
+    "inherits": "Element",
+    "implements": [
+      "GlobalEventHandlers",
+      "TouchEventHandlers",
+      "OnErrorEventHandlerForNodes"
+    ]
+  },
+  "HTMLHeadElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MozIcc": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "UDPSocket": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DocumentType": {
+    "inherits": "Node",
+    "implements": [
+      "ChildNode",
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGStopElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "ImageDocument": {
+    "inherits": "HTMLDocument",
+    "implements": []
+  },
+  "SVGElement": {
+    "inherits": "Element",
+    "implements": [
+      "GlobalEventHandlers",
+      "TouchEventHandlers",
+      "OnErrorEventHandlerForNodes"
+    ]
+  },
+  "GamepadEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLTableElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "PerformanceMark": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "InstallEvent": {
+    "inherits": "ExtendableEvent",
+    "implements": []
+  },
+  "FocusEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "OscillatorNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "PluginCrashedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPathSegLinetoVerticalRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "DocumentFragment": {
+    "inherits": "Node",
+    "implements": [
+      "ParentNode",
+      "LegacyQueryInterface"
+    ]
+  },
+  "OfflineAudioCompletionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPoint": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLTitleElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "Window": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface",
+      "GlobalEventHandlers",
+      "WindowEventHandlers",
+      "GlobalCrypto",
+      "SpeechSynthesisGetter",
+      "WindowModal",
+      "TouchEventHandlers",
+      "OnErrorEventHandlerForWindow",
+      "ChromeWindow",
+      "WindowOrWorkerGlobalScope"
+    ]
+  },
+  "WindowClient": {
+    "inherits": "Client",
+    "implements": []
+  },
+  "ErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "AudioNode": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaDevices": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "CanvasCaptureMediaStream": {
+    "inherits": "MediaStream",
+    "implements": []
+  },
+  "DynamicsCompressorNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "SVGSVGElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGZoomAndPan"
+    ]
+  },
+  "File": {
+    "inherits": "Blob",
+    "implements": []
+  },
+  "SVGAnimationElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGTests"
+    ]
+  },
+  "BluetoothPairingEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "ShadowRoot": {
+    "inherits": "DocumentFragment",
+    "implements": []
+  },
+  "ExtendableEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGFEOffsetElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "DesktopNotification": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGGradientElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference",
+      "SVGUnitTypes"
+    ]
+  },
+  "HTMLMetaElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "Text": {
+    "inherits": "CharacterData",
+    "implements": [
+      "LegacyQueryInterface",
+      "GeometryUtils"
+    ]
+  },
+  "DOMApplication": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "InstallTrigger": {
+    "inherits": "",
+    "implements": []
+  },
+  "MutationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLLabelElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGGeometryElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGPathElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": [
+      "SVGAnimatedPathData"
+    ]
+  },
+  "HTMLTemplateElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGAnimatedInteger": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGFEDisplacementMapElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGPathSegMovetoAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "XULCommandEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "Crypto": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Response": {
+    "inherits": "",
+    "implements": [
+      "Body"
+    ]
+  },
+  "SVGZoomEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "SVGLinearGradientElement": {
+    "inherits": "SVGGradientElement",
+    "implements": []
+  },
+  "WebGLContextEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "WebGL2RenderingContext": {
+    "inherits": "WebGLRenderingContext",
+    "implements": []
+  },
+  "SVGFEDistantLightElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "MouseScrollEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "DOMStringMap": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimateMotionElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "ChannelSplitterNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "ListBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "MozGsmIccInfo": {
+    "inherits": "MozIccInfo",
+    "implements": []
+  },
+  "TrackEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGStyleElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "PresentationDeviceInfoManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "NodeIterator": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAltGlyphElement": {
+    "inherits": "SVGTextPositioningElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGFEGaussianBlurElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "MozMobileConnection": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGFEConvolveMatrixElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "FileList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Document": {
+    "inherits": "Node",
+    "implements": [
+      "XPathEvaluator",
+      "GlobalEventHandlers",
+      "TouchEventHandlers",
+      "ParentNode",
+      "OnErrorEventHandlerForNodes",
+      "GeometryUtils",
+      "FontFaceSource",
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimatedEnumeration": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozStkCommandEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLFontElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SharedWorker": {
+    "inherits": "EventTarget",
+    "implements": [
+      "AbstractWorker"
+    ]
+  },
+  "RecordErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DelayNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "SVGPathSegCurvetoCubicAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "BluetoothGatt": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "CameraClosedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGMaskElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGUnitTypes"
+    ]
+  },
+  "ContactManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ProgressEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "ServiceWorker": {
+    "inherits": "EventTarget",
+    "implements": [
+      "AbstractWorker"
+    ]
+  },
+  "SVGPathSegLinetoHorizontalAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "CharacterData": {
+    "inherits": "Node",
+    "implements": [
+      "ChildNode",
+      "NonDocumentTypeChildNode"
+    ]
+  },
+  "KeyboardEvent": {
+    "inherits": "UIEvent",
+    "implements": [
+      "KeyEvent"
+    ]
+  },
+  "TelephonyCall": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "WorkerNavigator": {
+    "inherits": "",
+    "implements": [
+      "NavigatorID",
+      "NavigatorLanguage",
+      "NavigatorOnLine",
+      "NavigatorDataStore"
+    ]
+  },
+  "PopupBlockedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaElementAudioSourceNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "HTMLFrameSetElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "WindowEventHandlers"
+    ]
+  },
+  "BluetoothManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGFilterElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference",
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGClipPathElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGLineElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SpeechRecognitionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPointList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGFEDropShadowElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "HTMLQuoteElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGFESpotLightElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "ServiceWorkerContainer": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLContentElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLOutputElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "DataStoreChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Plugin": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGStringList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGRectElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "HTMLUListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "History": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SpeechRecognition": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "AnimationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TouchEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "IDBMutableFile": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "Range": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "CameraStateChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaStreamAudioDestinationNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "HTMLMenuItemElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MediaSource": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "PannerNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MozNFCPeerEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "GamepadButtonEvent": {
+    "inherits": "GamepadEvent",
+    "implements": []
+  },
+  "IDBRequest": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGLengthList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLDataListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLFieldSetElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "BluetoothDiscoveryHandle": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGDefsElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGTextElement": {
+    "inherits": "SVGTextPositioningElement",
+    "implements": []
+  },
+  "SVGScriptElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "InputEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "HTMLShadowElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "XPathEvaluator": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "AudioBufferSourceNode": {
+    "inherits": "AudioScheduledSourceNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MozNFCTagEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PageTransitionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PopStateEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Element": {
+    "inherits": "Node",
+    "implements": [
+      "ChildNode",
+      "NonDocumentTypeChildNode",
+      "ParentNode",
+      "Animatable",
+      "GeometryUtils",
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLInputElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "MozPhonetic"
+    ]
+  },
+  "ValidityState": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "DedicatedWorkerGlobalScope": {
+    "inherits": "WorkerGlobalScope",
+    "implements": []
+  },
+  "HTMLTimeElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "IDBFileHandle": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaKeyError": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "StyleSheet": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "URL": {
+    "inherits": "",
+    "implements": [
+      "URLUtils",
+      "URLUtilsSearchParams"
+    ]
+  },
+  "XMLHttpRequest": {
+    "inherits": "XMLHttpRequestEventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozMessageDeletedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticSmoothRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "RTCPeerConnectionIdentityErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCTrackEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCDTMFSender": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "RTCDTMFToneChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "AudioStreamTrack": {
+    "inherits": "MediaStreamTrack",
+    "implements": []
+  },
+  "HTMLSelectElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "DOMCursor": {
+    "inherits": "EventTarget",
+    "implements": [
+      "DOMRequestShared"
+    ]
+  },
+  "TextTrackList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozIccManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ScrollBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "NamedNodeMap": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGFEFloodElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "DOMDownloadManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DataContainerEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "IccCardLockError": {
+    "inherits": "DOMError",
+    "implements": []
+  },
+  "TelephonyCallGroup": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TVManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SelectionStateChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CSSValueList": {
+    "inherits": "CSSValue",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "VideoTrackList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SettingsLock": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "PerformanceMeasure": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "HTMLOptionsCollection": {
+    "inherits": "HTMLCollection",
+    "implements": []
+  },
+  "TVCurrentChannelChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "WorkerGlobalScope": {
+    "inherits": "EventTarget",
+    "implements": [
+      "GlobalCrypto",
+      "WindowOrWorkerGlobalScope"
+    ]
+  },
+  "MouseEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "SVGPathSegLinetoAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "HTMLAppletElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "MozFrameLoaderOwner",
+      "MozObjectLoadingContent"
+    ]
+  },
+  "LocalMediaStream": {
+    "inherits": "MediaStream",
+    "implements": []
+  },
+  "HTMLOptionElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "TVSource": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "StyleRuleChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLMeterElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "AudioChannelManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaRecorder": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGPreserveAspectRatio": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "TransitionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLBodyElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "WindowEventHandlers"
+    ]
+  },
+  "MozVoicemail": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLDivElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGPolylineElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": [
+      "SVGAnimatedPoints"
+    ]
+  },
+  "IDBVersionChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "ClipboardEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGFEMergeNodeElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "MessagePort": {
+    "inherits": "EventTarget",
+    "implements": [
+      "Transferable"
+    ]
+  },
+  "MozVoicemailEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BoxObject": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "BluetoothAttributeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CSSPrimitiveValue": {
+    "inherits": "CSSValue",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "PaintRequestList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MediaStreamAudioSourceNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "AudioScheduledSourceNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "ConstantSourceNode": {
+    "inherits": "AudioScheduledSourceNode",
+    "implements": []
+  },
+  "BaseAudioContext": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "AudioProcessingEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Attr": {
+    "inherits": "Node",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLObjectElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "MozFrameLoaderOwner",
+      "MozObjectLoadingContent"
+    ]
+  },
+  "SVGFEPointLightElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGAnimatedString": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGGElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "VRFieldOfView": {
+    "inherits": "VRFieldOfViewReadOnly",
+    "implements": []
+  },
+  "HTMLTableSectionElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MutationRecord": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MediaKeySession": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DataErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Worker": {
+    "inherits": "EventTarget",
+    "implements": [
+      "AbstractWorker"
+    ]
+  },
+  "HTMLTableColElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "IccChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLSpanElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MozActivity": {
+    "inherits": "DOMRequest",
+    "implements": []
+  },
+  "PerformanceResourceTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "HTMLCollection": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "USSDReceivedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLMapElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "ImageCapture": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "AudioTrackList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLSourceElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "Navigator": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface",
+      "NavigatorID",
+      "NavigatorLanguage",
+      "NavigatorOnLine",
+      "NavigatorContentUtils",
+      "NavigatorStorageUtils",
+      "NavigatorFeatures",
+      "NavigatorGeolocation",
+      "NavigatorBattery",
+      "NavigatorDataStore",
+      "NavigatorMobileId"
+    ]
+  },
+  "OfflineAudioContext": {
+    "inherits": "AudioContext",
+    "implements": []
+  },
+  "SVGPathSegCurvetoCubicSmoothRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGAnimatedPreserveAspectRatio": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozContactChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLMediaElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "DeviceStorage": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGImageElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "SVGURIReference"
+    ]
+  },
+  "UIEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGTransformList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozSpeakerManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozCellBroadcast": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGAnimateTransformElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "SVGFEBlendElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "CSSStyleSheet": {
+    "inherits": "StyleSheet",
+    "implements": []
+  },
+  "SVGPathSegArcRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "MozCellBroadcastEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "FMRadio": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLTableCellElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "ChromeWorker": {
+    "inherits": "Worker",
+    "implements": []
+  },
+  "Telephony": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGFECompositeElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "Event": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLButtonElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "ScrollAreaEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "IDBOpenDBRequest": {
+    "inherits": "IDBRequest",
+    "implements": []
+  },
+  "SVGComponentTransferFunctionElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGPathSegLinetoVerticalAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGTSpanElement": {
+    "inherits": "SVGTextPositioningElement",
+    "implements": []
+  },
+  "TVScanningStateChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BluetoothDevice": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLProgressElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MozOtaStatusEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLOptGroupElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "GamepadAxisMoveEvent": {
+    "inherits": "GamepadEvent",
+    "implements": []
+  },
+  "XULDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "Notification": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMPoint": {
+    "inherits": "DOMPointReadOnly",
+    "implements": []
+  },
+  "HMDVRDevice": {
+    "inherits": "VRDevice",
+    "implements": []
+  },
+  "SVGFEFuncRElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "MediaStreamTrackEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCDataChannel": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "AudioContext": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "RTCPeerConnectionIdentityEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "VTTCue": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ServiceWorkerGlobalScope": {
+    "inherits": "WorkerGlobalScope",
+    "implements": [
+      "GlobalFetch"
+    ]
+  },
+  "PopupBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "SpeechSynthesisUtterance": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TreeColumns": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "MozMobileMessageManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGFEFuncBElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "HTMLDListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "DOMRect": {
+    "inherits": "DOMRectReadOnly",
+    "implements": []
+  },
+  "HTMLHtmlElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGFEMergeElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "ContainerBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "CameraConfigurationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozAbortablePromise": {
+    "inherits": "_Promise",
+    "implements": []
+  },
+  "RTCPeerConnection": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGFESpecularLightingElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "XMLDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "DownloadEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "WorkerLocation": {
+    "inherits": "",
+    "implements": [
+      "URLUtilsReadOnly"
+    ]
+  },
+  "PositionSensorVRDevice": {
+    "inherits": "VRDevice",
+    "implements": []
+  },
+  "BeforeAfterKeyboardEvent": {
+    "inherits": "KeyboardEvent",
+    "implements": []
+  },
+  "SVGFEColorMatrixElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "CallEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BlobEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLUnknownElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "TouchList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMTransactionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGAnimateElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "DOMParser": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGEllipseElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SimpleGestureEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "NotifyPaintEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGTextPathElement": {
+    "inherits": "SVGTextContentElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "HTMLDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "CameraFacesDetectedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CustomEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TimeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DOMException": {
+    "inherits": "",
+    "implements": [
+      "ExceptionMembers"
+    ]
+  },
+  "IDBCursorWithValue": {
+    "inherits": "IDBCursor",
+    "implements": []
+  },
+  "SVGMPathElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "CommandEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozInterAppMessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLAudioElement": {
+    "inherits": "HTMLMediaElement",
+    "implements": []
+  },
+  "SVGViewElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGZoomAndPan"
+    ]
+  },
+  "SVGTextPositioningElement": {
+    "inherits": "SVGTextContentElement",
+    "implements": []
+  },
+  "SVGTextContentElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "Location": {
+    "inherits": "",
+    "implements": []
+  },
+  "FontFaceSet": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TVCurrentSourceChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Touch": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozSettingsEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BluetoothAdapter": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGPathSegMovetoRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "RTCDataChannelEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLModElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "BluetoothStatusChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SpeechSynthesisEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGTitleElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "DOMApplicationsManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SettingsManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MenuBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "Screen": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozClirModeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLEmbedElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "MozFrameLoaderOwner",
+      "MozObjectLoadingContent"
+    ]
+  },
+  "OfflineResourceList": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPathSegClosePath": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "ConvolverNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "BluetoothDiscoveryStateChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PropertyNodeList": {
+    "inherits": "NodeList",
+    "implements": []
+  },
+  "HTMLStyleElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "LinkStyle"
+    ]
+  },
+  "DataStore": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "CDATASection": {
+    "inherits": "Text",
+    "implements": []
+  },
+  "SourceBufferList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "StorageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozEmergencyCbModeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PluginArray": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGFETurbulenceElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "MozInterAppMessagePort": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SVGNumberList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozWifiStatusChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGFETileElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "CaretPosition": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPathSegCurvetoCubicRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "Request": {
+    "inherits": "",
+    "implements": [
+      "Body"
+    ]
+  },
+  "SVGAnimatedNumber": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGFEDiffuseLightingElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "TreeWalker": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "BarProp": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLLinkElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "LinkStyle"
+    ]
+  },
+  "SVGUseElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "HTMLCanvasElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGPathSegLinetoHorizontalRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "HTMLParamElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SourceBuffer": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HashChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PointerEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "FileReader": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "Comment": {
+    "inherits": "CharacterData",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MozMmsEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BatteryManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DOMMatrix": {
+    "inherits": "DOMMatrixReadOnly",
+    "implements": []
+  },
+  "SVGSwitchElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGFEImageElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes",
+      "SVGURIReference"
+    ]
+  },
+  "HTMLScriptElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLPictureElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "ServiceWorkerRegistration": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLVideoElement": {
+    "inherits": "HTMLMediaElement",
+    "implements": []
+  },
+  "IDBFileRequest": {
+    "inherits": "DOMRequest",
+    "implements": []
+  },
+  "SVGAnimatedNumberList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "RTCPeerConnectionIceEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PaintRequest": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLMenuElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "EngineeringMode": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "BluetoothDeviceEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DeviceLightEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "GainNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MozApplicationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGFEFuncAElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "StyleSheetApplicableStateChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TVEITBroadcastedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "UndoManager": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XMLSerializer": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPathSegCurvetoQuadraticSmoothAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "WaveShaperNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "VideoStreamTrack": {
+    "inherits": "MediaStreamTrack",
+    "implements": []
+  },
+  "DOMImplementation": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLTableCaptionElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGMarkerElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox"
+    ]
+  },
+  "MozWifiManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLPreElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "Rect": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DeviceStorageChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DOMMobileMessageError": {
+    "inherits": "DOMError",
+    "implements": []
+  },
+  "CSSFontFaceLoadEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLHeadingElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGRadialGradientElement": {
+    "inherits": "SVGGradientElement",
+    "implements": []
+  },
+  "DeviceProximityEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "EventSource": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "StereoPannerNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "AutocompleteErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLFrameElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozFrameLoaderOwner"
+    ]
+  },
+  "HTMLOListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "RadioNodeList": {
+    "inherits": "NodeList",
+    "implements": []
+  },
+  "StyleSheetChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TextTrack": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLBaseElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "AnalyserNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MediaStream": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLTableRowElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "UserProximityEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DragEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "HTMLHRElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "BiquadFilterNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "ScriptProcessorNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MimeTypeArray": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLIFrameElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozFrameLoaderOwner",
+      "BrowserElement"
+    ]
+  },
+  "FormData": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MediaKeyMessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozNFC": {
+    "inherits": "EventTarget",
+    "implements": [
+      "MozNFCManager"
+    ]
+  },
+  "HTMLLIElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "DOMTokenList": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XMLStylesheetProcessingInstruction": {
+    "inherits": "ProcessingInstruction",
+    "implements": []
+  },
+  "MozSettingsTransactionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGFEComponentTransferElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "MozSmsEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLDirectoryElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "MediaEncryptedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CFStateChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLTrackElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGPathSegLinetoRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "WheelEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "Node": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozWifiStationInfoEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGRect": {
+    "inherits": "",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMSettableTokenList": {
+    "inherits": "DOMTokenList",
+    "implements": []
+  },
+  "HTMLImageElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent"
+    ]
+  },
+  "DOMRequest": {
+    "inherits": "EventTarget",
+    "implements": [
+      "DOMRequestShared"
+    ]
+  },
+  "HTMLFormElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "SVGGraphicsElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGTests"
+    ]
+  },
+  "DeviceMotionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CompositionEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "SpeechRecognitionError": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CallGroupErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozInputMethod": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "UDPMessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaStreamEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HTMLTextAreaElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "XMLHttpRequestEventTarget": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "HTMLAnchorElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "HTMLHyperlinkElementUtils",
+      "URLUtilsSearchParams"
+    ]
+  },
+  "HTMLPropertiesCollection": {
+    "inherits": "HTMLCollection",
+    "implements": []
+  },
+  "SVGFEFuncGElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "ImageCaptureErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SVGSetElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "ChannelMergerNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "SyncEvent": {
+    "inherits": "ExtendableEvent",
+    "implements": []
+  },
+  "OffscreenCanvas": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "PromiseRejectionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CSSCounterStyleRule": {
+    "inherits": "CSSRule",
+    "implements": []
+  },
+  "PerformanceLongTaskTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "TaskAttributionTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "BeforeInstallPromptEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PerformanceNavigationTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "PerformancePaintTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  }
+}

--- a/api/inheritance.md
+++ b/api/inheritance.md
@@ -1,0 +1,25 @@
+# Types
+
+[data](https://github.com/mdn/data/blob/master/api/inheritance.json) |
+[schema](https://github.com/mdn/data/blob/master/css/inheritance.schema.json)
+
+The inheritance files defines, for each interface, the parent that they inherit properties and methods from, as well as the mixins that they implements.
+
+## Structure for inheritance data of a specific name
+
+The overall inheritance data is an object with one property per interface.
+Each interface entry looks like the following example (E.g. for the DocumentFragment interface).
+
+```json
+"DocumentFragment": {
+  "inherits": "Node",
+  "implements": [
+    "ParentNode",
+    "LegacyQueryInterface"
+  ]
+}
+```
+
+The 2 properties are both required.
+* `inherits` (a string): the name of the interface it inherits properties and methods from. If "", it means it doesn't inherit from any interface.
+* `implements` (array of strings): the list of mixins it implements the methods and properties. The array can be empty.

--- a/api/inheritance.md
+++ b/api/inheritance.md
@@ -1,9 +1,9 @@
-# Types
+# Inheritance
 
 [data](https://github.com/mdn/data/blob/master/api/inheritance.json) |
 [schema](https://github.com/mdn/data/blob/master/css/inheritance.schema.json)
 
-The inheritance files defines, for each interface, the parent that they inherit properties and methods from, as well as the mixins that they implements.
+Interfaces of Web APIs can inherit from other interfaces or implement [mixins](https://developer.mozilla.org/en-US/docs/Glossary/Mixin). For each interface, this data informs about the inherited (parent) interface and the implemented mixins.
 
 ## Structure for inheritance data of a specific name
 
@@ -21,5 +21,5 @@ Each interface entry looks like the following example (E.g. for the DocumentFrag
 ```
 
 The 2 properties are both required.
-* `inherits` (a string): the name of the interface it inherits properties and methods from. If "", it means it doesn't inherit from any interface.
-* `implements` (array of strings): the list of mixins it implements the methods and properties. The array can be empty.
+* `inherits` (a string or null): the name of the interface it inherits properties and methods from. If null, it means it doesn't inherit from any interface.
+* `implements` (array of strings): the list of mixins the interface implements. The array can be empty.

--- a/api/inheritance.schema.json
+++ b/api/inheritance.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "inherits": {
+        "type": "string"
+      },
+      "implements": {
+        "minItems": 0,
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "inherits",
+      "implements"
+    ]
+  }
+}

--- a/api/inheritance.schema.json
+++ b/api/inheritance.schema.json
@@ -5,7 +5,15 @@
     "additionalProperties": false,
     "properties": {
       "inherits": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "string",
+            "minLength": 1
+          }
+        ]
       },
       "implements": {
         "minItems": 0,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  api: require('./api'),
   css: require('./css'),
   l10n: require('./l10n'),
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Open Web data by the Mozilla Developer Network",
   "main": "index.js",
   "files": [
+    "api/*.json",
     "css/*.json",
     "l10n/*.json"
   ],

--- a/test/lint.js
+++ b/test/lint.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var Ajv = require('ajv');
 var ajv = new Ajv({ $data: true, allErrors: true });
-var dictPaths = ['css', 'l10n'];
+var dictPaths = ['api', 'css', 'l10n'];
 var hasErrors = false;
 
 ajv.addKeyword('property-reference', {
@@ -38,7 +38,7 @@ function jsonDiff(actual, expected) {
 function checkStyle(filename) {
   var actual = fs.readFileSync(filename, 'utf-8').trim();
   var expected = JSON.stringify(JSON.parse(actual), null, 2);
-  
+
   if (actual === expected) {
     console.log('  Style – OK');
   } else {


### PR DESCRIPTION
This PR imports the data from {{InterfaceData}} (that is the InterfaceData.json from mdn/kumascript/macros).

The format is a bit different, and the schema is defined (as well as a simple markdown file explaining the syntax in layman text).

Note that kumascript macros are still using InterfaceData.json, so it means that for the moment, until these macros are updated, we need to maintain both structure (temporary burden).