### PR TITLE
feat(css): Update `@import` syntax to CSS Cascade Module Level 4

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -237,8 +237,9 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values"
   },
   "@import": {
-    "syntax": "@import [ <string> | <url> ] [ <media-query-list> ]?;",
+    "syntax": "@import [ <string> | <url> ]\n        [ supports( [ <supports-condition> | <declaration> ] ) ]?\n        <media-query-list>? ;",
     "groups": [
+      "CSS Conditional Rules",
       "Media Queries"
     ],
     "status": "standard",


### PR DESCRIPTION
See <https://drafts.csswg.org/css-cascade-4/#at-import> and [bug 1427715](https://bugzilla.mozilla.org/show_bug.cgi?id=1427715).