### PR TITLE
fix(css): Complete `@supports` syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -608,6 +608,18 @@
   "subclass-selector": {
     "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
   },
+  "supports-condition": {
+    "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
+  },
+  "supports-in-parens": {
+    "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
+  },
+  "supports-feature": {
+    "syntax": "<supports-decl>"
+  },
+  "supports-decl": {
+    "syntax": "( <declaration> )"
+  },
   "symbol": {
     "syntax": "<string> | <image> | <custom-ident>"
   },

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -675,10 +675,13 @@
     "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
   },
   "supports-feature": {
-    "syntax": "<supports-decl>"
+    "syntax": "<supports-decl> | <supports-selector-fn>"
   },
   "supports-decl": {
     "syntax": "( <declaration> )"
+  },
+  "supports-selector-fn": {
+    "syntax": "selector( <complex-selector> )"
   },
   "symbol": {
     "syntax": "<string> | <image> | <custom-ident>"


### PR DESCRIPTION
This completes [the Formal Syntax section for the `@supports` at‑rule](https://developer.mozilla.org/docs/Web/CSS/@supports#Formal_syntax).

review?(@chrisdavidmills, @ddbeck, @Elchi3, @emilio, @jwhitlock, @wbamberg)

See also: https://github.com/w3c/csswg-drafts/issues/3774