### PR TITLE
Capitalize Hz, kHz and Q units

### DIFF
--- a/css/units.json
+++ b/css/units.json
@@ -70,7 +70,7 @@
     ],
     "status": "standard"
   },
-  "hz": {
+  "Hz": {
     "groups": [
       "CSS Units",
       "CSS Frequencies"
@@ -84,7 +84,7 @@
     ],
     "status": "standard"
   },
-  "khz": {
+  "kHz": {
     "groups": [
       "CSS Units",
       "CSS Frequencies"
@@ -126,7 +126,7 @@
     ],
     "status": "standard"
   },
-  "q": {
+  "Q": {
     "groups": [
       "CSS Units",
       "CSS Lengths"


### PR DESCRIPTION
For `Hz` and `kHz`, cf. https://drafts.csswg.org/css-values-3/#frequency.
For `Q`, cf. https://drafts.csswg.org/css-values-3/#Q.