### PR TITLE
Updating overflow-block overflow-inline

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6699,7 +6699,7 @@
     "status": "experimental"
   },
   "overflow-block": {
-    "syntax": "<'overflow'>",
+    "syntax": "visible | hidden | clip | scroll | auto",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -6730,7 +6730,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Mozilla/CSS/overflow-clip-box"
   },
   "overflow-inline": {
-    "syntax": "<'overflow'>",
+    "syntax": "visible | hidden | clip | scroll | auto",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
Creating pages for overflow-block and overflow-inline. The formal syntax currently just links to overflow, however we don't do that for overflow-x and overflow-y which also are the same as overflow. Seems to make sense to have the actual values visible on the page.