### PR TITLE
Adding combined types to types.json

### DIFF
--- a/css/types.json
+++ b/css/types.json
@@ -12,6 +12,13 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/angle"
   },
+  "angle-percentage": {
+    "groups": [
+      "CSS Types"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/angle-percentage"
+  },
   "basic-shape": {
     "groups": [
       "CSS Shapes",
@@ -46,6 +53,13 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/custom-ident"
+  },
+  "dimension": {
+    "groups": [
+      "CSS Display"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/dimension"
   },
   "display-outside": {
     "groups": [
@@ -111,6 +125,13 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/frequency"
   },
+  "frequency-percentage": {
+    "groups": [
+      "CSS Types"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/frequency-percentage"
+  },
   "gradient": {
     "groups": [
       "CSS Images",
@@ -146,6 +167,13 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/length"
+  },
+  "length-percentage": {
+    "groups": [
+      "CSS Types"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/length-percentage"
   },
   "number": {
     "groups": [
@@ -202,6 +230,13 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time"
+  },
+  "time-percentage": {
+    "groups": [
+      "CSS Types"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time-percentage"
   },
   "timing-function": {
     "groups": [

--- a/css/types.json
+++ b/css/types.json
@@ -56,7 +56,7 @@
   },
   "dimension": {
     "groups": [
-      "CSS Display"
+      "CSS Types"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/dimension"


### PR DESCRIPTION
This PR adds the combined data types refernced in https://github.com/mdn/browser-compat-data/pull/3353 to types.json so they will show up in the menu.