### PR TITLE
feat(api): Add HTMLMarqueeElement inheritance data

### DIFF
--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -442,6 +442,10 @@
       "SVGUnitTypes"
     ]
   },
+  "HTMLMarqueeElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
   "HTMLMetaElement": {
     "inherits": "HTMLElement",
     "implements": []


### PR DESCRIPTION
This adds inheritance data for [`HTMLMarqueeElement`](https://developer.mozilla.org/docs/Web/API/HTMLMarqueeElement).

---

See also: https://github.com/mdn/browser-compat-data/pull/2714

Also, I’m fine with #240.