### PR TITLE
Set initial values for <'-ms-scrollbar-*-color'> properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -338,7 +338,7 @@
     "groups": [
       "Microsoft Extensions"
     ],
-    "initial": "dependsOnUserAgent",
+    "initial": "ButtonText",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -368,7 +368,7 @@
     "groups": [
       "Microsoft Extensions"
     ],
-    "initial": "dependsOnUserAgent",
+    "initial": "ThreeDDarkShadow",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -383,7 +383,7 @@
     "groups": [
       "Microsoft Extensions"
     ],
-    "initial": "dependsOnUserAgent",
+    "initial": "ThreeDFace",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -398,7 +398,7 @@
     "groups": [
       "Microsoft Extensions"
     ],
-    "initial": "dependsOnUserAgent",
+    "initial": "ThreeDHighlight",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -413,7 +413,7 @@
     "groups": [
       "Microsoft Extensions"
     ],
-    "initial": "dependsOnUserAgent",
+    "initial": "ThreeDDarkShadow",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
@@ -428,7 +428,7 @@
     "groups": [
       "Microsoft Extensions"
     ],
-    "initial": "dependsOnUserAgent",
+    "initial": "Scrollbar",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",


### PR DESCRIPTION
Used https://github.com/w3c/csswg-drafts/issues/1956 as a source of truth.
Unfortunately, there is no an initial value for `-ms-scrollbar-base-color` found.

//cc @jameshkramer