### PR TITLE
Add shortDescription to CSS property schema

### DIFF
--- a/css/properties.md
+++ b/css/properties.md
@@ -113,7 +113,8 @@ on MDN and the [CSS Values and Units](https://www.w3.org/TR/css3-values/#value-d
 * `order` (enum): The [canonical order](https://developer.mozilla.org/en-US/docs/Glossary/Canonical_order) for the property. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L235).
 * `status` (enum): This is either `standard`, `nonstandard`, or `experimental` depending on the standardization status of the feature.
 
-There are 3 more properties that are optional:
+The following properties are optional:
 * `mdn_url` (string): a URL linking to the property's page on MDN. This URL must omit the localization part of the URL (such as `en-US/`).
+* `shortDescription` (string): a short description of the CSS property. This data typically comes from the property's MDN page summary.
 * `stacking` (boolean): Whether or not the property creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) for details.
 * `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/master/css/properties.schema.json#L153).

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -263,6 +263,9 @@
     "mdn_url": {
       "type": "string",
       "pattern": "^https://developer.mozilla.org/docs/"
+    },
+    "shortDescription": {
+      "type": "string"
     }
   },
   "type": "object",
@@ -385,6 +388,9 @@
       },
       "mdn_url": {
         "$ref": "#/definitions/mdn_url"
+      },
+      "shortDescription": {
+        "$ref": "#/definitions/shortDescription"
       }
     }
   }


### PR DESCRIPTION
This adds the `shortDescription` as an optional property in the CSS properties schema and documents it too. A small step toward issue #262.