### PR TITLE
changing CSS Motion group to CSS Motion Path

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -32,7 +32,7 @@
       "CSS Logical Properties",
       "CSS Masking",
       "CSS Miscellaneous",
-      "CSS Motion",
+      "CSS Motion Path",
       "CSS Namespaces",
       "CSS Overflow",
       "CSS Pages",

--- a/css/properties.json
+++ b/css/properties.json
@@ -6441,7 +6441,7 @@
       "offset-anchor"
     ],
     "groups": [
-      "CSS Motion"
+      "CSS Motion Path"
     ],
     "initial": [
       "offset-position",
@@ -6470,7 +6470,7 @@
     "animationType": "position",
     "percentages": "relativeToWidthAndHeight",
     "groups": [
-      "CSS Motion"
+      "CSS Motion Path"
     ],
     "initial": "auto",
     "appliesto": "transformableElements",
@@ -6485,7 +6485,7 @@
     "animationType": "lpc",
     "percentages": "referToTotalPathLength",
     "groups": [
-      "CSS Motion"
+      "CSS Motion Path"
     ],
     "initial": "0",
     "appliesto": "transformableElements",
@@ -6501,7 +6501,7 @@
     "animationType": "angleOrBasicShapeOrPath",
     "percentages": "no",
     "groups": [
-      "CSS Motion"
+      "CSS Motion Path"
     ],
     "initial": "none",
     "appliesto": "transformableElements",
@@ -6518,7 +6518,7 @@
     "animationType": "position",
     "percentages": "referToSizeOfContainingBlock",
     "groups": [
-      "CSS Motion"
+      "CSS Motion Path"
     ],
     "initial": "auto",
     "appliesto": "transformableElements",
@@ -6533,7 +6533,7 @@
     "animationType": "angleOrBasicShapeOrPath",
     "percentages": "no",
     "groups": [
-      "CSS Motion"
+      "CSS Motion Path"
     ],
     "initial": "auto",
     "appliesto": "transformableElements",


### PR DESCRIPTION
The main landing page for CSS Motion Path is https://developer.mozilla.org/en-US/docs/Web/CSS/Motion_Path

But the group name was set to CSS Motion. This meant that the auto-generated link on the sidebars to the landing page was being created as https://developer.mozilla.org/en-US/docs/Web/CSS/Motion, so the link was wrong in each case.

This change should fix that.