### PR TITLE
feat(css): Add `::part(…)` pseudo‑element

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -834,6 +834,15 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::grammar-error"
   },
+  "::part": {
+    "syntax": "::part( <ident>+ )",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::part"
+  },
   "::placeholder": {
     "syntax": "::placeholder",
     "groups": [


### PR DESCRIPTION
This adds data for the [`::part(…)`] pseudo‑element.

## See also:
- [Bug 1505489](https://bugzilla.mozilla.org/show_bug.cgi?id=1505489)

---

[`::part(…)`]: https://developer.mozilla.org/docs/Web/CSS/::part

review?(@chrisdavidmills, @ddbeck, @Elchi3, @emilio, @wbamberg)