### PR TITLE
feat(css): Add the `||` column combinator

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -80,6 +80,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Descendant_selectors"
   },
+  "Column combinator": {
+    "syntax": "A || B",
+    "groups": [
+      "Combinators",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Column_combinator"
+  },
   ":active": {
     "syntax": ":active",
     "groups": [


### PR DESCRIPTION
This adds the syntax data for [the `||` column combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Column_combinator).

review?(@chrisdavidmills, @Elchi3)