### PR TITLE
Fix AudioContext & OfflineAudioContext inheritance

### DIFF
--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -1378,7 +1378,7 @@
     ]
   },
   "OfflineAudioContext": {
-    "inherits": "AudioContext",
+    "inherits": "BaseAudioContext",
     "implements": []
   },
   "SVGPathSegCurvetoCubicSmoothRel": {
@@ -1557,7 +1557,7 @@
     "implements": []
   },
   "AudioContext": {
-    "inherits": "EventTarget",
+    "inherits": "BaseAudioContext",
     "implements": []
   },
   "RTCPeerConnectionIdentityEvent": {


### PR DESCRIPTION
[`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) and [`OfflineAudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/OfflineAudioContext) both inherit from [`BaseAudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext).

See also the [Web Audio API spec](https://www.w3.org/TR/webaudio/#idl-def-AudioContext).