### PR TITLE
Update transform-box data to match CSS specification

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8642,7 +8642,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform"
   },
   "transform-box": {
-    "syntax": "border-box | fill-box | view-box",
+    "syntax": "content-box | border-box | fill-box | stroke-box | view-box",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -8650,10 +8650,10 @@
     "groups": [
       "CSS Transforms"
     ],
-    "initial": "border-box ",
+    "initial": "view-box",
     "appliesto": "transformableElements",
     "computed": "asSpecified",
-    "order": "uniqueOrder",
+    "order": "perGrammar",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-box"
   },


### PR DESCRIPTION
Dear Mozillians,

This PR updates transform-box to match the latest specification. I went into a bit more details
[in the discourse thread](https://discourse.mozilla.org/t/mdn-transform-box-potential-issue/60980)

This is my first PR in this repository, if I did something wrong please tell me to correct it.