### PR TITLE
Add some missing items to selectors.json.

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -192,7 +192,7 @@
     "status": "standard"
   },
   ":focus-visible": {
-    "syntax": ":focus",
+    "syntax": "focus-visible",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -208,7 +208,7 @@
     "status": "experimental"
   },
   ":host": {
-    "syntax": ":hover",
+    "syntax": ":host",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -216,7 +216,7 @@
     "status": "experimental"
   },
   ":host-context": {
-    "syntax": ":hover",
+    "syntax": ":host-context",
     "groups": [
       "Pseudo-classes",
       "Selectors"

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -191,8 +191,32 @@
     ],
     "status": "standard"
   },
+  ":focus-visible": {
+    "syntax": ":focus",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental"
+  },
   ":focus-within": {
     "syntax": ":focus-within",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental"
+  },
+  ":host": {
+    "syntax": ":hover",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental"
+  },
+  ":host-context": {
+    "syntax": ":hover",
     "groups": [
       "Pseudo-classes",
       "Selectors"

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -192,7 +192,7 @@
     "status": "standard"
   },
   ":focus-visible": {
-    "syntax": "focus-visible",
+    "syntax": ":focus-visible",
     "groups": [
       "Pseudo-classes",
       "Selectors"


### PR DESCRIPTION
Makes sure all the items listed in [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) have an entry in selectors.json.