### PR TITLE
Bug 1512386: Add the attribute selector case‑sensitive modifier (`s`)

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -21,7 +21,7 @@
     "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
   },
   "attr-modifier": {
-    "syntax": "i"
+    "syntax": "i | s"
   },
   "attribute-selector": {
     "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"


### PR DESCRIPTION
See [bug&nbsp;1512386](https://bugzilla.mozilla.org/show_bug.cgi?id=1512386) for details.

See&nbsp;also: https://github.com/mdn/browser-compat-data/pull/3179 and&nbsp;https://github.com/mdn/browser-compat-data/pull/3212

review?(@chrisdavidmills, @ddbeck)