### PR TITLE
restrict cubic-bezier-timing-function abscissas to be in range [0,1]

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -180,7 +180,7 @@
     "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
   },
   "cubic-bezier-timing-function": {
-    "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number>, <number>, <number>, <number>)"
+    "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
   },
   "deprecated-system-color": {
     "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonFace | ButtonHighlight | ButtonShadow | ButtonText | CaptionText | GrayText | Highlight | HighlightText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"


### PR DESCRIPTION
Quote from here: https://drafts.csswg.org/css-easing-1/#funcdef-cubic-bezier-easing-function-cubic-bezier

`cubic-bezier(<number>, <number>, <number>, <number>)`
Specifies a cubic Bézier easing function. The four numbers specify points P1 and P2 of the curve as (x1, y1, x2, y2). Both x values must be in the range [0, 1] or the definition is invalid.

And from here: https://drafts.csswg.org/css-values-3/#numeric-ranges

Range restrictions can be annotated in the numeric type notation using CSS bracketed range notation—[min,max]—within the angle brackets, after the identifying keyword, indicating a closed range between (and including) min and max. For example, `<integer [0,10]>` indicates an integer between 0 and 10, inclusive.

So I think `<number [0,1]>` is the correct syntax for x1 and x2 parameters of `cubic-bezier`
