### PR TITLE
Fixed color-stop syntax used in gradient functions

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -393,7 +393,7 @@
     "syntax": "<length-percentage>"
   },
   "linear-color-stop": {
-    "syntax": "<color> && <color-stop-length>"
+    "syntax": "<color> <color-stop-length>?"
   },
   "linear-gradient()": {
     "syntax": "linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )"


### PR DESCRIPTION
The color stop syntax definition is incorrect, as it doesn't allow for colors stops without lengths, i.e.

``` css
div {
  background: radial-gradient(red 0%, blue 100%); /* works */
  background: radial-gradient(red, blue); /* doesn't work */
}
```

The [MDN documentation][1] states the correct syntax. This PR fixes that.

  [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/radial-gradient#Formal_syntax