### PR TITLE
Make standard CSS properties only belong to one group

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3295,9 +3295,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Columns",
-      "CSS Fragmentation",
-      "CSS Regions"
+      "CSS Fragmentation"
     ],
     "initial": "auto",
     "appliesto": "blockLevelElements",
@@ -3312,9 +3310,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Columns",
-      "CSS Fragmentation",
-      "CSS Regions"
+      "CSS Fragmentation"
     ],
     "initial": "auto",
     "appliesto": "blockLevelElements",
@@ -3329,9 +3325,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Columns",
-      "CSS Fragmentation",
-      "CSS Regions"
+      "CSS Fragmentation"
     ],
     "initial": "auto",
     "appliesto": "blockLevelElements",
@@ -3486,7 +3480,6 @@
     "animationType": "lpc",
     "percentages": "referToDimensionOfContentArea",
     "groups": [
-      "CSS Columns",
       "CSS Box Alignment"
     ],
     "initial": "normal",
@@ -5929,7 +5922,6 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Columns",
       "CSS Fragmentation"
     ],
     "initial": "2",
@@ -7510,7 +7502,6 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Columns",
       "CSS Fragmentation"
     ],
     "initial": "2",


### PR DESCRIPTION
This is a partial resolution to https://github.com/mdn/data/issues/239.

It updates data for standard CSS properties to make sure that they only belong to one "group", that being the most recent spec that defines them. This should be enough to make sidebars more coherent for pages like `column-gap`.

This is a little dodgy, I suppose, since the "most recent spec" is generally less mature than the others (e.g. `break-after` is still defined in CSS Regions, with the note:

> This section is also defined in [CSS3-BREAK]. If that specification moves to last call with the region values, the section here can be replaced by a reference.

(https://drafts.csswg.org/css-regions-1/#region-flow-break)

But I guess that realistically, it's safe to consider that `break-after` is now defined in the CSS Fragmentation spec.

This PR does not update data for various nonstandard properties:

```
box-flex-group
box-ordinal-group
box-flex
-moz-appearance
box-lines
box-orient
box-pack
box-direction
box-align
```

@rachelandrew , please let me know if this looks good to you.