### PR TITLE
Fix `box-sizing` group

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2508,7 +2508,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Box Model"
+      "CSS Basic User Interface"
     ],
     "initial": "content-box",
     "appliesto": "allElementsAcceptingWidthOrHeight",


### PR DESCRIPTION
This property belongs in CSS Basic User Interface. cf. https://drafts.csswg.org/css-ui-3/#box-sizing