### PR TITLE
Adding two value shorthands

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2261,6 +2261,78 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border"
   },
+  "border-block": {
+    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block"
+  },
+  "border-block-color": {
+    "syntax": "<'color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-color"
+  },
+  "border-block-style": {
+    "syntax": "<'border-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style"
+  },
+  "border-block-width": {
+    "syntax": "<'border-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width"
+  },
   "border-block-end": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
     "media": "visual",
@@ -2271,15 +2343,15 @@
       "CSS Logical Properties"
     ],
     "initial": [
-      "border-width",
-      "border-style",
-      "color"
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
     ],
     "appliesto": "allElements",
     "computed": [
-      "border-width",
-      "border-style",
-      "border-block-end-color"
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
     ],
     "order": "uniqueOrder",
     "status": "standard",
@@ -2748,6 +2820,30 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-width"
   },
+  "border-inline": {
+    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline"
+  },
   "border-inline-end": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
     "media": "visual",
@@ -2771,6 +2867,54 @@
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end"
+  },
+  "border-inline-color": {
+    "syntax": "<'color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color"
+  },
+  "border-inline-style": {
+    "syntax": "<'border-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style"
+  },
+  "border-inline-width": {
+    "syntax": "<'border-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width"
   },
   "border-inline-end-color": {
     "syntax": "<'color'>",
@@ -5540,6 +5684,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin"
   },
+  "margin-block": {
+    "syntax": "<'margin-left'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsMargin",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block"
+  },
   "margin-block-end": {
     "syntax": "<'margin-left'>",
     "media": "visual",
@@ -5590,6 +5750,22 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-bottom"
+  },
+  "margin-inline": {
+    "syntax": "<'margin-left'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsMargin",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline"
   },
   "margin-inline-end": {
     "syntax": "<'margin-left'>",
@@ -6646,6 +6822,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding"
   },
+  "padding-block": {
+    "syntax": "<'padding-left'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block"
+  },
   "padding-block-end": {
     "syntax": "<'padding-left'>",
     "media": "visual",
@@ -6696,6 +6888,22 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-bottom"
+  },
+  "padding-inline": {
+    "syntax": "<'padding-left'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline"
   },
   "padding-inline-end": {
     "syntax": "<'padding-left'>",

--- a/css/properties.json
+++ b/css/properties.json
@@ -2262,7 +2262,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border"
   },
   "border-block": {
-    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "syntax": "<'border-top-width'> || <'border-top-style'> || <'color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2286,7 +2286,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block"
   },
   "border-block-color": {
-    "syntax": "<'color'>",
+    "syntax": "<'border-top-color'>{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2302,7 +2302,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-color"
   },
   "border-block-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<'border-top-style'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2318,7 +2318,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style"
   },
   "border-block-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2334,7 +2334,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width"
   },
   "border-block-end": {
-    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "syntax": "<'border-top-width'> || <'border-top-style'> || <'color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2358,7 +2358,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end"
   },
   "border-block-end-color": {
-    "syntax": "<'color'>",
+    "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2374,7 +2374,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-color"
   },
   "border-block-end-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<'border-top-style'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2390,7 +2390,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-style"
   },
   "border-block-end-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2406,7 +2406,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width"
   },
   "border-block-start": {
-    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "syntax": "<'border-top-width'> || <'border-top-style'> || <'color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2430,7 +2430,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start"
   },
   "border-block-start-color": {
-    "syntax": "<'color'>",
+    "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2446,7 +2446,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-color"
   },
   "border-block-start-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<'border-top-style'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2462,7 +2462,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-style"
   },
   "border-block-start-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2509,7 +2509,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom"
   },
   "border-bottom-color": {
-    "syntax": "<color>",
+    "syntax": "<border-top-color>",
     "media": "visual",
     "inherited": false,
     "animationType": "color",
@@ -2821,7 +2821,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-width"
   },
   "border-inline": {
-    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "syntax": "<'border-top-width'> || <'border-top-style'> || <'color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2845,7 +2845,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline"
   },
   "border-inline-end": {
-    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "syntax": "<'border-top-width'> || <'border-top-style'> || <'color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2869,7 +2869,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end"
   },
   "border-inline-color": {
-    "syntax": "<'color'>",
+    "syntax": "<'border-top-color'>{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2885,7 +2885,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color"
   },
   "border-inline-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<'border-top-style'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2901,7 +2901,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style"
   },
   "border-inline-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2917,7 +2917,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width"
   },
   "border-inline-end-color": {
-    "syntax": "<'color'>",
+    "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2933,7 +2933,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color"
   },
   "border-inline-end-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<'border-top-style'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2949,7 +2949,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style"
   },
   "border-inline-end-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2965,7 +2965,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width"
   },
   "border-inline-start": {
-    "syntax": "<'border-width'> || <'border-style'> || <'color'>",
+    "syntax": "<'border-top-width'> || <'border-top-style'> || <'color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2989,7 +2989,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start"
   },
   "border-inline-start-color": {
-    "syntax": "<'color'>",
+    "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -3005,7 +3005,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color"
   },
   "border-inline-start-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<'border-top-style'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -3021,7 +3021,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style"
   },
   "border-inline-start-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
The two value shorthands were missing for Logical Properties, these don't currently have any browser support.

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties

