### PR TITLE
refactor(api): Sort `inheritance.json`

### DIFF
--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -1,922 +1,20 @@
 {
-  "SVGSymbolElement": {
-    "inherits": "SVGElement",
+  "AnalyserNode": {
+    "inherits": "AudioNode",
     "implements": [
-      "SVGFitToViewBox",
-      "SVGTests"
+      "AudioNodePassThrough"
     ]
   },
-  "TVChannel": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGPolygonElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": [
-      "SVGAnimatedPoints"
-    ]
-  },
-  "HTMLDataElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MozCdmaIccInfo": {
-    "inherits": "MozIccInfo",
-    "implements": []
-  },
-  "TreeBoxObject": {
-    "inherits": "BoxObject",
-    "implements": []
-  },
-  "CSSStyleDeclaration": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "Selection": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "XULElement": {
-    "inherits": "Element",
-    "implements": [
-      "GlobalEventHandlers",
-      "TouchEventHandlers",
-      "MozFrameLoaderOwner",
-      "OnErrorEventHandlerForNodes"
-    ]
-  },
-  "XMLHttpRequestUpload": {
-    "inherits": "XMLHttpRequestEventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "WindowRoot": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "BrowserElement": {
-    "inherits": null,
-    "implements": [
-      "BrowserElementCommon",
-      "BrowserElementPrivileged"
-    ]
-  },
-  "IDBTransaction": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "TVTuner": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "ScrollViewChangeEvent": {
+  "AnimationEvent": {
     "inherits": "Event",
-    "implements": []
-  },
-  "SVGPathSegCurvetoCubicSmoothAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "CameraControl": {
-    "inherits": "MediaStream",
-    "implements": []
-  },
-  "SVGFEMorphologyElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "FetchEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "DeviceOrientationEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLBRElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MozWifiConnectionInfoEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "BroadcastChannel": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "IDBDatabase": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLFormControlsCollection": {
-    "inherits": "HTMLCollection",
-    "implements": []
-  },
-  "WebSocket": {
-    "inherits": "EventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGDescElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "SVGCircleElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": []
-  },
-  "SVGCursorElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "DOMDownload": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGPathSegArcAbs": {
-    "inherits": "SVGPathSeg",
     "implements": []
   },
   "ArchiveRequest": {
     "inherits": "DOMRequest",
     "implements": []
   },
-  "SharedWorkerGlobalScope": {
-    "inherits": "WorkerGlobalScope",
-    "implements": []
-  },
-  "Exception": {
-    "inherits": null,
-    "implements": [
-      "ExceptionMembers"
-    ]
-  },
-  "BluetoothAdapterEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLParagraphElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "AudioDestinationNode": {
-    "inherits": "AudioNode",
-    "implements": []
-  },
-  "ProcessingInstruction": {
-    "inherits": "CharacterData",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "BeforeUnloadEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PseudoElement": {
-    "inherits": null,
-    "implements": [
-      "GeometryUtils"
-    ]
-  },
-  "NetworkInformation": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "MutationObserver": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "NodeList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "CloseEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLAreaElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "HTMLHyperlinkElementUtils",
-      "URLUtilsSearchParams"
-    ]
-  },
-  "HTMLLegendElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGMetadataElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "SVGPathSegList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGForeignObjectElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": []
-  },
-  "SVGPatternElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFitToViewBox",
-      "SVGURIReference",
-      "SVGUnitTypes"
-    ]
-  },
-  "Performance": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLElement": {
-    "inherits": "Element",
-    "implements": [
-      "GlobalEventHandlers",
-      "TouchEventHandlers",
-      "OnErrorEventHandlerForNodes"
-    ]
-  },
-  "HTMLHeadElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MozIcc": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "UDPSocket": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "DocumentType": {
+  "Attr": {
     "inherits": "Node",
-    "implements": [
-      "ChildNode",
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGStopElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "ImageDocument": {
-    "inherits": "HTMLDocument",
-    "implements": []
-  },
-  "SVGElement": {
-    "inherits": "Element",
-    "implements": [
-      "GlobalEventHandlers",
-      "TouchEventHandlers",
-      "OnErrorEventHandlerForNodes"
-    ]
-  },
-  "GamepadEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLTableElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "PerformanceMark": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "InstallEvent": {
-    "inherits": "ExtendableEvent",
-    "implements": []
-  },
-  "FocusEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "OscillatorNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "PluginCrashedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGPathSegLinetoVerticalRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "DocumentFragment": {
-    "inherits": "Node",
-    "implements": [
-      "ParentNode",
-      "LegacyQueryInterface"
-    ]
-  },
-  "OfflineAudioCompletionEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGPoint": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLTitleElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "Window": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface",
-      "GlobalEventHandlers",
-      "WindowEventHandlers",
-      "GlobalCrypto",
-      "SpeechSynthesisGetter",
-      "WindowModal",
-      "TouchEventHandlers",
-      "OnErrorEventHandlerForWindow",
-      "ChromeWindow",
-      "WindowOrWorkerGlobalScope"
-    ]
-  },
-  "WindowClient": {
-    "inherits": "Client",
-    "implements": []
-  },
-  "ErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MessageEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGPathSegCurvetoQuadraticAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "AudioNode": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "MediaDevices": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "CanvasCaptureMediaStream": {
-    "inherits": "MediaStream",
-    "implements": []
-  },
-  "DynamicsCompressorNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "SVGSVGElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": [
-      "SVGFitToViewBox",
-      "SVGZoomAndPan"
-    ]
-  },
-  "File": {
-    "inherits": "Blob",
-    "implements": []
-  },
-  "SVGAnimationElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGTests"
-    ]
-  },
-  "BluetoothPairingEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "ShadowRoot": {
-    "inherits": "DocumentFragment",
-    "implements": []
-  },
-  "ExtendableEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGFEOffsetElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "DesktopNotification": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGGradientElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGURIReference",
-      "SVGUnitTypes"
-    ]
-  },
-  "HTMLMarqueeElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "HTMLMetaElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "Text": {
-    "inherits": "CharacterData",
-    "implements": [
-      "LegacyQueryInterface",
-      "GeometryUtils"
-    ]
-  },
-  "DOMApplication": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "InstallTrigger": {
-    "inherits": null,
-    "implements": []
-  },
-  "MutationEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLLabelElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGGeometryElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": []
-  },
-  "SVGPathElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": [
-      "SVGAnimatedPathData"
-    ]
-  },
-  "HTMLTemplateElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGAnimatedInteger": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGFEDisplacementMapElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "SVGPathSegMovetoAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "XULCommandEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "Crypto": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "Response": {
-    "inherits": null,
-    "implements": [
-      "Body"
-    ]
-  },
-  "SVGZoomEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "SVGLinearGradientElement": {
-    "inherits": "SVGGradientElement",
-    "implements": []
-  },
-  "WebGLContextEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "WebGL2RenderingContext": {
-    "inherits": "WebGLRenderingContext",
-    "implements": []
-  },
-  "SVGFEDistantLightElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "MouseScrollEvent": {
-    "inherits": "MouseEvent",
-    "implements": []
-  },
-  "DOMStringMap": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGAnimateMotionElement": {
-    "inherits": "SVGAnimationElement",
-    "implements": []
-  },
-  "ChannelSplitterNode": {
-    "inherits": "AudioNode",
-    "implements": []
-  },
-  "ListBoxObject": {
-    "inherits": "BoxObject",
-    "implements": []
-  },
-  "MozGsmIccInfo": {
-    "inherits": "MozIccInfo",
-    "implements": []
-  },
-  "TrackEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGStyleElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "PresentationDeviceInfoManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "NodeIterator": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGAltGlyphElement": {
-    "inherits": "SVGTextPositioningElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "SVGFEGaussianBlurElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "MozMobileConnection": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGFEConvolveMatrixElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "FileList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "Document": {
-    "inherits": "Node",
-    "implements": [
-      "XPathEvaluator",
-      "GlobalEventHandlers",
-      "TouchEventHandlers",
-      "ParentNode",
-      "OnErrorEventHandlerForNodes",
-      "GeometryUtils",
-      "FontFaceSource",
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGAnimatedEnumeration": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozStkCommandEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLFontElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SharedWorker": {
-    "inherits": "EventTarget",
-    "implements": [
-      "AbstractWorker"
-    ]
-  },
-  "RecordErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "DelayNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "SVGPathSegCurvetoCubicAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "BluetoothGatt": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "CameraClosedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGMaskElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGUnitTypes"
-    ]
-  },
-  "ContactManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "ProgressEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "ServiceWorker": {
-    "inherits": "EventTarget",
-    "implements": [
-      "AbstractWorker"
-    ]
-  },
-  "SVGPathSegLinetoHorizontalAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "CharacterData": {
-    "inherits": "Node",
-    "implements": [
-      "ChildNode",
-      "NonDocumentTypeChildNode"
-    ]
-  },
-  "KeyboardEvent": {
-    "inherits": "UIEvent",
-    "implements": [
-      "KeyEvent"
-    ]
-  },
-  "TelephonyCall": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "WorkerNavigator": {
-    "inherits": null,
-    "implements": [
-      "NavigatorID",
-      "NavigatorLanguage",
-      "NavigatorOnLine",
-      "NavigatorDataStore"
-    ]
-  },
-  "PopupBlockedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MediaElementAudioSourceNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "HTMLFrameSetElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "WindowEventHandlers"
-    ]
-  },
-  "BluetoothManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGFilterElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGURIReference",
-      "SVGUnitTypes"
-    ]
-  },
-  "SVGClipPathElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGUnitTypes"
-    ]
-  },
-  "SVGLineElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": []
-  },
-  "SpeechRecognitionEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGPointList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGFEDropShadowElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "HTMLQuoteElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGFESpotLightElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "ServiceWorkerContainer": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLContentElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "HTMLOutputElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "DataStoreChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "Plugin": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGStringList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGRectElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": []
-  },
-  "HTMLUListElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "History": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SpeechRecognition": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "AnimationEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "TouchEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "IDBMutableFile": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "Range": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "CameraStateChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MediaStreamAudioDestinationNode": {
-    "inherits": "AudioNode",
-    "implements": []
-  },
-  "HTMLMenuItemElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MediaSource": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "PannerNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "MozNFCPeerEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "GamepadButtonEvent": {
-    "inherits": "GamepadEvent",
-    "implements": []
-  },
-  "IDBRequest": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGLengthList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLDataListElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "HTMLFieldSetElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "BluetoothDiscoveryHandle": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGDefsElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": []
-  },
-  "SVGTextElement": {
-    "inherits": "SVGTextPositioningElement",
-    "implements": []
-  },
-  "SVGScriptElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "InputEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "HTMLShadowElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "XPathEvaluator": {
-    "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
@@ -927,299 +25,119 @@
       "AudioNodePassThrough"
     ]
   },
