### PR TITLE
feat(css): Update `appearance` data for `menulist‑button` changes

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -803,7 +803,7 @@
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-appearance"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
   },
   "-moz-binding": {
     "syntax": "<url> | none",
@@ -1191,7 +1191,7 @@
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-appearance"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
   },
   "-webkit-border-before": {
     "syntax": "<'border-width'> || <'border-style'> || <'color'>",
@@ -1882,7 +1882,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timing-function"
   },
   "appearance": {
-    "syntax": "none | auto | button | textfield | <compat>",
+    "syntax": "none | auto | button | textfield | menulist-button | <compat-auto>",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",
@@ -1895,7 +1895,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "experimental",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-appearance"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
   },
   "aspect-ratio": {
     "syntax": "auto | <ratio>",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -122,8 +122,8 @@
   "common-lig-values": {
     "syntax": "[ common-ligatures | no-common-ligatures ]"
   },
-  "compat": {
-    "syntax": "searchfield | textarea | push-button | button-bevel | slider-horizontal | checkbox | radio | square-button | menulist | menulist-button | listbox | meter | progress-bar"
+  "compat-auto": {
+    "syntax": "searchfield | textarea | push-button | slider-horizontal | checkbox | radio | square-button | menulist | listbox | meter | progress-bar"
   },
   "composite-style": {
     "syntax": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"


### PR DESCRIPTION
Also, `<compat>` was renamed to `<compat‑auto>`.

## See also:
- <https://github.com/mdn/browser-compat-data/pull/6257>
- <https://github.com/w3c/csswg-drafts/pull/3574>