### PR TITLE
Update align-items to match current spec

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -804,7 +804,7 @@
     "status": "standard"
   },
   "align-items": {
-    "syntax": "flex-start | flex-end | center | baseline | stretch",
+    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -23,6 +23,9 @@
   "auto-track-list": {
     "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
   },
+  "baseline-position": {
+    "syntax": "[ first | last ]? baseline"
+  },
   "basic-shape": {
     "syntax": "<inset()> | <circle()> | <ellipse()> | <polygon()>"
   },
@@ -404,6 +407,9 @@
   "opacity()": {
     "syntax": "opacity( [ <number-percentage> ] )"
   },
+  "overflow-position": {
+    "syntax": "unsafe | safe"
+  },
   "page-body": {
     "syntax": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
   },
@@ -487,6 +493,9 @@
   },
   "scaleZ()": {
     "syntax": "scaleZ( <number> )"
+  },
+  "self-position": {
+    "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
   },
   "shape-radius": {
     "syntax": "<length-percentage> | closest-side | farthest-side"


### PR DESCRIPTION
This change updates the `align-items` syntax to match the current definition
https://drafts.csswg.org/css-align-3/#align-items-property