### PR TITLE
fix(css): Most Web Components related features are now standard

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -140,7 +140,7 @@
       "Pseudo-classes",
       "Selectors"
     ],
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:defined"
   },
   ":dir": {
@@ -242,13 +242,22 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:has"
   },
+  ":host": {
+    "syntax": ":host",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host"
+  },
   ":host()": {
     "syntax": ":host( <compound-selector-list> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
     ],
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host()"
   },
   ":host-context()": {
@@ -835,7 +844,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::selection"
   },
   "::slotted": {
-    "syntax": "::slotted(<compound-selector-list>)",
+    "syntax": "::slotted( <compound-selector-list> )",
     "groups": [
       "Pseudo-elements",
       "Selectors"


### PR DESCRIPTION
Also, `:host` was originally contributed by @chrisdavidmills in https://github.com/mdn/data/pull/171/commits/7a3c36ad18a0b95e336e1b6d09db381c5fd82524.

review?(@chrisdavidmills, @connorshea, @teoli2003)