### PR TITLE
Move `fr` unit to "CSS Flexible Lengths"

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -18,6 +18,7 @@
       "CSS Device Adaptation",
       "CSS Display",
       "CSS Flexible Box Layout",
+      "CSS Flexible Lengths",
       "CSS Fonts",
       "CSS Fragmentation",
       "CSS Frequencies",

--- a/css/units.json
+++ b/css/units.json
@@ -58,7 +58,7 @@
   "fr": {
     "groups": [
       "CSS Units",
-      "CSS Lengths",
+      "CSS Flexible Lengths",
       "CSS Grid Layout"
     ],
     "status": "standard"


### PR DESCRIPTION
The link for `fr` on https://developer.mozilla.org/en-US/docs/Web/CSS/Reference points to the wrong page. This is because the `fr` unit doesn't belong with the other lengths, such as `em` or `px`. Rather, it is defined on the `<flex>` data type page.

We will also need to update https://github.com/mdn/kumascript/blob/master/macros/CSS_Ref.ejs.