### PR TITLE
Update CSS `appearance` syntax

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1882,7 +1882,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timing-function"
   },
   "appearance": {
-    "syntax": "none | auto | button | textfield | menulist-button | <compat-auto>",
+    "syntax": "none | auto | textfield | menulist-button | <compat-auto>",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -123,7 +123,7 @@
     "syntax": "[ common-ligatures | no-common-ligatures ]"
   },
   "compat-auto": {
-    "syntax": "searchfield | textarea | push-button | slider-horizontal | checkbox | radio | square-button | menulist | listbox | meter | progress-bar"
+    "syntax": "searchfield | textarea | push-button | slider-horizontal | checkbox | radio | square-button | menulist | listbox | meter | progress-bar | button"
   },
   "composite-style": {
     "syntax": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"


### PR DESCRIPTION
The `button` value was moved to `<compat-auto>`.

* Commit: w3c/csswg-drafts@c900e9345803b327038b970a4d5dfcedfb0ec912
* Spec: [css-ui-4#appearance-switching](https://drafts.csswg.org/css-ui-4/#appearance-switching)