### PR TITLE
feat(css): Add `margin‑trim` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5905,6 +5905,26 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-top"
   },
+  "margin-trim": {
+    "syntax": "none | in-flow | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainersAndMultiColumnContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-trim"
+  },
   "mask": {
     "syntax": "<mask-layer>#",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -178,6 +178,7 @@
         "beforeAndAfterPseudos",
         "blockContainerElements",
         "blockContainers",
+        "blockContainersAndMultiColumnContainers",
         "blockContainersExceptMultiColumnContainers",
         "blockContainersExceptTableWrappers",
         "blockContainersFlexContainersGridContainers",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -451,7 +451,13 @@
     "ja": "ブロックコンテナー",
     "ru": "блочные контейнеры"
   },
+  "blockContainersAndMultiColumnContainers": {
+    "de": "Blockcontainer und mehrspaltige Container",
+    "en-US": "Block containers and multi-column containers",
+    "ja": "ブロックコンテナー, 段組みクコンテナー"
+  },
   "blockContainersExceptMultiColumnContainers": {
+    "de": "Blockcontainer außer mehrspaltige Container",
     "en-US": "Block containers except multi-column containers"
   },
   "blockContainersExceptTableWrappers": {


### PR DESCRIPTION
I was one of the main pushers for this, in the form of https://github.com/w3c/csswg-drafts/issues/3216, which also went into https://github.com/w3c/csswg-drafts/issues/3068, which has resulted in this being specified in the [**CSS3 Box Model**](https://drafts.csswg.org/css-box-3/#margin-trim) specification.

~~I’ve also updated all **CSS3 Box Model** properties to state that they also apply to `::first‑line` (see https://drafts.csswg.org/css-box/#placement)~~ Extracted into #379.

review?(@chrisdavidmills, @ddbeck, @Elchi3, @wbamberg)