### PR TITLE
adding the auto value for the quotes property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7274,7 +7274,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position"
   },
   "quotes": {
-    "syntax": "none | [ <string> <string> ]+",
+    "syntax": "none | auto | [ <string> <string> ]+",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1421938.

Basically, the `quotes` property now has an `auto` value, which makes the browser automatically choose appropriate quotes depending on the `lang` attribute setting of the selected elements.