### PR TITLE
Add 'all' keyword to text-underline-decoration-skip-ink, per bug 1611965

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8265,7 +8265,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip"
   },
   "text-decoration-skip-ink": {
-    "syntax": "auto | none",
+    "syntax": "auto | all | none",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
CSS WG has agreed to ‘all’ in place of ‘always’, per
https://bugzilla.mozilla.org/show_bug.cgi?id=1611965#c4