### PR TITLE
Add `<outline-radius>` syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -416,6 +416,9 @@
   "overflow-position": {
     "syntax": "unsafe | safe"
   },
+  "outline-radius": {
+    "syntax": "<length> | <percentage>"
+  },
   "page-body": {
     "syntax": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
   },


### PR DESCRIPTION
Noticed that syntax for `<outline-radius>` was missing. Used in:

https://github.com/mdn/data/blob/af0369d9445c7e6f44f818d2034ccac16f328da9/css/properties.json#L910-L911
https://github.com/mdn/data/blob/af0369d9445c7e6f44f818d2034ccac16f328da9/css/properties.json#L945-L946