### PR TITLE
min-width and min-height properties initial value of auto

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5939,7 +5939,7 @@
     "groups": [
       "CSS Box Model"
     ],
-    "initial": "0",
+    "initial": "auto",
     "appliesto": "allElementsButNonReplacedAndTableColumns",
     "computed": "percentageAsSpecifiedOrAbsoluteLength",
     "order": "uniqueOrder",
@@ -5971,7 +5971,7 @@
     "groups": [
       "CSS Box Model"
     ],
-    "initial": "0",
+    "initial": "auto",
     "appliesto": "allElementsButNonReplacedAndTableRows",
     "computed": "percentageAsSpecifiedOrAbsoluteLength",
     "order": "uniqueOrder",


### PR DESCRIPTION
referencing this bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=1276323

In CSS Sizing the initial values for `min-width` and `min-height` have been changed from `0` to `auto`. 

https://drafts.csswg.org/css-sizing-3/#propdef-min-height

This was originally defined in the Flexbox spec as an extra value: https://drafts.csswg.org/css-flexbox-1/#min-size-auto