### PR TITLE
feat(api): Add `RTC*Transport` interfaces

### DIFF
--- a/api/inheritance.json
+++ b/api/inheritance.json
@@ -1589,6 +1589,14 @@
     "inherits": "Event",
     "implements": []
   },
+  "RTCDtlsTransport": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
+  "RTCIceTransport": {
+    "inherits": "EventTarget",
+    "implements": []
+  },
   "RTCPeerConnection": {
     "inherits": "EventTarget",
     "implements": []
@@ -1603,6 +1611,10 @@
   },
   "RTCPeerConnectionIdentityEvent": {
     "inherits": "Event",
+    "implements": []
+  },
+  "RTCSctpTransport": {
+    "inherits": "EventTarget",
     "implements": []
   },
   "RTCTrackEvent": {


### PR DESCRIPTION
`RTC*Transport` interfaces now all inherit from `EventTarget`.

See <https://github.com/w3c/webrtc-pc/issues/1363> and <https://github.com/w3c/webrtc-pc/issues/2130> for details.