### PR TITLE
Update font-stretch for CSS Fonts Level 4

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4105,7 +4105,7 @@
     "status": "standard"
   },
   "font-stretch": {
-    "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
+    "syntax": "<font-stretch-absolute>",
     "media": "visual",
     "inherited": true,
     "animationType": "fontStretch",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -224,6 +224,9 @@
   "fixed-size": {
     "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
   },
+  "font-stretch-absolute": {
+    "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
+  },
   "font-variant-css21": {
     "syntax": "[ normal | small-caps ]"
   },


### PR DESCRIPTION
CSS Fonts Level 4 updates the syntax for `font-stretch`: https://drafts.csswg.org/css-fonts-4/#font-stretch-prop