### PR TITLE
Mark a couple of scroll-snap properties as obsolete

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5631,7 +5631,7 @@
     "appliesto": "allElements",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "status": "standard"
+    "status": "obsolete"
   },
   "scroll-snap-destination": {
     "syntax": "<position>",
@@ -5646,7 +5646,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "status": "standard"
+    "status": "obsolete"
   },
   "scroll-snap-points-x": {
     "syntax": "none | repeat( <length-percentage> )",


### PR DESCRIPTION
scroll-snap-destination and scroll-snap-coordinate are already marked as deprecated on the relevant MDN pages but not in the data
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-destination
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-coordinate