### PR TITLE
Add data for font-smooth

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4612,6 +4612,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust"
   },
+  "font-smooth": {
+    "syntax": "auto | never | always | <absolute-size> | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-smooth"
+  },
   "font-stretch": {
     "syntax": "<font-stretch-absolute>",
     "media": "visual",


### PR DESCRIPTION
This PR adds data for the [`font-smooth`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/font-smooth) property.

I've taken it from https://www.w3.org/TR/WD-font/#font-smooth.

This PR blocks the work to finish https://github.com/mdn/sprints/issues/3324, which fixes all "data.formal_syntax" and "data.formal_definition" linter errors.