### PR TITLE
Add MDN URLs to types data

### DIFF
--- a/css/types.json
+++ b/css/types.json
@@ -9,28 +9,32 @@
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/angle"
   },
   "basic-shape": {
     "groups": [
       "CSS Shapes",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape"
   },
   "blend-mode": {
     "groups": [
       "Compositing and Blending",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/blend-mode"
   },
   "color": {
     "groups": [
       "CSS Color",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color"
   },
   "custom-ident": {
     "groups": [
@@ -40,33 +44,38 @@
       "CSS Animations",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/custom-ident"
   },
   "filter-function": {
     "groups": [
       "Filter Effects"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function"
   },
   "flex": {
     "groups": [
       "CSS Grid Layout",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex"
   },
   "frequency": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/frequency"
   },
   "gradient": {
     "groups": [
       "CSS Images",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient"
   },
   "ident": {
     "groups": [
@@ -79,67 +88,78 @@
       "CSS Images",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image"
   },
   "integer": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/integer"
   },
   "length": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/length"
   },
   "number": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/number"
   },
   "percentage": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/percentage"
   },
   "position": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position"
   },
   "ratio": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ratio"
   },
   "resolution": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/resolution"
   },
   "shape": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape"
   },
   "string": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/string"
   },
   "time": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time"
   },
   "timing-function": {
     "groups": [
@@ -147,19 +167,22 @@
       "CSS Transitions",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/single-transition-timing-function"
   },
   "transform-function": {
     "groups": [
       "CSS Transforms",
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function"
   },
   "url": {
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url"
   }
 }

--- a/css/types.json
+++ b/css/types.json
@@ -34,7 +34,7 @@
       "CSS Types"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value"
   },
   "custom-ident": {
     "groups": [
@@ -60,7 +60,7 @@
       "CSS Types"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex_value"
   },
   "frequency": {
     "groups": [
@@ -124,7 +124,7 @@
       "CSS Types"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position_value"
   },
   "ratio": {
     "groups": [

--- a/css/types.schema.json
+++ b/css/types.schema.json
@@ -18,6 +18,10 @@
           "nonstandard",
           "experimental"
         ]
+      },
+      "mdn_url": {
+        "type": "string",
+        "pattern": "^https://developer.mozilla.org/docs/Web/CSS/"
       }
     },
     "required": [


### PR DESCRIPTION
This is yet another continuation of #233. This PR adds MDN URLs to the CSS types data and schema.

Two entries didn't get URLs:

- `an-plus-b` (not sure what this is referring to)
- `ident` (couldn't find a page)