### PR TITLE
CSS Selectors - add "Pseudo" group

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -65,6 +65,7 @@
       "Microsoft Extensions",
       "Mozilla Extensions",
       "Pointer Events",
+      "Pseudo",
       "Pseudo-classes",
       "Pseudo-elements",
       "Selectors",

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -105,7 +105,7 @@
       "Selectors"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Pseudo-classes"
   },
   "Pseudo-elements": {
     "syntax": "::",
@@ -114,7 +114,7 @@
       "Selectors"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements"
   },
   ":active": {
     "syntax": ":active",

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -98,6 +98,24 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Column_combinator"
   },
+  "Pseudo-classes": {
+    "syntax": ":",
+    "groups": [
+      "Pseudo",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes"
+  },
+  "Pseudo-elements": {
+    "syntax": "::",
+    "groups": [
+      "Pseudo",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements"
+  },
   ":active": {
     "syntax": ":active",
     "groups": [


### PR DESCRIPTION
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors

In #393 PR we added the Selectors list.

In this PR we we will add a "Pseudo" group linking to:
* [Pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
* [Pseudo-elements](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements)

In a separate PR I will move the Pseudo-classes and the Pseudo-elements to `properties.json`. They should not be part of CSS Selectors sidebar.

The final goal is to create a clear hierarchy for CSS Selectors and a separate sidebar for Pseudo-classes and the Pseudo-elements.