### PR TITLE
update counter syntax to match spec

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -165,7 +165,7 @@
     "syntax": "contrast( [ <number-percentage> ] )"
   },
   "counter()": {
-    "syntax": "counter( <custom-ident>, [ <counter-style> | none ]? )"
+    "syntax": "counter( <custom-ident>, <counter-style>? )"
   },
   "counter-style": {
     "syntax": "<counter-style-name> | symbols()"
@@ -174,7 +174,7 @@
     "syntax": "<custom-ident>"
   },
   "counters()": {
-    "syntax": "counters( <custom-ident>, <string>, [ <counter-style> | none ]? )"
+    "syntax": "counters( <custom-ident>, <string>, <counter-style>? )"
   },
   "cross-fade()": {
     "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"


### PR DESCRIPTION
As per this issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1576821

Spec has been updated to make none invalid. THis PR updates the data to match the current spec. https://drafts.csswg.org/css-lists-3/#counter-functions