### PR TITLE
Adds overscroll-behavior block and inline

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6854,8 +6854,40 @@
     "appliesto": "nonReplacedBlockAndInlineBlockElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "nonstandard",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior"
+  },
+  "overscroll-behavior-block": {
+    "syntax": "contain | none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block"
+  },
+  "overscroll-behavior-inline": {
+    "syntax": "contain | none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline"
   },
   "overscroll-behavior-x": {
     "syntax": "contain | none | auto",
@@ -6870,7 +6902,7 @@
     "appliesto": "nonReplacedBlockAndInlineBlockElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "nonstandard",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x"
   },
   "overscroll-behavior-y": {
@@ -6886,7 +6918,7 @@
     "appliesto": "nonReplacedBlockAndInlineBlockElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "nonstandard",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y"
   },
   "padding": {


### PR DESCRIPTION
I'm working on https://github.com/mdn/sprints/issues/2635 and so need to add the properties `overscroll-behavior-block` and `overflow-behavior-inline`.

Also updated `nonstandard` to `standard` for the overflow-behavior properties as these have a spec: https://www.w3.org/TR/css-overscroll-1