### PR TITLE
feat(css): Add `<display-*>` types

### DIFF
--- a/css/types.json
+++ b/css/types.json
@@ -47,6 +47,48 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/custom-ident"
   },
+  "display-outside": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-outside"
+  },
+  "display-inside": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-inside"
+  },
+  "display-listitem": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-listitem"
+  },
+  "display-internal": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-internal"
+  },
+  "display-box": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-box"
+  },
+  "display-legacy": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-legacy"
+  },
   "filter-function": {
     "groups": [
       "Filter Effects"


### PR DESCRIPTION
This PR adds all the current [**CSS&nbsp;Display**](https://developer.mozilla.org/docs/Web/CSS/CSS_Display) types:
- [`<display-outside>`](https://developer.mozilla.org/docs/Web/CSS/display-outside)
- [`<display-inside>`](https://developer.mozilla.org/docs/Web/CSS/display-inside)
- [`<display-listitem>`](https://developer.mozilla.org/docs/Web/CSS/display-listitem)
- [`<display-internal>`](https://developer.mozilla.org/docs/Web/CSS/display-internal)
- [`<display-box>`](https://developer.mozilla.org/docs/Web/CSS/display-box)
- [`<display-legacy>`](https://developer.mozilla.org/docs/Web/CSS/display-legacy)

review?(@chrisdavidmills, @teoli2003)