### PR TITLE
feat(css): add missing '-ms-grid-' properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -238,6 +238,38 @@
     "status": "nonstandard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-flow-into"
   },
+  "-ms-grid-columns": {
+    "syntax": "none | <track-list> | <auto-track-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpcDifferenceLpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-columns"
+  },
+  "-ms-grid-rows": {
+    "syntax": "none | <track-list> | <auto-track-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpcDifferenceLpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-rows"
+  },
   "-ms-high-contrast-adjust": {
     "syntax": "auto | none",
     "media": "visual",


### PR DESCRIPTION
`-ms-grid-columns` and `-ms-grid-rows` [are aliases](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/) for `grid-template-columns` and `grid-template-rows`, respectively.