### PR TITLE
Rename the offset- logical properties to inset-

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5099,6 +5099,70 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inline-size"
   },
+  "inset-block-end": {
+    "syntax": "<'left'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalHeightOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-end"
+  },
+  "inset-block-start": {
+    "syntax": "<'left'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalHeightOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-start"
+  },
+  "inset-inline-end": {
+    "syntax": "<'left'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-end"
+  },
+  "inset-inline-start": {
+    "syntax": "<'left'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start"
+  },
   "isolation": {
     "syntax": "auto | isolate",
     "media": "visual",
@@ -6080,70 +6144,6 @@
     "computed": "forLengthAbsoluteValueOtherwisePercentage",
     "order": "perGrammar",
     "status": "experimental"
-  },
-  "offset-block-end": {
-    "syntax": "<'left'>",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalHeightOfContainingBlock",
-    "groups": [
-      "CSS Logical Properties"
-    ],
-    "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-block-end"
-  },
-  "offset-block-start": {
-    "syntax": "<'left'>",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalHeightOfContainingBlock",
-    "groups": [
-      "CSS Logical Properties"
-    ],
-    "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-block-start"
-  },
-  "offset-inline-end": {
-    "syntax": "<'left'>",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
-    "groups": [
-      "CSS Logical Properties"
-    ],
-    "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-inline-end"
-  },
-  "offset-inline-start": {
-    "syntax": "<'left'>",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "logicalWidthOfContainingBlock",
-    "groups": [
-      "CSS Logical Properties"
-    ],
-    "initial": "auto",
-    "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
-    "order": "uniqueOrder",
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-inline-start"
   },
   "offset-distance": {
     "syntax": "<length-percentage>",


### PR DESCRIPTION
Changed in Firefox 63. https://www.fxsitecompat.com/en-CA/docs/2018/offset-logical-properties-have-been-renamed-to-inset/

I am currently updating the property pages on MDN.