-  "MozNFCTagEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PageTransitionEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PopStateEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "Element": {
-    "inherits": "Node",
-    "implements": [
-      "ChildNode",
-      "NonDocumentTypeChildNode",
-      "ParentNode",
-      "Animatable",
-      "GeometryUtils",
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLInputElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozImageLoadingContent",
-      "MozPhonetic"
-    ]
-  },
-  "ValidityState": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGAElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "DedicatedWorkerGlobalScope": {
-    "inherits": "WorkerGlobalScope",
-    "implements": []
-  },
-  "HTMLTimeElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "IDBFileHandle": {
+  "AudioChannelManager": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "MediaKeyError": {
-    "inherits": "Event",
+  "AudioContext": {
+    "inherits": "BaseAudioContext",
     "implements": []
   },
-  "StyleSheet": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "URL": {
-    "inherits": null,
-    "implements": [
-      "URLUtils",
-      "URLUtilsSearchParams"
-    ]
-  },
-  "XMLHttpRequest": {
-    "inherits": "XMLHttpRequestEventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozMessageDeletedEvent": {
-    "inherits": "Event",
+  "AudioDestinationNode": {
+    "inherits": "AudioNode",
     "implements": []
   },
-  "SVGPathSegCurvetoQuadraticSmoothRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "RTCPeerConnectionIdentityErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "RTCTrackEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "RTCDTMFSender": {
+  "AudioNode": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "RTCDTMFToneChangeEvent": {
+  "AudioProcessingEvent": {
     "inherits": "Event",
+    "implements": []
+  },
+  "AudioScheduledSourceNode": {
+    "inherits": "AudioNode",
     "implements": []
   },
   "AudioStreamTrack": {
     "inherits": "MediaStreamTrack",
     "implements": []
   },
-  "HTMLSelectElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "DOMCursor": {
-    "inherits": "EventTarget",
-    "implements": [
-      "DOMRequestShared"
-    ]
-  },
-  "TextTrackList": {
+  "AudioTrackList": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "MozIccManager": {
-    "inherits": "EventTarget",
+  "AutocompleteErrorEvent": {
+    "inherits": "Event",
     "implements": []
   },
-  "ScrollBoxObject": {
-    "inherits": "BoxObject",
-    "implements": []
-  },
-  "NamedNodeMap": {
+  "BarProp": {
     "inherits": null,
     "implements": [
       "LegacyQueryInterface"
     ]
   },
-  "SVGFEFloodElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "DOMDownloadManager": {
+  "BaseAudioContext": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "DataContainerEvent": {
+  "BatteryManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "BeforeAfterKeyboardEvent": {
+    "inherits": "KeyboardEvent",
+    "implements": []
+  },
+  "BeforeInstallPromptEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "IccCardLockError": {
-    "inherits": "DOMError",
-    "implements": []
-  },
-  "TelephonyCallGroup": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "TVManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SelectionStateChangedEvent": {
+  "BeforeUnloadEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "CSSValueList": {
-    "inherits": "CSSValue",
+  "BiquadFilterNode": {
+    "inherits": "AudioNode",
     "implements": [
-      "LegacyQueryInterface"
+      "AudioNodePassThrough"
     ]
   },
-  "VideoTrackList": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SettingsLock": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "PerformanceMeasure": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "HTMLOptionsCollection": {
-    "inherits": "HTMLCollection",
-    "implements": []
-  },
-  "TVCurrentChannelChangedEvent": {
+  "BlobEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "WorkerGlobalScope": {
-    "inherits": "EventTarget",
-    "implements": [
-      "GlobalCrypto",
-      "WindowOrWorkerGlobalScope"
-    ]
-  },
-  "MouseEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "SVGPathSegLinetoAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "HTMLAppletElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozImageLoadingContent",
-      "MozFrameLoaderOwner",
-      "MozObjectLoadingContent"
-    ]
-  },
-  "LocalMediaStream": {
-    "inherits": "MediaStream",
-    "implements": []
-  },
-  "HTMLOptionElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "TVSource": {
+  "BluetoothAdapter": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "StyleRuleChangeEvent": {
+  "BluetoothAdapterEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "HTMLMeterElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "AudioChannelManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "MediaRecorder": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGPreserveAspectRatio": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "TransitionEvent": {
+  "BluetoothAttributeEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "HTMLBodyElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "WindowEventHandlers"
-    ]
-  },
-  "MozVoicemail": {
+  "BluetoothDevice": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "HTMLDivElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGPolylineElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": [
-      "SVGAnimatedPoints"
-    ]
-  },
-  "IDBVersionChangeEvent": {
+  "BluetoothDeviceEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "Clipboard": {
+  "BluetoothDiscoveryHandle": {
     "inherits": "EventTarget",
     "implements": []
   },
-  "ClipboardEvent": {
+  "BluetoothDiscoveryStateChangedEvent": {
     "inherits": "Event",
     "implements": []
   },
-  "SVGFEMergeNodeElement": {
-    "inherits": "SVGElement",
+  "BluetoothGatt": {
+    "inherits": "EventTarget",
     "implements": []
   },
-  "MessagePort": {
+  "BluetoothManager": {
     "inherits": "EventTarget",
-    "implements": [
-      "Transferable"
-    ]
+    "implements": []
   },
-  "MozVoicemailEvent": {
+  "BluetoothPairingEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "BluetoothStatusChangedEvent": {
     "inherits": "Event",
     "implements": []
   },
@@ -1229,1264 +147,22 @@
       "LegacyQueryInterface"
     ]
   },
-  "BluetoothAttributeEvent": {
-    "inherits": "Event",
+  "BroadcastChannel": {
+    "inherits": "EventTarget",
     "implements": []
   },
-  "CSSPrimitiveValue": {
-    "inherits": "CSSValue",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "PaintRequestList": {
+  "BrowserElement": {
     "inherits": null,
     "implements": [
-      "LegacyQueryInterface"
+      "BrowserElementCommon",
+      "BrowserElementPrivileged"
     ]
-  },
-  "MediaStreamAudioSourceNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "AudioScheduledSourceNode": {
-    "inherits": "AudioNode",
-    "implements": []
-  },
-  "ConstantSourceNode": {
-    "inherits": "AudioScheduledSourceNode",
-    "implements": []
-  },
-  "BaseAudioContext": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "AudioProcessingEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "Attr": {
-    "inherits": "Node",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLObjectElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozImageLoadingContent",
-      "MozFrameLoaderOwner",
-      "MozObjectLoadingContent"
-    ]
-  },
-  "SVGFEPointLightElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "SVGAnimatedString": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGGElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": []
-  },
-  "VRFieldOfView": {
-    "inherits": "VRFieldOfViewReadOnly",
-    "implements": []
-  },
-  "HTMLTableSectionElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MutationRecord": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MediaKeySession": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "DataErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "Worker": {
-    "inherits": "EventTarget",
-    "implements": [
-      "AbstractWorker"
-    ]
-  },
-  "HTMLTableColElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "IccChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLSpanElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MozActivity": {
-    "inherits": "DOMRequest",
-    "implements": []
-  },
-  "PerformanceResourceTiming": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "HTMLCollection": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "USSDReceivedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLMapElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "ImageCapture": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "AudioTrackList": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLSourceElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "Navigator": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface",
-      "NavigatorID",
-      "NavigatorLanguage",
-      "NavigatorOnLine",
-      "NavigatorContentUtils",
-      "NavigatorStorageUtils",
-      "NavigatorFeatures",
-      "NavigatorGeolocation",
-      "NavigatorBattery",
-      "NavigatorDataStore",
-      "NavigatorMobileId"
-    ]
-  },
-  "OfflineAudioContext": {
-    "inherits": "BaseAudioContext",
-    "implements": []
-  },
-  "SVGPathSegCurvetoCubicSmoothRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "SVGAnimatedPreserveAspectRatio": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozContactChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLMediaElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "DeviceStorage": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGImageElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": [
-      "MozImageLoadingContent",
-      "SVGURIReference"
-    ]
-  },
-  "UIEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGTransformList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozSpeakerManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "MozCellBroadcast": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGAnimateTransformElement": {
-    "inherits": "SVGAnimationElement",
-    "implements": []
-  },
-  "SVGFEBlendElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "CSSStyleSheet": {
-    "inherits": "StyleSheet",
-    "implements": []
-  },
-  "SVGPathSegArcRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "MozCellBroadcastEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "FMRadio": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLTableCellElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "ChromeWorker": {
-    "inherits": "Worker",
-    "implements": []
-  },
-  "Telephony": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGFECompositeElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "Event": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLButtonElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "ScrollAreaEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "IDBOpenDBRequest": {
-    "inherits": "IDBRequest",
-    "implements": []
-  },
-  "SVGComponentTransferFunctionElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "SVGPathSegLinetoVerticalAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "SVGTSpanElement": {
-    "inherits": "SVGTextPositioningElement",
-    "implements": []
-  },
-  "TVScanningStateChangedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "BluetoothDevice": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLProgressElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MozOtaStatusEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLOptGroupElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "GamepadAxisMoveEvent": {
-    "inherits": "GamepadEvent",
-    "implements": []
-  },
-  "XULDocument": {
-    "inherits": "Document",
-    "implements": []
-  },
-  "Notification": {
-    "inherits": "EventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "DOMPoint": {
-    "inherits": "DOMPointReadOnly",
-    "implements": []
-  },
-  "HMDVRDevice": {
-    "inherits": "VRDevice",
-    "implements": []
-  },
-  "SVGFEFuncRElement": {
-    "inherits": "SVGComponentTransferFunctionElement",
-    "implements": []
-  },
-  "MediaStreamTrackEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "RTCDataChannel": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "AudioContext": {
-    "inherits": "BaseAudioContext",
-    "implements": []
-  },
-  "RTCPeerConnectionIdentityEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "VTTCue": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "ServiceWorkerGlobalScope": {
-    "inherits": "WorkerGlobalScope",
-    "implements": [
-      "GlobalFetch"
-    ]
-  },
-  "PopupBoxObject": {
-    "inherits": "BoxObject",
-    "implements": []
-  },
-  "SpeechSynthesisUtterance": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "TreeColumns": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGDocument": {
-    "inherits": "Document",
-    "implements": []
-  },
-  "MozMobileMessageManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGFEFuncBElement": {
-    "inherits": "SVGComponentTransferFunctionElement",
-    "implements": []
-  },
-  "HTMLDListElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "DOMRect": {
-    "inherits": "DOMRectReadOnly",
-    "implements": []
-  },
-  "HTMLHtmlElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGFEMergeElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "ContainerBoxObject": {
-    "inherits": "BoxObject",
-    "implements": []
-  },
-  "CameraConfigurationEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MozAbortablePromise": {
-    "inherits": "_Promise",
-    "implements": []
-  },
-  "RTCPeerConnection": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGFESpecularLightingElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "XMLDocument": {
-    "inherits": "Document",
-    "implements": []
-  },
-  "DownloadEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "WorkerLocation": {
-    "inherits": null,
-    "implements": [
-      "URLUtilsReadOnly"
-    ]
-  },
-  "PositionSensorVRDevice": {
-    "inherits": "VRDevice",
-    "implements": []
-  },
-  "BeforeAfterKeyboardEvent": {
-    "inherits": "KeyboardEvent",
-    "implements": []
-  },
-  "SVGFEColorMatrixElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "CallEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "BlobEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLUnknownElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "TouchList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "DOMTransactionEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGPathSegCurvetoQuadraticRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "SVGAnimateElement": {
-    "inherits": "SVGAnimationElement",
-    "implements": []
-  },
-  "DOMParser": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGEllipseElement": {
-    "inherits": "SVGGeometryElement",
-    "implements": []
-  },
-  "SimpleGestureEvent": {
-    "inherits": "MouseEvent",
-    "implements": []
-  },
-  "NotifyPaintEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGTextPathElement": {
-    "inherits": "SVGTextContentElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "HTMLDocument": {
-    "inherits": "Document",
-    "implements": []
-  },
-  "CameraFacesDetectedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "CustomEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "TimeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "DOMException": {
-    "inherits": null,
-    "implements": [
-      "ExceptionMembers"
-    ]
-  },
-  "IDBCursorWithValue": {
-    "inherits": "IDBCursor",
-    "implements": []
-  },
-  "SVGMPathElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "CommandEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MozInterAppMessageEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLAudioElement": {
-    "inherits": "HTMLMediaElement",
-    "implements": []
-  },
-  "SVGViewElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFitToViewBox",
-      "SVGZoomAndPan"
-    ]
-  },
-  "SVGTextPositioningElement": {
-    "inherits": "SVGTextContentElement",
-    "implements": []
-  },
-  "SVGTextContentElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": []
-  },
-  "Location": {
-    "inherits": null,
-    "implements": []
-  },
-  "FontFaceSet": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "TVCurrentSourceChangedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "Touch": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozSettingsEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "BluetoothAdapter": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGPathSegMovetoRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "RTCDataChannelEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLModElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "BluetoothStatusChangedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SpeechSynthesisEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGTitleElement": {
-    "inherits": "SVGElement",
-    "implements": []
-  },
-  "DOMApplicationsManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SettingsManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "MenuBoxObject": {
-    "inherits": "BoxObject",
-    "implements": []
-  },
-  "Screen": {
-    "inherits": "EventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozClirModeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLEmbedElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozImageLoadingContent",
-      "MozFrameLoaderOwner",
-      "MozObjectLoadingContent"
-    ]
-  },
-  "OfflineResourceList": {
-    "inherits": "EventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGPathSegClosePath": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "ConvolverNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "BluetoothDiscoveryStateChangedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PropertyNodeList": {
-    "inherits": "NodeList",
-    "implements": []
-  },
-  "HTMLStyleElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "LinkStyle"
-    ]
-  },
-  "DataStore": {
-    "inherits": "EventTarget",
-    "implements": []
   },
   "CDATASection": {
     "inherits": "Text",
     "implements": []
   },
