### PR TITLE
refactor(css‑variables): Simplify `var()` function syntax definition

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -723,7 +723,7 @@
     "syntax": "<wq-name> | <ns-prefix>? '*'"
   },
   "var()": {
-    "syntax": "var( <custom-property-name> [, <declaration-value> ]? )"
+    "syntax": "var( <custom-property-name> , <declaration-value>? )"
   },
   "viewport-length": {
     "syntax": "auto | <length-percentage>"


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/pull/3485 for&nbsp;details.

Part&nbsp;of https://github.com/mdn/data/issues/230

review?(@ddbeck, @tabatkins)