### PR TITLE
Simplify <'-moz-border-*-colors'> syntaxes

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -773,7 +773,7 @@
     "status": "nonstandard"
   },
   "-moz-border-bottom-colors": {
-    "syntax": "[ <color> ]* <color> | none",
+    "syntax": "<color>+ | none",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -788,7 +788,7 @@
     "status": "nonstandard"
   },
   "-moz-border-left-colors": {
-    "syntax": "[ <color> ]* <color> | none",
+    "syntax": "<color>+ | none",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -803,7 +803,7 @@
     "status": "nonstandard"
   },
   "-moz-border-right-colors": {
-    "syntax": "[ <color> ]* <color> | none",
+    "syntax": "<color>+ | none",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -818,7 +818,7 @@
     "status": "nonstandard"
   },
   "-moz-border-top-colors": {
-    "syntax": "[ <color> ]* <color> | none",
+    "syntax": "<color>+ | none",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
Replace `[ <color> ]* <color>` for `<color>+`