### PR TITLE
Add MDN URL to schema docs

### DIFF
--- a/css/at-rules.md
+++ b/css/at-rules.md
@@ -25,7 +25,8 @@ The 3 properties seen above are all required:
 * `groups` (array of strings): CSS is organized in modules like "CSS Fonts" or "CSS Animations". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the at-rule is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
 
-There are 2 more properties that are optional:
+There are 3 more properties that are optional:
+* `mdn_url` (string): a URL linking to the at-rule's page on MDN. This URL must omit the localization part of the URL (such as `en-US/`).
 * `interfaces` (array of strings): These are the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) interfaces that belong to the at-rule.
 * `descriptors` (object): see below
 

--- a/css/properties.md
+++ b/css/properties.md
@@ -113,6 +113,7 @@ on MDN and the [CSS Values and Units](https://www.w3.org/TR/css3-values/#value-d
 * `order` (enum): The [canonical order](https://developer.mozilla.org/en-US/docs/Glossary/Canonical_order) for the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L235).
 * `status` (enum): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
 
-There are 2 more properties that are optional:
+There are 3 more properties that are optional:
+* `mdn_url` (string): a URL linking to the property's page on MDN. This URL must omit the localization part of the URL (such as `en-US/`).
 * `stacking` (boolean): Whether or not the property creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) for details.
 * `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L153).

--- a/css/selectors.md
+++ b/css/selectors.md
@@ -23,3 +23,6 @@ The three properties shown above are all required:
 * `syntax` (string): The syntax of the selector (e.g. `::after` with two colons indicating a [pseudo-element](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Pseudo-classes_and_pseudo-elements#Pseudo-elements), `:hover` with one colon indicating a [pseudo-class](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Pseudo-classes_and_pseudo-elements#Pseudo-classes), or `A ~ B` indicating a [combinator](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Combinators_and_multiple_selectors#Combinators)).
 * `groups` (array of strings): CSS is organized in modules like "CSS Units" or "CSS Lengths". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the selector is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
+
+There is another property that is optional:
+* `mdn_url` (string): a URL linking to the selector's page on MDN. This URL must omit the localization part of the URL (such as `en-US/`).

--- a/css/types.md
+++ b/css/types.md
@@ -21,3 +21,6 @@ A type object looks like the following example.
 The 2 properties are both required.
 * `groups` (array of strings): CSS is organized in modules like "CSS Types" or "CSS Color". MDN organizes features in these groups as well — `groups` should contain the name of the module(s) the type is defined in.
 * `status` (enum string): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
+
+There is another property that is optional:
+* `mdn_url` (string): a URL linking to the type's page on MDN. This URL must omit the localization part of the URL (such as `en-US/`).


### PR DESCRIPTION
This PR documents the new `mdn_url` added in #256, #258, #259, and #260.

This should be the last PR needed to conclude #233.

cc: @wbamberg 