### PR TITLE
opacity can take a percentage

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6543,7 +6543,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-rotate"
   },
   "opacity": {
-    "syntax": "<number>",
+    "syntax": "<alpha-value>",
     "media": "visual",
     "inherited": false,
     "animationType": "number",
@@ -7963,11 +7963,11 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type-y"
   },
   "shape-image-threshold": {
-    "syntax": "<number>",
+    "syntax": "<alpha-value>",
     "media": "visual",
     "inherited": false,
     "animationType": "number",
-    "percentages": "no",
+    "percentages": "yes",
     "groups": [
       "CSS Shapes"
     ],

--- a/css/properties.json
+++ b/css/properties.json
@@ -7967,7 +7967,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "number",
-    "percentages": "yes",
+    "percentages": "no",
     "groups": [
       "CSS Shapes"
     ],


### PR DESCRIPTION
Updating as `opacity` and `shape-image-threshold` acccept `<alpha-value>` rather than `<number>` which enables percentage opacity values.

https://bugzilla.mozilla.org/show_bug.cgi?id=1562086
https://bugzilla.mozilla.org/show_bug.cgi?id=1568615