### PR TITLE
text-combine-upright is not animatable

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8194,7 +8194,7 @@
     "syntax": "none | all | [ digits <integer>? ]",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Writing Modes"

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -27,6 +27,7 @@
         "integer",
         "length",
         "lpc",
+        "notAnimatable",
         "numberOrLength",
         "number",
         "position",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -984,6 +984,9 @@
     "ja": "通常要素で使われると常に <code>normal</code>。{{cssxref(\"::before\")}} 及び {{cssxref(\"::after\")}} では: <code>normal</code> の指定があれば計算値は <code>none</code>。指定がなければ、<ul><li>URI 値は、絶対的 URI となる</li><li><code>attr()</code> 値は、計算値の文字列となる</li><li>その他のキーワードについては指定どおり</li></ul>",
     "ru": "На элементах всегда вычисляется как <code>normal</code>. На {{cssxref(\"::before\")}} и {{cssxref(\"::after\")}}, если <code>normal</code> указано, интерпретируется как <code>none</code>. Иначе, для значений URI, абсолютного URI; для значений <code>attr()</code> - результирующая строка; для других ключевых слов, как указано."
   },
+  "notAnimatable": {
+    "en-US": "Not animatable"
+  },
   "number": {
     "de": "<a href=\"/de/docs/Web/CSS/number#Interpolation\">Nummer</a>",
     "en-US": "a <a href=\"/en-US/docs/Web/CSS/number#Interpolation\" title=\"Values of the <number> CSS data type are interpolated as real, floating-point, numbers.\">number</a>",


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1654195 `text-combine-upright` is made not animatable, this PR is to fix that in the data.