### PR TITLE
Fix -webkit-overflow-scrolling inheritance

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1505,7 +1505,7 @@
   "-webkit-overflow-scrolling": {
     "syntax": "auto | touch",
     "media": "visual",
-    "inherited": false,
+    "inherited": true,
     "animationType": "discrete",
     "percentages": "no",
     "groups": [


### PR DESCRIPTION
This corrects -webkit-overflow-scrolling to be an inherited property. Setting -webkit-overflow-scrolling: touch on an element causes it and its descendants to create stacking contexts, which affects the behavior of z-index.

https://bugs.chromium.org/p/chromium/issues/detail?id=128325#c23