### PR TITLE
Update font-weight syntax for CSS Fonts 4

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4305,7 +4305,7 @@
     "status": "standard"
   },
   "font-weight": {
-    "syntax": "normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+    "syntax": "<font-weight-absolute> | bolder | lighter",
     "media": "visual",
     "inherited": true,
     "animationType": "fontWeight",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -228,7 +228,7 @@
     "syntax": "[ normal | small-caps ]"
   },
   "font-weight-absolute": {
-    "syntax": "[normal | bold | <number>]"
+    "syntax": "normal | bold | <number>"
   },
   "frames-timing-function": {
     "syntax": "frames(<integer>)"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -227,6 +227,9 @@
   "font-variant-css21": {
     "syntax": "[ normal | small-caps ]"
   },
+  "font-weight-absolute": {
+    "syntax": "[normal | bold | <number>]"
+  },
   "frames-timing-function": {
     "syntax": "frames(<integer>)"
   },


### PR DESCRIPTION
This updates the syntax of `font-weight` for the CSS Fonts Level 4 spec: https://drafts.csswg.org/css-fonts-4/#font-weight-prop

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1436048

I've tested it using csssyntax.ejs on a local Kuma, and it did what I expected.