### PR TITLE
syntax order to match spec

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7323,7 +7323,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/right"
   },
   "rotate": {
-    "syntax": "none | [ x | y | z | <number>{3} ]? && <angle>",
+    "syntax": "none | <angle> | [ x | y | z | <number>{3} ] && <angle>",
     "media": "visual",
     "inherited": false,
     "animationType": "transform",


### PR DESCRIPTION
https://drafts.csswg.org/css-transforms-2/#propdef-rotate

the old syntax and new are actually the same in the end, but the update is easier to decipher and matches what is currently in the spec linked to above.