### PR TITLE
Update `text-align` syntax

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6794,7 +6794,7 @@
     "status": "standard"
   },
   "text-align": {
-    "syntax": "start | end | left | right | center | justify | match-parent",
+    "syntax": "start | end | left | right | center | justify | justify-all | match-parent",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
This adds the `justify-all` keyword, as per https://drafts.csswg.org/css-text-3/#valdef-text-align-justify-all.