### PR TITLE
fixing the CSS gap property applies to line

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4843,7 +4843,7 @@
       "row-gap",
       "column-gap"
     ],
-    "appliesto": "gridContainers",
+    "appliesto": "multiColumnElementsFlexContainersGridContainers",
     "computed": [
       "row-gap",
       "column-gap"


### PR DESCRIPTION
To close https://github.com/mdn/sprints/issues/2757 updating the appliesto line for the CSS `gap` property.