-  "SourceBufferList": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "StorageEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MozEmergencyCbModeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PluginArray": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGFETurbulenceElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "MozInterAppMessagePort": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "SVGNumberList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozWifiStatusChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGFETileElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "CaretPosition": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGPathSegCurvetoCubicRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "Request": {
-    "inherits": null,
-    "implements": [
-      "Body"
-    ]
-  },
-  "SVGAnimatedNumber": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGFEDiffuseLightingElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "TreeWalker": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "BarProp": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLLinkElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "LinkStyle"
-    ]
-  },
-  "SVGUseElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": [
-      "SVGURIReference"
-    ]
-  },
-  "HTMLCanvasElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGPathSegLinetoHorizontalRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "HTMLParamElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SourceBuffer": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HashChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PointerEvent": {
-    "inherits": "MouseEvent",
-    "implements": []
-  },
-  "FileReader": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "Comment": {
-    "inherits": "CharacterData",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MozMmsEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "BatteryManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "DOMMatrix": {
-    "inherits": "DOMMatrixReadOnly",
-    "implements": []
-  },
-  "SVGSwitchElement": {
-    "inherits": "SVGGraphicsElement",
-    "implements": []
-  },
-  "SVGFEImageElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes",
-      "SVGURIReference"
-    ]
-  },
-  "HTMLScriptElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "HTMLPictureElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "ServiceWorkerRegistration": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLVideoElement": {
-    "inherits": "HTMLMediaElement",
-    "implements": []
-  },
-  "IDBFileRequest": {
-    "inherits": "DOMRequest",
-    "implements": []
-  },
-  "SVGAnimatedNumberList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "RTCPeerConnectionIceEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "PaintRequest": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLMenuElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "EngineeringMode": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "BluetoothDeviceEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "DeviceLightEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "GainNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "MozApplicationEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGFEFuncAElement": {
-    "inherits": "SVGComponentTransferFunctionElement",
-    "implements": []
-  },
-  "StyleSheetApplicableStateChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "TVEITBroadcastedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "UndoManager": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "XMLSerializer": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "SVGPathSegCurvetoQuadraticSmoothAbs": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "WaveShaperNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "VideoStreamTrack": {
-    "inherits": "MediaStreamTrack",
-    "implements": []
-  },
-  "DOMImplementation": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLTableCaptionElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGMarkerElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFitToViewBox"
-    ]
-  },
-  "MozWifiManager": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLPreElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "Rect": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "DeviceStorageChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "DOMMobileMessageError": {
-    "inherits": "DOMError",
-    "implements": []
-  },
-  "CSSFontFaceLoadEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLHeadingElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGRadialGradientElement": {
-    "inherits": "SVGGradientElement",
-    "implements": []
-  },
-  "DeviceProximityEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "EventSource": {
-    "inherits": "EventTarget",
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "StereoPannerNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "AutocompleteErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLFrameElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozFrameLoaderOwner"
-    ]
-  },
-  "HTMLOListElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "RadioNodeList": {
-    "inherits": "NodeList",
-    "implements": []
-  },
-  "StyleSheetChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "TextTrack": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLBaseElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "AnalyserNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "MediaStream": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLTableRowElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "UserProximityEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "DragEvent": {
-    "inherits": "MouseEvent",
-    "implements": []
-  },
-  "HTMLHRElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "BiquadFilterNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "ScriptProcessorNode": {
-    "inherits": "AudioNode",
-    "implements": [
-      "AudioNodePassThrough"
-    ]
-  },
-  "MimeTypeArray": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "HTMLIFrameElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozFrameLoaderOwner",
-      "BrowserElement"
-    ]
-  },
-  "FormData": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "MediaKeyMessageEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MozNFC": {
-    "inherits": "EventTarget",
-    "implements": [
-      "MozNFCManager"
-    ]
-  },
-  "HTMLLIElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "DOMTokenList": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "XMLStylesheetProcessingInstruction": {
-    "inherits": "ProcessingInstruction",
-    "implements": []
-  },
-  "MozSettingsTransactionEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGFEComponentTransferElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGFilterPrimitiveStandardAttributes"
-    ]
-  },
-  "MozSmsEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLDirectoryElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "MediaEncryptedEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
   "CFStateChangeEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLTrackElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGPathSegLinetoRel": {
-    "inherits": "SVGPathSeg",
-    "implements": []
-  },
-  "WheelEvent": {
-    "inherits": "MouseEvent",
-    "implements": []
-  },
-  "Node": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "MozWifiStationInfoEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGRect": {
-    "inherits": null,
-    "implements": [
-      "LegacyQueryInterface"
-    ]
-  },
-  "DOMSettableTokenList": {
-    "inherits": "DOMTokenList",
-    "implements": []
-  },
-  "HTMLImageElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "MozImageLoadingContent"
-    ]
-  },
-  "DOMRequest": {
-    "inherits": "EventTarget",
-    "implements": [
-      "DOMRequestShared"
-    ]
-  },
-  "HTMLFormElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "SVGGraphicsElement": {
-    "inherits": "SVGElement",
-    "implements": [
-      "SVGTests"
-    ]
-  },
-  "DeviceMotionEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "CompositionEvent": {
-    "inherits": "UIEvent",
-    "implements": []
-  },
-  "SpeechRecognitionError": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "CallGroupErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MozInputMethod": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "UDPMessageEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "MediaStreamEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "HTMLTextAreaElement": {
-    "inherits": "HTMLElement",
-    "implements": []
-  },
-  "XMLHttpRequestEventTarget": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "HTMLAnchorElement": {
-    "inherits": "HTMLElement",
-    "implements": [
-      "HTMLHyperlinkElementUtils",
-      "URLUtilsSearchParams"
-    ]
-  },
-  "HTMLPropertiesCollection": {
-    "inherits": "HTMLCollection",
-    "implements": []
-  },
-  "SVGFEFuncGElement": {
-    "inherits": "SVGComponentTransferFunctionElement",
-    "implements": []
-  },
-  "ImageCaptureErrorEvent": {
-    "inherits": "Event",
-    "implements": []
-  },
-  "SVGSetElement": {
-    "inherits": "SVGAnimationElement",
-    "implements": []
-  },
-  "ChannelMergerNode": {
-    "inherits": "AudioNode",
-    "implements": []
-  },
-  "SyncEvent": {
-    "inherits": "ExtendableEvent",
-    "implements": []
-  },
-  "OffscreenCanvas": {
-    "inherits": "EventTarget",
-    "implements": []
-  },
-  "PromiseRejectionEvent": {
     "inherits": "Event",
     "implements": []
   },
