### PR TITLE
feat(css): Add <complex-selector> syntax

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -342,7 +342,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:link"
   },
   ":matches": {
-    "syntax": ":matches( <complex-selector-list># )",
+    "syntax": ":matches( <selector># )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -351,7 +351,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:matches"
   },
   ":not": {
-    "syntax": ":not( <complex-selector-list># )",
+    "syntax": ":not( <complex-selector-list> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -360,7 +360,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:not"
   },
   ":nth-child": {
-    "syntax": ":nth-child( <nth> [ of <selector># ]? )",
+    "syntax": ":nth-child( <nth> [ of <complex-selector-list> ]? )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -369,7 +369,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-child"
   },
   ":nth-last-child": {
-    "syntax": ":nth-last-child( <nth> [ of <selector># ]? )",
+    "syntax": ":nth-last-child( <nth> [ of <complex-selector-list> ]? )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -834,7 +834,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::selection"
   },
   "::slotted": {
-    "syntax": "::slotted(<compound-selector-list>)",
+    "syntax": "::slotted( <compound-selector-list> )",
     "groups": [
       "Pseudo-elements",
       "Selectors"

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -342,7 +342,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:link"
   },
   ":matches": {
-    "syntax": ":matches( <selector># )",
+    "syntax": ":matches( <complex-selector-list># )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -351,7 +351,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:matches"
   },
   ":not": {
-    "syntax": ":not( <selector># )",
+    "syntax": ":not( <complex-selector-list># )",
     "groups": [
       "Pseudo-classes",
       "Selectors"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -104,6 +104,9 @@
   "color-stop-list": {
     "syntax": "<color-stop>#{2,}"
   },
+  "combinator": {
+    "syntax": "'>' | '+' | '~' | [ '||' ]"
+  },
   "common-lig-values": {
     "syntax": "[ common-ligatures | no-common-ligatures ]"
   },
@@ -118,6 +121,12 @@
   },
   "compound-selector-list": {
     "syntax": "<compound-selector>#"
+  },
+  "complex-selector": {
+    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+  },
+  "complex-selector-list": {
+    "syntax": "<complex-selector>#"
   },
   "contextual-alt-values": {
     "syntax": "[ contextual | no-contextual ]"
@@ -487,6 +496,12 @@
   },
   "radial-gradient()": {
     "syntax": "radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )"
+  },
+  "relative-selector": {
+    "syntax": "<combinator>? <complex-selector>"
+  },
+  "relative-selector-list": {
+    "syntax": "<relative-selector>#"
   },
   "relative-size": {
     "syntax": "larger | smaller"


### PR DESCRIPTION
See also #286 and #284.

`<compound-selector>` was already added in PR&nbsp;https://github.com/mdn/data/pull/169.

Blocks https://github.com/mdn/data/pull/324.

review?(@chrisdavidmills, @Elchi3)