### PR TITLE
Add badge to display install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For example, the [CSSTree](https://github.com/csstree/csstree/) CSS parser.
 
 
 [![NPM version](https://img.shields.io/npm/v/mdn-data.svg)](https://www.npmjs.com/package/mdn-data)
+[![Install Size](https://packagephobia.now.sh/badge?p=mdn-data)](https://packagephobia.now.sh/result?p=mdn-data)
 [![Build Status](https://travis-ci.org/mdn/data.svg?branch=master)](https://travis-ci.org/mdn/data)
 
 ## Repository contents


### PR DESCRIPTION
This adds a badge to the README.md file to display the npm install size