@@ -2494,37 +170,9 @@
     "inherits": "CSSRule",
     "implements": []
   },
-  "PerformanceLongTaskTiming": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "TaskAttributionTiming": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "BeforeInstallPromptEvent": {
+  "CSSFontFaceLoadEvent": {
     "inherits": "Event",
     "implements": []
-  },
-  "PerformanceNavigationTiming": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "PerformancePaintTiming": {
-    "inherits": "PerformanceEntry",
-    "implements": []
-  },
-  "CSSStyleValue": {
-    "inherits": null,
-    "implements": [
-      "CSSImageValue",
-      "CSSKeywordValue",
-      "CSSNumericValue",
-      "CSSPositionValue",
-      "CSSTransformValue",
-      "CSSUnitValue",
-      "CSSUnparsedValue"
-    ]
   },
   "CSSImageValue": {
     "inherits": "CSSStyleValue",
@@ -2533,24 +181,6 @@
   "CSSKeywordValue": {
     "inherits": "CSSStyleValue",
     "implements": []
-  },
-  "CSSNumericValue": {
-    "inherits": "CSSStyleValue",
-    "implements": [
-      "CSSMathValue",
-      "CSSUnitValue"
-    ]
-  },
-  "CSSMathValue": {
-    "inherits": "CSSNumericValue",
-    "implements": [
-      "CSSMathInvert",
-      "CSSMathMax",
-      "CSSMathMin",
-      "CSSMathNegate",
-      "CSSMathProduct",
-      "CSSMathSum"
-    ]
   },
   "CSSMathInvert": {
     "inherits": "CSSMathValue",
@@ -2576,42 +206,41 @@
     "inherits": "CSSMathValue",
     "implements": []
   },
-  "CSSUnitValue": {
+  "CSSMathValue": {
     "inherits": "CSSNumericValue",
-    "implements": []
-  },
-  "CSSPositionValue": {
-    "inherits": "CSSStyleValue",
-    "implements": []
-  },
-  "CSSTransformValue": {
-    "inherits": "CSSStyleValue",
-    "implements": []
-  },
-  "CSSUnparsedValue": {
-    "inherits": "CSSStyleValue",
-    "implements": []
-  },
-  "CSSTransformComponent": {
-    "inherits": null,
     "implements": [
-      "CSSMatrixComponent",
-      "CSSPerspective",
-      "CSSRotate",
-      "CSSScale",
-      "CSSSkew",
-      "CSSSkewX",
-      "CSSSkewY",
-      "CSSTranslate"
+      "CSSMathInvert",
+      "CSSMathMax",
+      "CSSMathMin",
+      "CSSMathNegate",
+      "CSSMathProduct",
+      "CSSMathSum"
     ]
   },
   "CSSMatrixComponent": {
     "inherits": "CSSTransformComponent",
     "implements": []
   },
+  "CSSNumericValue": {
+    "inherits": "CSSStyleValue",
+    "implements": [
+      "CSSMathValue",
+      "CSSUnitValue"
+    ]
+  },
   "CSSPerspective": {
     "inherits": "CSSTransformComponent",
     "implements": []
+  },
+  "CSSPositionValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSPrimitiveValue": {
+    "inherits": "CSSValue",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
   },
   "CSSRotate": {
     "inherits": "CSSTransformComponent",
@@ -2633,8 +262,2071 @@
     "inherits": "CSSTransformComponent",
     "implements": []
   },
+  "CSSStyleDeclaration": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "CSSStyleSheet": {
+    "inherits": "StyleSheet",
+    "implements": []
+  },
+  "CSSStyleValue": {
+    "inherits": null,
+    "implements": [
+      "CSSImageValue",
+      "CSSKeywordValue",
+      "CSSNumericValue",
+      "CSSPositionValue",
+      "CSSTransformValue",
+      "CSSUnitValue",
+      "CSSUnparsedValue"
+    ]
+  },
+  "CSSTransformComponent": {
+    "inherits": null,
+    "implements": [
+      "CSSMatrixComponent",
+      "CSSPerspective",
+      "CSSRotate",
+      "CSSScale",
+      "CSSSkew",
+      "CSSSkewX",
+      "CSSSkewY",
+      "CSSTranslate"
+    ]
+  },
+  "CSSTransformValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
   "CSSTranslate": {
     "inherits": "CSSTransformComponent",
+    "implements": []
+  },
+  "CSSUnitValue": {
+    "inherits": "CSSNumericValue",
+    "implements": []
+  },
+  "CSSUnparsedValue": {
+    "inherits": "CSSStyleValue",
+    "implements": []
+  },
+  "CSSValueList": {
+    "inherits": "CSSValue",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "CallEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CallGroupErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CameraClosedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CameraConfigurationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CameraControl": {
+    "inherits": "MediaStream",
+    "implements": []
+  },
+  "CameraFacesDetectedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CameraStateChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CanvasCaptureMediaStream": {
+    "inherits": "MediaStream",
+    "implements": []
+  },
+  "CaretPosition": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "ChannelMergerNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "ChannelSplitterNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "CharacterData": {
+    "inherits": "Node",
+    "implements": [
+      "ChildNode",
+      "NonDocumentTypeChildNode"
+    ]
+  },
+  "ChromeWorker": {
+    "inherits": "Worker",
+    "implements": []
+  },
+  "Clipboard": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ClipboardEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CloseEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "CommandEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Comment": {
+    "inherits": "CharacterData",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "CompositionEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "ConstantSourceNode": {
+    "inherits": "AudioScheduledSourceNode",
+    "implements": []
+  },
+  "ContactManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ContainerBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "ConvolverNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "Crypto": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "CustomEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DOMApplication": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DOMApplicationsManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DOMCursor": {
+    "inherits": "EventTarget",
+    "implements": [
+      "DOMRequestShared"
+    ]
+  },
+  "DOMDownload": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DOMDownloadManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DOMException": {
+    "inherits": null,
+    "implements": [
+      "ExceptionMembers"
+    ]
+  },
+  "DOMImplementation": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMMatrix": {
+    "inherits": "DOMMatrixReadOnly",
+    "implements": []
+  },
+  "DOMMobileMessageError": {
+    "inherits": "DOMError",
+    "implements": []
+  },
+  "DOMParser": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMPoint": {
+    "inherits": "DOMPointReadOnly",
+    "implements": []
+  },
+  "DOMRect": {
+    "inherits": "DOMRectReadOnly",
+    "implements": []
+  },
+  "DOMRequest": {
+    "inherits": "EventTarget",
+    "implements": [
+      "DOMRequestShared"
+    ]
+  },
+  "DOMSettableTokenList": {
+    "inherits": "DOMTokenList",
+    "implements": []
+  },
+  "DOMStringMap": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMTokenList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "DOMTransactionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DataContainerEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DataErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DataStore": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DataStoreChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DedicatedWorkerGlobalScope": {
+    "inherits": "WorkerGlobalScope",
+    "implements": []
+  },
+  "DelayNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "DesktopNotification": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DeviceLightEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DeviceMotionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DeviceOrientationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DeviceProximityEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DeviceStorage": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "DeviceStorageChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Document": {
+    "inherits": "Node",
+    "implements": [
+      "FontFaceSource",
+      "GeometryUtils",
+      "GlobalEventHandlers",
+      "LegacyQueryInterface",
+      "OnErrorEventHandlerForNodes",
+      "ParentNode",
+      "TouchEventHandlers",
+      "XPathEvaluator"
+    ]
+  },
+  "DocumentFragment": {
+    "inherits": "Node",
+    "implements": [
+      "LegacyQueryInterface",
+      "ParentNode"
+    ]
+  },
+  "DocumentType": {
+    "inherits": "Node",
+    "implements": [
+      "ChildNode",
+      "LegacyQueryInterface"
+    ]
+  },
+  "DownloadEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "DragEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "DynamicsCompressorNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "Element": {
+    "inherits": "Node",
+    "implements": [
+      "Animatable",
+      "ChildNode",
+      "GeometryUtils",
+      "LegacyQueryInterface",
+      "NonDocumentTypeChildNode",
+      "ParentNode"
+    ]
+  },
+  "EngineeringMode": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Event": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "EventSource": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Exception": {
+    "inherits": null,
+    "implements": [
+      "ExceptionMembers"
+    ]
+  },
+  "ExtendableEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "FMRadio": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "FetchEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "File": {
+    "inherits": "Blob",
+    "implements": []
+  },
+  "FileList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "FileReader": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "FocusEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "FontFaceSet": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "FormData": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "GainNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "GamepadAxisMoveEvent": {
+    "inherits": "GamepadEvent",
+    "implements": []
+  },
+  "GamepadButtonEvent": {
+    "inherits": "GamepadEvent",
+    "implements": []
+  },
+  "GamepadEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "HMDVRDevice": {
+    "inherits": "VRDevice",
+    "implements": []
+  },
+  "HTMLAnchorElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "HTMLHyperlinkElementUtils",
+      "URLUtilsSearchParams"
+    ]
+  },
+  "HTMLAppletElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozFrameLoaderOwner",
+      "MozImageLoadingContent",
+      "MozObjectLoadingContent"
+    ]
+  },
+  "HTMLAreaElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "HTMLHyperlinkElementUtils",
+      "URLUtilsSearchParams"
+    ]
+  },
+  "HTMLAudioElement": {
+    "inherits": "HTMLMediaElement",
+    "implements": []
+  },
+  "HTMLBRElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLBaseElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLBodyElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "WindowEventHandlers"
+    ]
+  },
+  "HTMLButtonElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLCanvasElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLCollection": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "HTMLContentElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLDListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLDataElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLDataListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLDirectoryElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLDivElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "HTMLElement": {
+    "inherits": "Element",
+    "implements": [
+      "GlobalEventHandlers",
+      "OnErrorEventHandlerForNodes",
+      "TouchEventHandlers"
+    ]
+  },
+  "HTMLEmbedElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozFrameLoaderOwner",
+      "MozImageLoadingContent",
+      "MozObjectLoadingContent"
+    ]
+  },
+  "HTMLFieldSetElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLFontElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLFormControlsCollection": {
+    "inherits": "HTMLCollection",
+    "implements": []
+  },
+  "HTMLFormElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLFrameElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozFrameLoaderOwner"
+    ]
+  },
+  "HTMLFrameSetElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "WindowEventHandlers"
+    ]
+  },
+  "HTMLHRElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLHeadElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLHeadingElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLHtmlElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLIFrameElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "BrowserElement",
+      "MozFrameLoaderOwner"
+    ]
+  },
+  "HTMLImageElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent"
+    ]
+  },
+  "HTMLInputElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "MozPhonetic"
+    ]
+  },
+  "HTMLLIElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLLabelElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLLegendElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLLinkElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "LinkStyle"
+    ]
+  },
+  "HTMLMapElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLMarqueeElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLMediaElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLMenuElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLMenuItemElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLMetaElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLMeterElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLModElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLOListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLObjectElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "MozFrameLoaderOwner",
+      "MozImageLoadingContent",
+      "MozObjectLoadingContent"
+    ]
+  },
+  "HTMLOptGroupElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLOptionElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLOptionsCollection": {
+    "inherits": "HTMLCollection",
+    "implements": []
+  },
+  "HTMLOutputElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLParagraphElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLParamElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLPictureElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLPreElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLProgressElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLPropertiesCollection": {
+    "inherits": "HTMLCollection",
+    "implements": []
+  },
+  "HTMLQuoteElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLScriptElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLSelectElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLShadowElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLSourceElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLSpanElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLStyleElement": {
+    "inherits": "HTMLElement",
+    "implements": [
+      "LinkStyle"
+    ]
+  },
+  "HTMLTableCaptionElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTableCellElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTableColElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTableElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTableRowElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTableSectionElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTemplateElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTextAreaElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTimeElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTitleElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLTrackElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLUListElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLUnknownElement": {
+    "inherits": "HTMLElement",
+    "implements": []
+  },
+  "HTMLVideoElement": {
+    "inherits": "HTMLMediaElement",
+    "implements": []
+  },
+  "HashChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "History": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "IDBCursorWithValue": {
+    "inherits": "IDBCursor",
+    "implements": []
+  },
+  "IDBDatabase": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "IDBFileHandle": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "IDBFileRequest": {
+    "inherits": "DOMRequest",
+    "implements": []
+  },
+  "IDBMutableFile": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "IDBOpenDBRequest": {
+    "inherits": "IDBRequest",
+    "implements": []
+  },
+  "IDBRequest": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "IDBTransaction": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "IDBVersionChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "IccCardLockError": {
+    "inherits": "DOMError",
+    "implements": []
+  },
+  "IccChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "ImageCapture": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ImageCaptureErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "ImageDocument": {
+    "inherits": "HTMLDocument",
+    "implements": []
+  },
+  "InputEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "InstallEvent": {
+    "inherits": "ExtendableEvent",
+    "implements": []
+  },
+  "InstallTrigger": {
+    "inherits": null,
+    "implements": []
+  },
+  "KeyboardEvent": {
+    "inherits": "UIEvent",
+    "implements": [
+      "KeyEvent"
+    ]
+  },
+  "ListBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "LocalMediaStream": {
+    "inherits": "MediaStream",
+    "implements": []
+  },
+  "Location": {
+    "inherits": null,
+    "implements": []
+  },
+  "MediaDevices": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaElementAudioSourceNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MediaEncryptedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaKeyError": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaKeyMessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaKeySession": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaRecorder": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaSource": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaStream": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MediaStreamAudioDestinationNode": {
+    "inherits": "AudioNode",
+    "implements": []
+  },
+  "MediaStreamAudioSourceNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "MediaStreamEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MediaStreamTrackEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MenuBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "MessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MessagePort": {
+    "inherits": "EventTarget",
+    "implements": [
+      "Transferable"
+    ]
+  },
+  "MimeTypeArray": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MouseEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "MouseScrollEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "MozAbortablePromise": {
+    "inherits": "_Promise",
+    "implements": []
+  },
+  "MozActivity": {
+    "inherits": "DOMRequest",
+    "implements": []
+  },
+  "MozApplicationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozCdmaIccInfo": {
+    "inherits": "MozIccInfo",
+    "implements": []
+  },
+  "MozCellBroadcast": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozCellBroadcastEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozClirModeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozContactChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozEmergencyCbModeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozGsmIccInfo": {
+    "inherits": "MozIccInfo",
+    "implements": []
+  },
+  "MozIcc": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozIccManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozInputMethod": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozInterAppMessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozInterAppMessagePort": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozMessageDeletedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozMmsEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozMobileConnection": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozMobileMessageManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozNFC": {
+    "inherits": "EventTarget",
+    "implements": [
+      "MozNFCManager"
+    ]
+  },
+  "MozNFCPeerEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozNFCTagEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozOtaStatusEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozSettingsEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozSettingsTransactionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozSmsEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozSpeakerManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozStkCommandEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozVoicemail": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozVoicemailEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozWifiConnectionInfoEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozWifiManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "MozWifiStationInfoEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MozWifiStatusChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MutationEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "MutationObserver": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "MutationRecord": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "NamedNodeMap": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Navigator": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface",
+      "NavigatorBattery",
+      "NavigatorContentUtils",
+      "NavigatorDataStore",
+      "NavigatorFeatures",
+      "NavigatorGeolocation",
+      "NavigatorID",
+      "NavigatorLanguage",
+      "NavigatorMobileId",
+      "NavigatorOnLine",
+      "NavigatorStorageUtils"
+    ]
+  },
+  "NetworkInformation": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "Node": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "NodeIterator": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "NodeList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Notification": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "NotifyPaintEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "OfflineAudioCompletionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "OfflineAudioContext": {
+    "inherits": "BaseAudioContext",
+    "implements": []
+  },
+  "OfflineResourceList": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "OffscreenCanvas": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "OscillatorNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "PageTransitionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PaintRequest": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "PaintRequestList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "PannerNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "Performance": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "PerformanceLongTaskTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "PerformanceMark": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "PerformanceMeasure": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "PerformanceNavigationTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "PerformancePaintTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "PerformanceResourceTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "Plugin": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "PluginArray": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "PluginCrashedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PointerEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "PopStateEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PopupBlockedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PopupBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "PositionSensorVRDevice": {
+    "inherits": "VRDevice",
+    "implements": []
+  },
+  "PresentationDeviceInfoManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ProcessingInstruction": {
+    "inherits": "CharacterData",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "ProgressEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PromiseRejectionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "PropertyNodeList": {
+    "inherits": "NodeList",
+    "implements": []
+  },
+  "PseudoElement": {
+    "inherits": null,
+    "implements": [
+      "GeometryUtils"
+    ]
+  },
+  "RTCDTMFSender": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "RTCDTMFToneChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCDataChannel": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "RTCDataChannelEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCPeerConnection": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "RTCPeerConnectionIceEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCPeerConnectionIdentityErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCPeerConnectionIdentityEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RTCTrackEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "RadioNodeList": {
+    "inherits": "NodeList",
+    "implements": []
+  },
+  "Range": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "RecordErrorEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Rect": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "Request": {
+    "inherits": null,
+    "implements": [
+      "Body"
+    ]
+  },
+  "Response": {
+    "inherits": null,
+    "implements": [
+      "Body"
+    ]
+  },
+  "SVGAElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGAltGlyphElement": {
+    "inherits": "SVGTextPositioningElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGAnimateElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "SVGAnimateMotionElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "SVGAnimateTransformElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "SVGAnimatedEnumeration": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimatedInteger": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimatedNumber": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimatedNumberList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimatedPreserveAspectRatio": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimatedString": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGAnimationElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGTests"
+    ]
+  },
+  "SVGCircleElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SVGClipPathElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGComponentTransferFunctionElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGCursorElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGDefsElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGDescElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "SVGElement": {
+    "inherits": "Element",
+    "implements": [
+      "GlobalEventHandlers",
+      "OnErrorEventHandlerForNodes",
+      "TouchEventHandlers"
+    ]
+  },
+  "SVGEllipseElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SVGFEBlendElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEColorMatrixElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEComponentTransferElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFECompositeElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEConvolveMatrixElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEDiffuseLightingElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEDisplacementMapElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEDistantLightElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGFEDropShadowElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEFloodElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEFuncAElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "SVGFEFuncBElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "SVGFEFuncGElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "SVGFEFuncRElement": {
+    "inherits": "SVGComponentTransferFunctionElement",
+    "implements": []
+  },
+  "SVGFEGaussianBlurElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEImageElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes",
+      "SVGURIReference"
+    ]
+  },
+  "SVGFEMergeElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEMergeNodeElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGFEMorphologyElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEOffsetElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFEPointLightElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGFESpecularLightingElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFESpotLightElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGFETileElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFETurbulenceElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFilterPrimitiveStandardAttributes"
+    ]
+  },
+  "SVGFilterElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference",
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGForeignObjectElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGGElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGGeometryElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGGradientElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference",
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGGraphicsElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGTests"
+    ]
+  },
+  "SVGImageElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "MozImageLoadingContent",
+      "SVGURIReference"
+    ]
+  },
+  "SVGLengthList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGLineElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SVGLinearGradientElement": {
+    "inherits": "SVGGradientElement",
+    "implements": []
+  },
+  "SVGMPathElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGMarkerElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox"
+    ]
+  },
+  "SVGMaskElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGMetadataElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGNumberList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPathElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": [
+      "SVGAnimatedPathData"
+    ]
+  },
+  "SVGPathSegArcAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegArcRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegClosePath": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoCubicAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoCubicRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoCubicSmoothAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoCubicSmoothRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticSmoothAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegCurvetoQuadraticSmoothRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegLinetoAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegLinetoHorizontalAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegLinetoHorizontalRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegLinetoRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegLinetoVerticalAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegLinetoVerticalRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPathSegMovetoAbs": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPathSegMovetoRel": {
+    "inherits": "SVGPathSeg",
+    "implements": []
+  },
+  "SVGPatternElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGURIReference",
+      "SVGUnitTypes"
+    ]
+  },
+  "SVGPoint": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPointList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGPolygonElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": [
+      "SVGAnimatedPoints"
+    ]
+  },
+  "SVGPolylineElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": [
+      "SVGAnimatedPoints"
+    ]
+  },
+  "SVGPreserveAspectRatio": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGRadialGradientElement": {
+    "inherits": "SVGGradientElement",
+    "implements": []
+  },
+  "SVGRect": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGRectElement": {
+    "inherits": "SVGGeometryElement",
+    "implements": []
+  },
+  "SVGSVGElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGZoomAndPan"
+    ]
+  },
+  "SVGScriptElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGSetElement": {
+    "inherits": "SVGAnimationElement",
+    "implements": []
+  },
+  "SVGStopElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGStringList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGStyleElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGSwitchElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGSymbolElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGTests"
+    ]
+  },
+  "SVGTSpanElement": {
+    "inherits": "SVGTextPositioningElement",
+    "implements": []
+  },
+  "SVGTextContentElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": []
+  },
+  "SVGTextElement": {
+    "inherits": "SVGTextPositioningElement",
+    "implements": []
+  },
+  "SVGTextPathElement": {
+    "inherits": "SVGTextContentElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGTextPositioningElement": {
+    "inherits": "SVGTextContentElement",
+    "implements": []
+  },
+  "SVGTitleElement": {
+    "inherits": "SVGElement",
+    "implements": []
+  },
+  "SVGTransformList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SVGUseElement": {
+    "inherits": "SVGGraphicsElement",
+    "implements": [
+      "SVGURIReference"
+    ]
+  },
+  "SVGViewElement": {
+    "inherits": "SVGElement",
+    "implements": [
+      "SVGFitToViewBox",
+      "SVGZoomAndPan"
+    ]
+  },
+  "SVGZoomEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "Screen": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "ScriptProcessorNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "ScrollAreaEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "ScrollBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "ScrollViewChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Selection": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "SelectionStateChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "ServiceWorker": {
+    "inherits": "EventTarget",
+    "implements": [
+      "AbstractWorker"
+    ]
+  },
+  "ServiceWorkerContainer": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ServiceWorkerGlobalScope": {
+    "inherits": "WorkerGlobalScope",
+    "implements": [
+      "GlobalFetch"
+    ]
+  },
+  "ServiceWorkerRegistration": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SettingsLock": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SettingsManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ShadowRoot": {
+    "inherits": "DocumentFragment",
+    "implements": []
+  },
+  "SharedWorker": {
+    "inherits": "EventTarget",
+    "implements": [
+      "AbstractWorker"
+    ]
+  },
+  "SharedWorkerGlobalScope": {
+    "inherits": "WorkerGlobalScope",
+    "implements": []
+  },
+  "SimpleGestureEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "SourceBuffer": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SourceBufferList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SpeechRecognition": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "SpeechRecognitionError": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SpeechRecognitionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SpeechSynthesisEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SpeechSynthesisUtterance": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "StereoPannerNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "StorageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "StylePropertyMap": {
+    "inherits": "StylePropertyMapReadOnly",
     "implements": []
   },
   "StylePropertyMapReadOnly": {
@@ -2643,8 +2335,316 @@
       "StylePropertyMap"
     ]
   },
