### PR TITLE
Update font-style for CSS Fonts Level 4

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4125,7 +4125,7 @@
     "status": "standard"
   },
   "font-style": {
-    "syntax": "normal | italic | oblique",
+    "syntax": "normal | italic | oblique <angle>?",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
CSS Fonts Level 4 updates the syntax for `font-style`: https://drafts.csswg.org/css-fonts-4/#font-style-prop