### PR TITLE
scrollbar-width does not take lengths.

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7333,10 +7333,10 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-color"
   },
   "scrollbar-width": {
-    "syntax": "auto | thin | none | <length>",
+    "syntax": "auto | thin | none",
     "media": "visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "discrete",
     "percentages": "no",
     "groups": [
       "CSS Scrollbars"


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1514875 and co. The CSSWG objected to this so it was removed.