-  "StylePropertyMap": {
-    "inherits": "StylePropertyMapReadOnly",
+  "StyleRuleChangeEvent": {
+    "inherits": "Event",
     "implements": []
+  },
+  "StyleSheet": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "StyleSheetApplicableStateChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "StyleSheetChangeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "SyncEvent": {
+    "inherits": "ExtendableEvent",
+    "implements": []
+  },
+  "TVChannel": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TVCurrentChannelChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TVCurrentSourceChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TVEITBroadcastedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TVManager": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TVScanningStateChangedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TVSource": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TVTuner": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TaskAttributionTiming": {
+    "inherits": "PerformanceEntry",
+    "implements": []
+  },
+  "Telephony": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TelephonyCall": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TelephonyCallGroup": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "Text": {
+    "inherits": "CharacterData",
+    "implements": [
+      "GeometryUtils",
+      "LegacyQueryInterface"
+    ]
+  },
+  "TextTrack": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TextTrackList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "TimeEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "Touch": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "TouchEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "TouchList": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "TrackEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TransitionEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "TreeBoxObject": {
+    "inherits": "BoxObject",
+    "implements": []
+  },
+  "TreeColumns": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "TreeWalker": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "UDPMessageEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "UDPSocket": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "UIEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "URL": {
+    "inherits": null,
+    "implements": [
+      "URLUtils",
+      "URLUtilsSearchParams"
+    ]
+  },
+  "USSDReceivedEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "UndoManager": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "UserProximityEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "VRFieldOfView": {
+    "inherits": "VRFieldOfViewReadOnly",
+    "implements": []
+  },
+  "VTTCue": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "ValidityState": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "VideoStreamTrack": {
+    "inherits": "MediaStreamTrack",
+    "implements": []
+  },
+  "VideoTrackList": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "WaveShaperNode": {
+    "inherits": "AudioNode",
+    "implements": [
+      "AudioNodePassThrough"
+    ]
+  },
+  "WebGL2RenderingContext": {
+    "inherits": "WebGLRenderingContext",
+    "implements": []
+  },
+  "WebGLContextEvent": {
+    "inherits": "Event",
+    "implements": []
+  },
+  "WebSocket": {
+    "inherits": "EventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "WheelEvent": {
+    "inherits": "MouseEvent",
+    "implements": []
+  },
+  "Window": {
+    "inherits": null,
+    "implements": [
+      "ChromeWindow",
+      "GlobalCrypto",
+      "GlobalEventHandlers",
+      "LegacyQueryInterface",
+      "OnErrorEventHandlerForWindow",
+      "SpeechSynthesisGetter",
+      "TouchEventHandlers",
+      "WindowEventHandlers",
+      "WindowModal",
+      "WindowOrWorkerGlobalScope"
+    ]
+  },
+  "WindowClient": {
+    "inherits": "Client",
+    "implements": []
+  },
+  "WindowRoot": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "Worker": {
+    "inherits": "EventTarget",
+    "implements": [
+      "AbstractWorker"
+    ]
+  },
+  "WorkerGlobalScope": {
+    "inherits": "EventTarget",
+    "implements": [
+      "GlobalCrypto",
+      "WindowOrWorkerGlobalScope"
+    ]
+  },
+  "WorkerLocation": {
+    "inherits": null,
+    "implements": [
+      "URLUtilsReadOnly"
+    ]
+  },
+  "WorkerNavigator": {
+    "inherits": null,
+    "implements": [
+      "NavigatorDataStore",
+      "NavigatorID",
+      "NavigatorLanguage",
+      "NavigatorOnLine"
+    ]
+  },
+  "XMLDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "XMLHttpRequest": {
+    "inherits": "XMLHttpRequestEventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XMLHttpRequestEventTarget": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "XMLHttpRequestUpload": {
+    "inherits": "XMLHttpRequestEventTarget",
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XMLSerializer": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XMLStylesheetProcessingInstruction": {
+    "inherits": "ProcessingInstruction",
+    "implements": []
+  },
+  "XPathEvaluator": {
+    "inherits": null,
+    "implements": [
+      "LegacyQueryInterface"
+    ]
+  },
+  "XULCommandEvent": {
+    "inherits": "UIEvent",
+    "implements": []
+  },
+  "XULDocument": {
+    "inherits": "Document",
+    "implements": []
+  },
+  "XULElement": {
+    "inherits": "Element",
+    "implements": [
+      "GlobalEventHandlers",
+      "MozFrameLoaderOwner",
+      "OnErrorEventHandlerForNodes",
+      "TouchEventHandlers"
+    ]
   }
 }


### PR DESCRIPTION
This sorts `api/inheritance.json`, just like in https://github.com/mdn/kumascript/pull/709.

Note that I kept `inherits` preceding `implements`.

---

review?(@a2sheppy, @atopal, @chrisdavidmills, @Elchi3, @teoli2003, @wbamberg)