### PR TITLE
Remove `marker-offset` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4385,21 +4385,6 @@
     ],
     "status": "standard"
   },
-  "marker-offset": {
-    "syntax": "<length> | auto",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "CSS Generated Content"
-    ],
-    "initial": "auto",
-    "appliesto": "elementsWithDisplayMarker",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
-    "status": "nonstandard"
-  },
   "mask": {
     "syntax": "<mask-layer>#",
     "media": "visual",


### PR DESCRIPTION
This property doesn't seem to be a part of any spec anymore. cf. https://developer.mozilla.org/en-US/docs/Web/CSS/marker-offset