### PR TITLE
Restrict font-weight-absolute values to numbers in the 1...1000 range

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -285,7 +285,7 @@
     "syntax": "[ normal | small-caps ]"
   },
   "font-weight-absolute": {
-    "syntax": "normal | bold | <number>"
+    "syntax": "normal | bold | <number [1,1000]>"
   },
   "frequency-percentage": {
     "syntax": "<frequency> | <percentage>"


### PR DESCRIPTION
My [fuzz testing tool](https://github.com/papandreou/css-generators) generates crazy numerical `font-weight` values because the range isn't restricted by the grammar.

I suggest limiting it to 1...1000 as per the extra notes in the [CSS Fonts Module Level 4 Working Draft](https://drafts.csswg.org/css-fonts-4/#font-weight-prop). I'm proposing the equivalent change to the spec here: https://github.com/w3c/csswg-drafts/pull/5345