### PR TITLE
feat(css): Add the `:has(…)` selector

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -224,6 +224,15 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:focus-within"
   },
+  ":has": {
+    "syntax": ":has( <relative-selector-list> )",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:has"
+  },
   ":host": {
     "syntax": ":host",
     "groups": [


### PR DESCRIPTION
Needed for [the `:has(…)` selector](https://developer.mozilla.org/docs/Web/CSS/:has)

Partially depends on #287, see also https://github.com/mdn/browser-compat-data/pull/1461.

review?(@chrisdavidmills)