### PR TITLE
Change background syntaxes according to W3C spec

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1231,7 +1231,7 @@
     "status": "standard"
   },
   "background-position": {
-    "syntax": "<position>#",
+    "syntax": "<bg-position>#",
     "media": "visual",
     "inherited": false,
     "animationType": "repeatableListOfSimpleListOfLpc",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -30,7 +30,10 @@
     "syntax": "none | <image>"
   },
   "bg-layer": {
-    "syntax": "<bg-image> || <position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box>{1,2}"
+    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box> || <box>"
+  },
+  "bg-position": {
+    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
   },
   "bg-size": {
     "syntax": "[ <length-percentage> | auto ]{1,2} | cover | contain"
@@ -198,7 +201,7 @@
     "syntax": "[ <filter-function> | <url> ]+"
   },
   "final-bg-layer": {
-    "syntax": "<bg-image> || <position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box> || <box> || <'background-color'>"
+    "syntax": "<'background-color'> || <bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box> || <box>"
   },
   "fit-content()": {
     "syntax": "fit-content( [ <length> | <percentage> ] )"
@@ -423,7 +426,7 @@
     "syntax": "polygon( <fill-rule>? , [ <length-percentage> <length-percentage> ]# )"
   },
   "position": {
-    "syntax": "[[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ]]"
+    "syntax": "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
   },
   "pseudo-page": {
     "syntax": ": [ left | right | first | blank ]"


### PR DESCRIPTION
- Changed `<bg-layer>` and `<final-bg-layer>` per [CSS Backgrounds and Borders Module Level 3](https://www.w3.org/TR/css-backgrounds-3/)
- Renamed `<position>` to `<bg-position>`
- Added `<position>` according to [CSS Values and Units Module Level 4](https://drafts.csswg.org/css-values/#position)

See #159 for details