### PR TITLE
adding math-style

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -61,6 +61,7 @@
       "CSSOM View",
       "Filter Effects",
       "Grouping Selectors",
+      "MathML",
       "Media Queries",
       "Microsoft Extensions",
       "Mozilla Extensions",

--- a/css/properties.json
+++ b/css/properties.json
@@ -6309,6 +6309,7 @@
     "syntax": "normal | compact",
     "media": "visual",
     "inherited": true,
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "MathML"

--- a/css/properties.json
+++ b/css/properties.json
@@ -6305,6 +6305,21 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-type"
   },
+  "math-style": {
+    "syntax": "normal | compact",
+    "media": "visual",
+    "inherited": true,
+    "percentages": "no",
+    "groups": [
+      "MathML"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-style"
+  },
   "max-block-size": {
     "syntax": "<'max-width'>",
     "media": "visual",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -984,6 +984,9 @@
     "ja": "通常要素で使われると常に <code>normal</code>。{{cssxref(\"::before\")}} 及び {{cssxref(\"::after\")}} では: <code>normal</code> の指定があれば計算値は <code>none</code>。指定がなければ、<ul><li>URI 値は、絶対的 URI となる</li><li><code>attr()</code> 値は、計算値の文字列となる</li><li>その他のキーワードについては指定どおり</li></ul>",
     "ru": "На элементах всегда вычисляется как <code>normal</code>. На {{cssxref(\"::before\")}} и {{cssxref(\"::after\")}}, если <code>normal</code> указано, интерпретируется как <code>none</code>. Иначе, для значений URI, абсолютного URI; для значений <code>attr()</code> - результирующая строка; для других ключевых слов, как указано."
   },
+  "notAnimatable": {
+    "en-US": "notAnimatable"
+  },
   "number": {
     "de": "<a href=\"/de/docs/Web/CSS/number#Interpolation\">Nummer</a>",
     "en-US": "a <a href=\"/en-US/docs/Web/CSS/number#Interpolation\" title=\"Values of the <number> CSS data type are interpolated as real, floating-point, numbers.\">number</a>",


### PR DESCRIPTION
Working on documenting for https://bugzilla.mozilla.org/show_bug.cgi?id=1665975

This PR adds the `math-style` property from MathML Core: https://mathml-refresh.github.io/mathml-core/#the-math-style-property