### PR TITLE
Validate syntaxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,16 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "css-tree": {
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "~1.1.0",
+        "source-map": "^0.5.3"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -150,6 +160,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
+    "mdn-data": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "scripts": {
     "lint": "node test/lint",
-    "travis": "npm test",
-    "test": "node test/test"
+    "validate-syntaxes": "node test/validate-syntaxes",
+    "test": "npm run lint && npm run validate-syntaxes",
+    "travis": "npm test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   "homepage": "https://developer.mozilla.org",
   "devDependencies": {
     "ajv": "^5.0.1",
-    "better-ajv-errors": "^0.5.1"
+    "better-ajv-errors": "^0.5.1",
+    "css-tree": "^1.0.0-alpha.29"
   },
   "scripts": {
     "lint": "node test/lint",
     "travis": "npm test",
-    "test": "npm run lint"
+    "test": "node test/test"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,2 @@
+require('./lint');
+require('./validate-syntaxes');

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,0 @@
-require('./lint');
-require('./validate-syntaxes');

--- a/test/validate-syntaxes.js
+++ b/test/validate-syntaxes.js
@@ -2,9 +2,9 @@ var properties = require('../css/properties');
 var syntaxes = require('../css/syntaxes');
 var basicTypes = require('../css/types');
 var parseGrammar = require('css-tree').grammar.parse;
+var walkGrammar = require('css-tree').grammar.walk;
 
 var hasErrors = false;
-var itemsHaveErrors;
 
 function isBasicType(name) { return basicTypes.hasOwnProperty(name); }
 function isSyntax(name) { return syntaxes.hasOwnProperty(name); }
@@ -13,65 +13,63 @@ function isProperty(name) { return properties.hasOwnProperty(name); }
 // Checks that the syntaxes this grammar refers to exist.
 // Returns an array of errors (strings), one for each broken reference.
 function validateGrammar(grammar) {
-  switch (grammar.type) {
-    case 'Group':
-      // validate the nested grammars and collect all the errors
-      return grammar.terms
-        .map(validateGrammar)
-        .reduce(function(a, b) { return a.concat(b); }, []);
-    case 'Multiplier':
-      // validate the nested grammar
-      return validateGrammar(grammar.term);
-    case 'Type':
-      // validate basic types and non-terminal types, e.g. <length>, <bg-image>
-      var typeName = grammar.name;
-      if (!(isBasicType(typeName) || isSyntax(typeName))) {
-        return ['invalid type: ' + typeName];
-      }
-      return [];
-    case 'Property':
-      // validate references to properties, e.g. <'background-color'>
-      var typeName = grammar.name;
-      if (!isProperty(typeName)) {
-        return ['invalid property: ' + typeName];
-      }
-      return [];
-    default:
-      return [];
-  }
+  var errors = [];
+
+  walkGrammar(grammar, function(node) {
+    switch (node.type) {
+      case 'Type':
+        // validate basic types and non-terminal types, e.g. <length>, <bg-image>
+        var typeName = node.name;
+        if (!isBasicType(typeName) && !isSyntax(typeName)) {
+          errors.push('Broken reference: <' + typeName + '>');
+        }
+        break;
+
+      case 'Property':
+        // validate references to properties, e.g. <'background-color'>
+        var typeName = node.name;
+        if (!isProperty(typeName)) {
+          errors.push('Broken reference: <\'' + typeName + '\'>');
+        }
+        break;
+    }
+  });
+
+  return errors;
 }
 
 function validateItem(name, item) {
   try {
     var syntax = parseGrammar(item.syntax);
-    var errs = validateGrammar(syntax);
-    if (errs.length > 0) {
+    var errors = validateGrammar(syntax);
+    if (errors.length > 0) {
       // print validation errors
       console.log('  ' + name + ':');
-      errs.forEach(function (err) { console.log('    ' + err); });
-      itemsHaveErrors = true;
+      console.log('    ' + errors.join('\n    '));
+      return false;
     }
-  }
-  catch (err) {
+  } catch (err) {
     // print parsing errors
     console.log('  ' + name + ':');
     console.log('    ' + err.message.replace(/\n/g, '\n    '));
-    itemsHaveErrors = true;
+    return false;
   }
 }
 
 function validateItems(file, items) {
   console.log(file);
 
-  itemsHaveErrors = false;
+  var itemsHaveErrors = false;
 
-  Object.keys(items).forEach(function(key) { validateItem(key, items[key]); });
+  for (var key in items) {
+    if (!validateItem(key, items[key])) {
+      itemsHaveErrors = true;
+    }
+  }
 
   if (itemsHaveErrors) {
-    console.log('');
     hasErrors = true;
-  }
-  else {
+  } else {
     console.log('  Syntaxes – OK');
   }
 }

--- a/test/validate-syntaxes.js
+++ b/test/validate-syntaxes.js
@@ -20,8 +20,14 @@ function validateGrammar(grammar) {
       return validateGrammar(grammar.term);
     case 'Type':
       var typeName = grammar.name;
-      if (!(isBasicType(typeName) || isSyntax(typeName) || isProperty(typeName))) {
-        return [typeName];
+      if (!(isBasicType(typeName) || isSyntax(typeName))) {
+        return ['invalid type: ' + typeName];
+      }
+      return [];
+    case 'Property':
+      var typeName = grammar.name;
+      if (!isProperty(typeName)) {
+        return ['invalid property: ' + typeName];
       }
       return [];
     default:
@@ -35,7 +41,7 @@ function validateItem(name, item) {
     var errs = validateGrammar(syntax);
     if (errs.length > 0) {
       console.log('  ' + name + ':');
-      errs.forEach(function (type) { console.log('    invalid type: ' + type); });
+      errs.forEach(function (err) { console.log('    ' + err); });
       itemsHaveErrors = true;
     }
   }

--- a/test/validate-syntaxes.js
+++ b/test/validate-syntaxes.js
@@ -1,0 +1,70 @@
+var properties = require('../css/properties');
+var syntaxes = require('../css/syntaxes');
+var basicTypes = require('../css/types');
+var parseGrammar = require('css-tree').grammar.parse;
+
+var hasErrors = false;
+var itemsHaveErrors;
+
+function isBasicType(name) { return basicTypes.hasOwnProperty(name); }
+function isSyntax(name) { return syntaxes.hasOwnProperty(name); }
+function isProperty(name) { return properties.hasOwnProperty(name); }
+
+function validateGrammar(grammar) {
+  switch (grammar.type) {
+    case 'Group':
+      return grammar.terms
+        .map(validateGrammar)
+        .reduce(function(a, b) { return a.concat(b); }, []);
+    case 'Multiplier':
+      return validateGrammar(grammar.term);
+    case 'Type':
+      var typeName = grammar.name;
+      if (!(isBasicType(typeName) || isSyntax(typeName) || isProperty(typeName))) {
+        return [typeName];
+      }
+      return [];
+    default:
+      return [];
+  }
+}
+
+function validateItem(name, item) {
+  try {
+    var syntax = parseGrammar(item.syntax);
+    var errs = validateGrammar(syntax);
+    if (errs.length > 0) {
+      console.log('  ' + name + ':');
+      errs.forEach(function (type) { console.log('    invalid type: ' + type); });
+      itemsHaveErrors = true;
+    }
+  }
+  catch (err) {
+    console.log('  ' + name + ':');
+    console.log('    ' + err.message.replace(/\n/g, '\n    '));
+    itemsHaveErrors = true;
+  }
+}
+
+function validateItems(file, items) {
+  console.log(file);
+
+  itemsHaveErrors = false;
+
+  Object.keys(items).forEach(function(key) { validateItem(key, items[key]); });
+
+  if (itemsHaveErrors) {
+    console.log('');
+    hasErrors = true;
+  }
+  else {
+    console.log('  Syntaxes – OK');
+  }
+}
+
+validateItems('css/properties.json', properties);
+validateItems('css/syntaxes.json', syntaxes);
+
+if (hasErrors) {
+  process.exit(1);
+}

--- a/test/validate-syntaxes.js
+++ b/test/validate-syntaxes.js
@@ -10,21 +10,27 @@ function isBasicType(name) { return basicTypes.hasOwnProperty(name); }
 function isSyntax(name) { return syntaxes.hasOwnProperty(name); }
 function isProperty(name) { return properties.hasOwnProperty(name); }
 
+// Checks that the syntaxes this grammar refers to exist.
+// Returns an array of errors (strings), one for each broken reference.
 function validateGrammar(grammar) {
   switch (grammar.type) {
     case 'Group':
+      // validate the nested grammars and collect all the errors
       return grammar.terms
         .map(validateGrammar)
         .reduce(function(a, b) { return a.concat(b); }, []);
     case 'Multiplier':
+      // validate the nested grammar
       return validateGrammar(grammar.term);
     case 'Type':
+      // validate basic types and non-terminal types, e.g. <length>, <bg-image>
       var typeName = grammar.name;
       if (!(isBasicType(typeName) || isSyntax(typeName))) {
         return ['invalid type: ' + typeName];
       }
       return [];
     case 'Property':
+      // validate references to properties, e.g. <'background-color'>
       var typeName = grammar.name;
       if (!isProperty(typeName)) {
         return ['invalid property: ' + typeName];
@@ -40,12 +46,14 @@ function validateItem(name, item) {
     var syntax = parseGrammar(item.syntax);
     var errs = validateGrammar(syntax);
     if (errs.length > 0) {
+      // print validation errors
       console.log('  ' + name + ':');
       errs.forEach(function (err) { console.log('    ' + err); });
       itemsHaveErrors = true;
     }
   }
   catch (err) {
+    // print parsing errors
     console.log('  ' + name + ':');
     console.log('    ' + err.message.replace(/\n/g, '\n    '));
     itemsHaveErrors = true;

--- a/test/validate-syntaxes.js
+++ b/test/validate-syntaxes.js
@@ -10,18 +10,18 @@ function isBasicType(name) { return basicTypes.hasOwnProperty(name); }
 function isSyntax(name) { return syntaxes.hasOwnProperty(name); }
 function isProperty(name) { return properties.hasOwnProperty(name); }
 
-function validateGrammar(grammar, searchInProperties) {
-    switch (grammar.type) {
+function validateGrammar(grammar) {
+  switch (grammar.type) {
     case 'Group':
       return grammar.terms
-        .map(function(t) { return validateGrammar(t, searchInProperties); })
+        .map(validateGrammar)
         .reduce(function(a, b) { return a.concat(b); }, []);
     case 'Multiplier':
-      return validateGrammar(grammar.term, searchInProperties);
+      return validateGrammar(grammar.term);
     case 'Type':
       var typeName = grammar.name;
-      if (!(isBasicType(typeName) || isSyntax(typeName) || searchInProperties && isProperty(typeName))) {
-          return [typeName];
+      if (!(isBasicType(typeName) || isSyntax(typeName) || isProperty(typeName))) {
+        return [typeName];
       }
       return [];
     default:
@@ -29,10 +29,10 @@ function validateGrammar(grammar, searchInProperties) {
   }
 }
 
-function validateItem(name, item, searchInProperties) {
+function validateItem(name, item) {
   try {
     var syntax = parseGrammar(item.syntax);
-    var errs = validateGrammar(syntax, searchInProperties);
+    var errs = validateGrammar(syntax);
     if (errs.length > 0) {
       console.log('  ' + name + ':');
       errs.forEach(function (type) { console.log('    invalid type: ' + type); });
@@ -46,12 +46,12 @@ function validateItem(name, item, searchInProperties) {
   }
 }
 
-function validateItems(file, items, searchInProperties) {
+function validateItems(file, items) {
   console.log(file);
 
   itemsHaveErrors = false;
 
-  Object.keys(items).forEach(function(key) { validateItem(key, items[key], searchInProperties); });
+  Object.keys(items).forEach(function(key) { validateItem(key, items[key]); });
 
   if (itemsHaveErrors) {
     console.log('');
@@ -62,8 +62,8 @@ function validateItems(file, items, searchInProperties) {
   }
 }
 
-validateItems('css/properties.json', properties, true);
-validateItems('css/syntaxes.json', syntaxes, false);
+validateItems('css/properties.json', properties);
+validateItems('css/syntaxes.json', syntaxes);
 
 if (hasErrors) {
   process.exit(1);


### PR DESCRIPTION
I made a test to validate the syntaxes in `properties.json` and `syntaxes.json`, as suggested in #172.

As of now the test fails as there are several types that are neither in `syntaxes.json` nor in `types.json`:
```
any-value
attr-fallback
attr-name
custom-property-name
declaration
declaration-list
declaration-value
dimension
function-token
hash-token
hex-color
ident-token
name-repeat
path()
positive-integer
string-token
x
y
```