### PR TITLE
feat(css): Add the viewport‑fit @viewport descriptor

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -455,6 +455,18 @@
         "order": "uniqueOrder",
         "status": "standard"
       },
+      "viewport-fit": {
+        "syntax": "auto | contain | cover",
+        "media": [
+          "visual",
+          "continuous"
+        ],
+        "initial": "auto",
+        "percentages": "no",
+        "computed": "asSpecified",
+        "order": "uniqueOrder",
+        "status": "standard"
+      },
       "width": {
         "syntax": "<viewport-length>{1,2}",
         "media": [


### PR DESCRIPTION
This adds data for [the `viewport‑fit` `@viewport` CSS descriptor](https://developer.mozilla.org/docs/Web/CSS/@viewport/viewport-fit).

---

See also mdn/kumascript#802 and mdn/browser-compat-data#2173.

review?(@chrisdavidmills, @ddbeck)