### PR TITLE
Remove from-font value from text-underline-offset

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8556,7 +8556,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-transform"
   },
   "text-underline-offset": {
-    "syntax": "auto | from-font | <length> | <percentage> ",
+    "syntax": "auto | <length> | <percentage> ",
     "media": "visual",
     "inherited": true,
     "animationType": "byComputedValueType",


### PR DESCRIPTION
There's not such a value for this property based on [CSSWG](https://drafts.csswg.org/css-text-decor-4/#underline-offset)