### PR TITLE
Adding ::marker pseudo-element

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -834,6 +834,15 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::grammar-error"
   },
+  "::marker": {
+    "syntax": "::marker",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::marker"
+  },
   "::part": {
     "syntax": "::part( <ident>+ )",
     "groups": [


### PR DESCRIPTION
Adding data for `::marker` which is in Firefox 68.

https://drafts.csswg.org/css-lists-3/#marker-pseudo