### PR TITLE
syntaxes.json: <'border-radius'> instead of <border-radius>

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -312,7 +312,7 @@
     "syntax": "<length> | <percentage> | min-content | max-content | auto"
   },
   "inset()": {
-    "syntax": "inset( <length-percentage>{1,4} [ round <border-radius> ]? )"
+    "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
   },
   "invert()": {
     "syntax": "invert( <number-percentage> )"


### PR DESCRIPTION
In [syntaxes.json](https://github.com/mdn/data/blob/master/css/syntaxes.json#L315) the non-terminal data type `<border-radius>` should be enclosed in quotes, as explained in [Value definition syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax#Non-terminal_data_types):

> data types *sharing the same name of a property*, put between quotes