### PR TITLE
updating syntax for align-content, justify-content, and place-content

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1428,7 +1428,7 @@
     "status": "nonstandard"
   },
   "align-content": {
-    "syntax": "flex-start | flex-end | center | space-between | space-around | space-evenly | stretch",
+    "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position> ? <content-position>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -1436,7 +1436,7 @@
     "groups": [
       "CSS Flexible Box Layout"
     ],
-    "initial": "stretch",
+    "initial": "normal",
     "appliesto": "multilineFlexContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -4653,7 +4653,7 @@
     "status": "standard"
   },
   "justify-content": {
-    "syntax": "flex-start | flex-end | center | space-between | space-around | space-evenly",
+    "syntax": "normal | <content-distribution> | <overflow-position> ? [ <content-position> | left | right ]",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -4661,7 +4661,7 @@
     "groups": [
       "CSS Flexible Box Layout"
     ],
-    "initial": "flex-start",
+    "initial": "normal",
     "appliesto": "flexContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -6119,6 +6119,21 @@
     "appliesto": "transformableElements",
     "computed": "forLengthAbsoluteValueOtherwisePercentage",
     "order": "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+    "status": "standard"
+  },
+  "place-content": {
+    "syntax": "<'align-content'> <'justify-content'>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "multilineFlexContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
     "status": "standard"
   },
   "pointer-events": {

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -104,8 +104,14 @@
   "contextual-alt-values": {
     "syntax": "[ contextual | no-contextual ]"
   },
+  "content-distribution": {
+    "syntax": "space-between | space-around | space-evenly | stretch"
+  },
   "content-list": {
     "syntax": "[ <string> | contents | <image> | <quote> | <target> | <leader()> ]+"
+  },
+  "content-position": {
+    "syntax": "center | start | end | flex-start | flex-end"
   },
   "content-replacement": {
     "syntax": "<image>"


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1430817.

There is one aspect that I'm not happy with as yet. The appliesto values for these properties should be 'multicol containers, flex containers, and grid containers' for justify-content and place-content, and 'block containers, multicol containers, flex containers, and grid containers' for align-content — how do I represent that in the properties JSON? 