### PR TITLE
Moving box-align properties out of the flexbox group

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1645,7 +1645,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Flexible Box Layout"
+      "CSS Box Alignment"
     ],
     "initial": "normal",
     "appliesto": "multilineFlexContainers",
@@ -1661,7 +1661,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Flexible Box Layout"
+      "CSS Box Alignment"
     ],
     "initial": "normal",
     "appliesto": "allElements",
@@ -1677,7 +1677,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Flexible Box Layout"
+      "CSS Box Alignment"
     ],
     "initial": "auto",
     "appliesto": "flexItemsGridItemsAndAbsolutelyPositionedBoxes",
@@ -5234,7 +5234,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Flexible Box Layout"
+      "CSS Box Alignment"
     ],
     "initial": "normal",
     "appliesto": "flexContainers",
@@ -6823,7 +6823,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Flexible Box Layout"
+      "CSS Box Alignment"
     ],
     "initial": "normal",
     "appliesto": "multilineFlexContainers",


### PR DESCRIPTION
The flexbox spec explains that we should refer to Box Align in future for these properties and we have now updated the docs to explain the relationship. So moving the properties from flexbox to box align in the data.