### PR TITLE
Update computed value of overflow* properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6378,7 +6378,10 @@
     ],
     "initial": "visible",
     "appliesto": "blockContainersFlexContainersGridContainers",
-    "computed": "asSpecified",
+    "computed": [
+      "overflow-x",
+      "overflow-y"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow"
@@ -6409,7 +6412,7 @@
     ],
     "initial": "auto",
     "appliesto": "blockContainersFlexContainersGridContainers",
-    "computed": "asSpecified",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
     "order": "perGrammar",
     "status": "experimental"
   },
@@ -6440,7 +6443,7 @@
     ],
     "initial": "auto",
     "appliesto": "blockContainersFlexContainersGridContainers",
-    "computed": "asSpecified",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
     "order": "perGrammar",
     "status": "experimental"
   },
@@ -6471,7 +6474,7 @@
     ],
     "initial": "visible",
     "appliesto": "blockContainersFlexContainersGridContainers",
-    "computed": "asSpecified",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-x"
@@ -6487,7 +6490,7 @@
     ],
     "initial": "visible",
     "appliesto": "blockContainersFlexContainersGridContainers",
-    "computed": "asSpecified",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-y"

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -106,6 +106,7 @@
         "asLength",
         "asSpecified",
         "asSpecifiedAppliesToEachProperty",
+        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
         "asSpecifiedExceptMatchParent",
         "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
         "asSpecifiedRelativeToAbsoluteLengths",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -358,9 +358,9 @@
     "ru": "как указанное значение, применяется к каждому свойству этой короткой записи."
   },
   "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent": {
-    "en-US": "as specified, except with <code>visible</code>/<code>clip</code> computing to <code>auto</code>/<code>hidden</code> respectively if one of {{cssxref{\"overflow-x\"}}} or {{cssxref{\"overflow-y\"}}} is neither <code>visible</code> nor </code>hidden</code>",
-    "es": "como se especifica, excepto que si {{cssxref{\"overflow-x\"}}} o bien {{cssxref{\"overflow-y\"}}} es distinto de <code>visible</code> o <code>clip</code>, estos dos valores computan a <code>auto</code> o <code>hidden</code> respectivamente",
-    "ca": "com s'especifica, excepte que si {{cssxref{\"overflow-x\"}}} o bé {{cssxref{\"overflow-y\"}}} són diferents de <code>visible</code> o <code>clip</code>, aquests dos valors computen a <code>auto</code> o <code>hidden</code> respectivament"
+    "en-US": "as specified, except with <code>visible</code>/<code>clip</code> computing to <code>auto</code>/<code>hidden</code> respectively if one of {{cssxref(\"overflow-x\")}} or {{cssxref(\"overflow-y\")}} is neither <code>visible</code> nor </code>hidden</code>",
+    "es": "como se especifica, excepto que si {{cssxref(\"overflow-x\")}} o bien {{cssxref(\"overflow-y\")}} es distinto de <code>visible</code> o <code>clip</code>, estos dos valores computan a <code>auto</code> o <code>hidden</code> respectivamente",
+    "ca": "com s'especifica, excepte que si {{cssxref(\"overflow-x\")}} o bé {{cssxref(\"overflow-y\")}} són diferents de <code>visible</code> o <code>clip</code>, aquests dos valors computen a <code>auto</code> o <code>hidden</code> respectivament"
   },
   "asSpecifiedExceptMatchParent": {
     "de": "wie angegeben, außer für den <code>match-parent</code> Wert, welcher in Bezug auf den <code>direction</code> Wert des Elternelements berechnet wird und einen berechneten Wert von <code>left</code> oder <code>right</code> ergibt",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -345,6 +345,7 @@
     "de": "wie angegeben",
     "en-US": "as specified",
     "es": "como se especifica",
+    "ca": "com s'especifica",
     "fr": "comme spécifié",
     "ja": "指定値",
     "pl": "jako określone",
@@ -355,6 +356,11 @@
     "en-US": "as the specified value applies to each property this is a shorthand for.",
     "fr": "comme la valeur spécifiée s'applique sur chaque propriété englobée par le raccourci",
     "ru": "как указанное значение, применяется к каждому свойству этой короткой записи."
+  },
+  "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent": {
+    "en-US": "as specified, except with <code>visible</code>/<code>clip</code> computing to <code>auto</code>/<code>hidden</code> respectively if one of {{cssxref{\"overflow-x\"}}} or {{cssxref{\"overflow-y\"}}} is neither <code>visible</code> nor </code>hidden</code>",
+    "es": "como se especifica, excepto que si {{cssxref{\"overflow-x\"}}} o bien {{cssxref{\"overflow-y\"}}} es distinto de <code>visible</code> o <code>clip</code>, estos dos valores computan a <code>auto</code> o <code>hidden</code> respectivamente",
+    "ca": "com s'especifica, excepte que si {{cssxref{\"overflow-x\"}}} o bé {{cssxref{\"overflow-y\"}}} són diferents de <code>visible</code> o <code>clip</code>, aquests dos valors computen a <code>auto</code> o <code>hidden</code> respectivament"
   },
   "asSpecifiedExceptMatchParent": {
     "de": "wie angegeben, außer für den <code>match-parent</code> Wert, welcher in Bezug auf den <code>direction</code> Wert des Elternelements berechnet wird und einen berechneten Wert von <code>left</code> oder <code>right</code> ergibt",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -358,7 +358,7 @@
     "ru": "как указанное значение, применяется к каждому свойству этой короткой записи."
   },
   "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent": {
-    "en-US": "as specified, except with <code>visible</code>/<code>clip</code> computing to <code>auto</code>/<code>hidden</code> respectively if one of {{cssxref(\"overflow-x\")}} or {{cssxref(\"overflow-y\")}} is neither <code>visible</code> nor </code>hidden</code>",
+    "en-US": "as specified, except with <code>visible</code>/<code>clip</code> computing to <code>auto</code>/<code>hidden</code> respectively if one of {{cssxref(\"overflow-x\")}} or {{cssxref(\"overflow-y\")}} is neither <code>visible</code> nor </code>clip</code>",
     "es": "como se especifica, excepto que si {{cssxref(\"overflow-x\")}} o bien {{cssxref(\"overflow-y\")}} es distinto de <code>visible</code> o <code>clip</code>, estos dos valores computan a <code>auto</code> o <code>hidden</code> respectivamente",
     "ca": "com s'especifica, excepte que si {{cssxref(\"overflow-x\")}} o bé {{cssxref(\"overflow-y\")}} són diferents de <code>visible</code> o <code>clip</code>, aquests dos valors computen a <code>auto</code> o <code>hidden</code> respectivament"
   },


### PR DESCRIPTION
Amends #202 and #207 to fix computed value, so it matches [the spec](https://drafts.csswg.org/css-overflow-3/#property-index).

Basically, warn developers that setting `overflow-x: hidden` also means `overflow-y: auto` implicitly.