### PR TITLE
adding syntax data for text-decoration-thickness and text-underline-offset

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8094,13 +8094,14 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-combine-upright"
   },
   "text-decoration": {
-    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
+    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
     "media": "visual",
     "inherited": false,
     "animationType": [
       "text-decoration-color",
       "text-decoration-style",
-      "text-decoration-line"
+      "text-decoration-line",
+      "text-decoration-thickness"
     ],
     "percentages": "no",
     "groups": [
@@ -8115,7 +8116,8 @@
     "computed": [
       "text-decoration-line",
       "text-decoration-style",
-      "text-decoration-color"
+      "text-decoration-color",
+      "text-decoration-thickness"
     ],
     "order": "orderOfAppearance",
     "alsoAppliesTo": [
@@ -8148,7 +8150,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-color"
   },
   "text-decoration-line": {
-    "syntax": "none | [ underline || overline || line-through || blink ]",
+    "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -8220,6 +8222,27 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-style"
+  },
+  "text-decoration-thickness": {
+    "syntax": "auto | from-font | <length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness"
   },
   "text-emphasis": {
     "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
@@ -8434,6 +8457,27 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-transform"
+  },
+  "text-underline-offset": {
+    "syntax": "auto | from-font | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset"
   },
   "text-underline-position": {
     "syntax": "auto | [ under || [ left | right ] ]",


### PR DESCRIPTION
Plus also text-decoration shorthand.

As per the work on https://app.zenhub.com/workspaces/mdn-sprint-board-5ab3d23fd0f4ea53b0022a61/issues/mdn/sprints/2104