### PR TITLE
Fix <shape> syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -335,6 +335,9 @@
   "leader-type": {
     "syntax": "dotted | solid | space | <string>"
   },
+  "length-auto": {
+    "syntax": "<length> | auto"
+  },
   "length-percentage": {
     "syntax": "<length> | <percentage>"
   },
@@ -564,7 +567,7 @@
     "syntax": "[ <length>{2,3} && <color>? ]"
   },
   "shape": {
-    "syntax": "rect(<top>, <right>, <bottom>, <left>)"
+    "syntax": "rect(<length-auto>, <length-auto>, <length-auto>, <length-auto>)"
   },
   "shape-box": {
     "syntax": "<box> | margin-box"


### PR DESCRIPTION
As mentioned in #244 the syntax `<shape>` should be fixed.

The [correct syntax](https://www.w3.org/TR/CSS2/visufx.html#value-def-shape) of `<top>`, `<right>`... is `<length> | auto`. The [MND docs](https://developer.mozilla.org/en-US/docs/Web/CSS/shape#Syntax) erroneously state that it's `<length>`.