### PR TITLE
Fix <transform-function> syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -600,7 +600,7 @@
     "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( [ <length> | <percentage> ] )"
   },
   "transform-function": {
-    "syntax": "[ <matrix()> || <translate()> || <translateX()> || <translateY()> || <scale()> || <scaleX()> || <scaleY()> || <rotate()> || <skew()> || <skewX()> || <skewY()> || <matrix3d()> || <translate3d()> || <translateZ()> || <scale3d()> || <scaleZ()> || <rotate3d()> || <rotateX()> || <rotateY()> || <rotateZ()> || <perspective()> ]+"
+    "syntax": "<matrix()> | <translate()> | <translateX()> | <translateY()> | <scale()> | <scaleX()> | <scaleY()> | <rotate()> | <skew()> | <skewX()> | <skewY()> | <matrix3d()> | <translate3d()> | <translateZ()> | <scale3d()> | <scaleZ()> | <rotate3d()> | <rotateX()> | <rotateY()> | <rotateZ()> | <perspective()>"
   },
   "transform-list": {
     "syntax": "<transform-function>+"


### PR DESCRIPTION
Previously `<transform-function>` syntax describes one or more functions in any order repeated one or more times. However, according to spec it should be a regular enum. Repetition is defined in `<transform-list>`.
Although the old syntax is quite correct (can be used for a value matching), it is overwhelmed. This commit simplifies the syntax.
There is no `<transform-function>` syntax description in [CSS Transforms Module Level 1](https://www.w3.org/TR/css-transforms-1/#typedef-transform-function), but it can be generated by a description.