### PR TITLE
Fix broken reference to units.md

### DIFF
--- a/css/readme.md
+++ b/css/readme.md
@@ -29,4 +29,4 @@ The CSS data is split into these parts:
 * **units**:
 [data](https://github.com/mdn/data/blob/master/css/units.json) |
 [schema](https://github.com/mdn/data/blob/master/css/units.schema.json) |
-[docs](https://github.com/mdn/data/blob/master/css/units,md)
+[docs](https://github.com/mdn/data/blob/master/css/units.md)


### PR DESCRIPTION
Right now, clicking the _docs_ link at https://github.com/mdn/data/tree/master/css#readme takes me to a broken link, because the URL has a typo. This commit fixes the typo by changing a comma `,` into a dot `.`.

This may also restore order to the galaxy, because I’ve just wanted to say that.