### PR TITLE
fixing attr() formal syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -735,7 +735,7 @@
     "syntax": "translateZ( <length> )"
   },
   "type-or-unit": {
-    "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | px | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | deg | grad | rad | turn | ms | s | Hz | kHz | %"
+    "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | px | deg | grad | rad | turn | ms | s | Hz | kHz | %"
   },
   "type-selector": {
     "syntax": "<wq-name> | <ns-prefix>? '*'"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -735,7 +735,7 @@
     "syntax": "translateZ( <length> )"
   },
   "type-or-unit": {
-    "syntax": "string | integer | color | url | integer | number | length | angle | time | frequency | em | ex | px | rem | vw | vh | vmin | vmax | mm | q | cm | in | pt | pc | deg | grad | rad | ms | s | Hz | kHz | %"
+    "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | px | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | deg | grad | rad | turn | ms | s | Hz | kHz | %"
   },
   "type-selector": {
     "syntax": "<wq-name> | <ns-prefix>? '*'"


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/1155

I made this fix, but I also added some of the missing type-or-unit options that had been added since.