### PR TITLE
Fix border-bottom-color reference syntax

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2509,7 +2509,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom"
   },
   "border-bottom-color": {
-    "syntax": "<border-top-color>",
+    "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
     "animationType": "color",


### PR DESCRIPTION
I got an error when building types with CSSType using your latest changes. I understand this is the way you reference the syntax to another property.