### PR TITLE
marking obsolete scroll snap properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7927,7 +7927,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "nonstandard",
+    "status": "obsolete",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type-x"
   },
   "scroll-snap-type-y": {
@@ -7943,7 +7943,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "nonstandard",
+    "status": "obsolete",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type-y"
   },
   "shape-image-threshold": {


### PR DESCRIPTION
scroll-snap-type-x and scroll-snap-type-y are being removed from Firefox in 68. This PR marks them as obsolete to match the other removed properties.