### PR TITLE
Fix a syntax errors for @font-face

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -120,7 +120,7 @@
     "status": "nonstandard"
   },
   "@font-face": {
-    "syntax": "@font-face {\n  [ font-family: <family-name>; ] ||\n  [ src: [ <url> [ format(<string>#) ]? | <font-face-name> ]#; ] ||\n  [ unicode-range: <urange>#; ] ||\n  [ font-variant: <font-variant>; ] ||\n  [ font-feature-settings: normal | <feature-tag-value>#; ] ||\n  [ font-variation-settings: normal | [ <string> <number>] # ||\n [ font-stretch: <font-stretch>; ] ||\n  [ font-weight: <weight>; ] ||\n  [ font-style: <style>; ]\n}",
+    "syntax": "@font-face {\n  [ font-family: <family-name>; ] ||\n  [ src: <src>; ] ||\n  [ unicode-range: <unicode-range>; ] ||\n  [ font-variant: <font-variant>; ] ||\n  [ font-feature-settings: <font-feature-settings>; ] ||\n  [ font-variation-settings: <font-variation-settings>; ] ||\n  [ font-stretch: <font-stretch>; ] ||\n  [ font-weight: <font-weight>; ] ||\n  [ font-style: <font-style>; ]\n}",
     "interfaces": [
       "CSSFontFaceRule"
     ],
@@ -156,7 +156,7 @@
         "status": "standard"
       },
       "font-variation-settings": {
-        "syntax": "normal | [ <string> <number>] #",
+        "syntax": "normal | [ <string> <number> ]#",
         "media": "all",
         "initial": "normal",
         "percentages": "no",
@@ -201,7 +201,7 @@
         "status": "standard"
       },
       "src": {
-        "syntax": "[ <url> format(<string>#)? | local(<family-name>) ]#",
+        "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#",
         "media": "all",
         "initial": "n/a (required)",
         "percentages": "no",


### PR DESCRIPTION
I'm working on a new syntax parser and validator in CSSTree. Now it parses a complicated syntaxes and I found an error in `@font-face` syntaxes.

Btw, syntaxes in `css/at-rule.json` have several issues (see #222)