### PR TITLE
Add line-height-step data

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5329,7 +5329,7 @@
     "computed": "absoluteLength",
     "order": "perGrammar",
     "status": "experimental",
-    "mdn_url": "https://developer.mozilla.org/docs/Mozilla/CSS/line-height-step"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-height-step"
   },
   "list-style": {
     "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",

--- a/css/properties.json
+++ b/css/properties.json
@@ -5315,6 +5315,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-height"
   },
+  "line-height-step": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "0",
+    "appliesto": "blockContainers",
+    "computed": "absoluteLength",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Mozilla/CSS/line-height-step"
+  },
   "list-style": {
     "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
     "media": "visual",


### PR DESCRIPTION
While using the data to look up URLs, I found that this property was missing entirely. This is my first time adding a property from scratch, so I'd appreciate a closer look here. Thank you!