### PR TITLE
adding houdini properties to inheritance data

### DIFF
--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -2509,5 +2509,137 @@
   "PerformancePaintTiming": {
     "inherits": "PerformanceEntry",
     "implements": []
+  },
+  "CSSStyleValue": {
+    "inherits": null,
+    "implements": [
+      "CSSImageValue",
+      "CSSKeywordValue",
+      "CSSNumericValue",
+      "CSSPositionValue",
+      "CSSTransformValue",
+      "CSSUnitValue",
+      "CSSUnparsedValue"
+    ]
+  },
+  "CSSImageValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSKeywordValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSNumericValue": {
+    "inherits": "CSSStyleValue",
+    "implements": [
+      "CSSMathValue"
+    ]
+  },
+  "CSSMathValue": {
+    "inherits": "CSSNumericValue",
+    "implements": [
+      "CSSMathInvert",
+      "CSSMathMax",
+      "CSSMathMin",
+      "CSSMathNegate",
+      "CSSMathProduct",
+      "CSSMathSum",
+    ]
+  },
+  "CSSMathInvert": {
+    "inherits": "CSSMathValue",
+    "implements": []
+  },
+  "CSSMathMax": {
+    "inherits": "CSSMathValue",
+    "implements": []
+  },
+  "CSSMathMin": {
+    "inherits": "CSSMathValue",
+    "implements": []
+  },
+  "CSSMathNegate": {
+    "inherits": "CSSMathValue",
+    "implements": []
+  },
+  "CSSMathProduct": {
+    "inherits": "CSSMathValue",
+    "implements": []
+  },
+  "CSSMathSum": {
+    "inherits": "CSSMathValue",
+    "implements": []
+  },
+  "CSSPositionValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSTransformValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSUnitValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSUnparsedValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSTransformComponent": {
+    "inherits": null,
+    "implements": [
+      "CSSMatrixComponent",
+      "CSSPerspective",
+      "CSSRotate",
+      "CSSScale",
+      "CSSSkew",
+      "CSSSkewX",
+      "CSSSkewY",
+      "CSSTranslate"
+    ]
+  },
+  "CSSMatrixComponent": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSPerspective": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSRotate": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSScale": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSSkew": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSSkewX": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSSkewY": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSTranslate": {
+    "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "StylePropertyMapReadOnly": {
+    "inherits": null,
+    "implements": [
+      "StylePropertyMap"
+    ]
+  },
+  "StylePropertyMap": {
+    "inherits": "StylePropertyMapReadOnly",
+    "implements": []
   }
 }

--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -2544,7 +2544,7 @@
       "CSSMathMin",
       "CSSMathNegate",
       "CSSMathProduct",
-      "CSSMathSum",
+      "CSSMathSum"
     ]
   },
   "CSSMathInvert": {

--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -2533,7 +2533,8 @@
   "CSSNumericValue": {
     "inherits": "CSSStyleValue",
     "implements": [
-      "CSSMathValue"
+      "CSSMathValue",
+      "CSSUnitValue"
     ]
   },
   "CSSMathValue": {
@@ -2571,15 +2572,15 @@
     "inherits": "CSSMathValue",
     "implements": []
   },
+  "CSSUnitValue": {
+    "inherits": "CSSNumericValue",
+    "implements": []
+  },
   "CSSPositionValue": {
     "inherits": "CSSStyleValue",
     "implements": []
   },
   "CSSTransformValue": {
-    "inherits": "CSSStyleValue",
-    "implements": []
-  },
-  "CSSUnitValue": {
     "inherits": "CSSStyleValue",
     "implements": []
   },


### PR DESCRIPTION
As per https://github.com/mdn/data/issues/302

A couple of points — in the issue, CSSMathValue and CSSUnitValue are both listed in two places. I've not included the second instance, in both cases. @jpmedley , let me know if that's correct. Thanks!