### PR TITLE
Fix syntax for background-position-{x,y}

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2159,7 +2159,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position"
   },
   "background-position-x": {
-    "syntax": "[ center | [ left | right | x-start | x-end ]? <length-percentage>? ]#",
+    "syntax": "[ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -2175,7 +2175,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-x"
   },
   "background-position-y": {
-    "syntax": "[ center | [ top | bottom | y-start | y-end ]? <length-percentage>? ]#",
+    "syntax": "[ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
I'm working on a fuzz testing tool that generates random CSS based on the syntax definitions in this repo. I noticed that the `syntax`es for `background-position-x` and `background-position-y` permit the empty string because they're missing a `[ ... ]!` compared to [CSS Backgrounds and Borders Module Level 4 spec](https://drafts.csswg.org/css-backgrounds-4/#background-position-longhands).

... Seems like it was fixed in the spec draft earlier this year: https://github.com/w3c/csswg-drafts/pull/3904