### PR TITLE
Which elements overflow-wrap applies to.

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6738,7 +6738,7 @@
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
+    "appliesto": "nonReplacedInlineElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "standard",
@@ -8787,7 +8787,7 @@
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "allElements",
+    "appliesto": "nonReplacedInlineElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "standard",


### PR DESCRIPTION
Currently reads 'all elements' but spec says 'inline boxes'.
https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
An inline box is a non-replaced inline-level box whose inner display type is flow. 
for #937