### PR TITLE
Use bracket notation for '-moz-force-broken-image-icon'

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -918,7 +918,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-float-edge"
   },
   "-moz-force-broken-image-icon": {
-    "syntax": "<integer>",
+    "syntax": "<number [0,1]>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -918,7 +918,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-float-edge"
   },
   "-moz-force-broken-image-icon": {
-    "syntax": "<number [0,1]>",
+    "syntax": "<integer [0,1]>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
Fixes https://github.com/mdn/data/issues/429