### PR TITLE
Width height

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6265,7 +6265,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-block-size"
   },
   "max-height": {
-    "syntax": "<length> | <percentage> | none | max-content | min-content | fit-content | fill-available",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6312,7 +6312,7 @@
     "status": "experimental"
   },
   "max-width": {
-    "syntax": "<length> | <percentage> | none | max-content | min-content | fit-content | fill-available",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",

--- a/css/properties.json
+++ b/css/properties.json
@@ -5226,7 +5226,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation"
   },
   "height": {
-    "syntax": "[ <length> | <percentage> ] && [ border-box | content-box ]? | available | min-content | max-content | fit-content | auto",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6344,7 +6344,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-block-size"
   },
   "min-height": {
-    "syntax": "<length> | <percentage> | auto | max-content | min-content | fit-content | fill-available",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6376,7 +6376,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-inline-size"
   },
   "min-width": {
-    "syntax": "<length> | <percentage> | auto | max-content | min-content | fit-content | fill-available",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -8818,7 +8818,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/widows"
   },
   "width": {
-    "syntax": "[ <length> | <percentage> ] && [ border-box | content-box ]? | available | min-content | max-content | fit-content | auto",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",


### PR DESCRIPTION
As part of working through experimental features in https://github.com/mdn/sprints/issues/2402 discovered the pages relating to Box Sizing have values listed which are removed from the curent spec (https://github.com/mdn/sprints/issues/2507). This PR updates the formal syntax to match CSS Box Sizing Level 3 for `width`, `min-width`, `height`, `min-height`, `max-width`, `max-height`.

Current spec: https://drafts.csswg.org/css-sizing-3/#preferred-size-properties