### PR TITLE
CSS Basic Shapes - addition of path()

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6162,7 +6162,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-distance"
   },
   "offset-path": {
-    "syntax": "none | ray( [ <angle> && <size>? && contain? ] ) | <path()> | <url> | [ <basic-shape> || <geometry-box> ]",
+    "syntax": "none | ray( [ <angle> && <size>? && contain? ] ) | <url> | [ <basic-shape> || <geometry-box> ]",
     "media": "visual",
     "inherited": false,
     "animationType": "angleOrBasicShapeOrPath",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -465,7 +465,7 @@
     "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
   },
   "path()": {
-    "path( [ <fill-rule>, ]? <string> )"
+    "syntax": "path( [ <fill-rule>, ]? <string> )"
   },
   "perspective()": {
     "syntax": "perspective( <length> )"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -36,7 +36,7 @@
     "syntax": "[ first | last ]? baseline"
   },
   "basic-shape": {
-    "syntax": "<inset()> | <circle()> | <ellipse()> | <polygon()>"
+    "syntax": "<inset()> | <circle()> | <ellipse()> | <polygon() | path() >"
   },
   "bg-image": {
     "syntax": "none | <image>"
@@ -463,6 +463,9 @@
   },
   "page-selector": {
     "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+  },
+  "path()": {
+    "path( [ <fill-rule>, ]? <string> )"
   },
   "perspective()": {
     "syntax": "perspective( <length> )"


### PR DESCRIPTION
 added path() to basic shape definition and general path syntax.

Add support for clip-path: path()
https://bugzilla.mozilla.org/show_bug.cgi?id=1246764

Definition of path()
https://drafts.csswg.org/css-shapes-2/#supported-basic-shapes

to be added to basic shapes at:
https://www.w3.org/TR/css-shapes/#basic-shape-functions
