### PR TITLE
masonry properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1735,6 +1735,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self"
   },
+  "align-tracks": {
+    "syntax": "[normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "gridContainersWithMasonryLayoutInTheirBlockAxis",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-tracks"
+  },
   "all": {
     "syntax": "initial | inherit | unset | revert",
     "media": "noPracticalMedia",
@@ -5608,6 +5624,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self"
   },
+  "justify-tracks": {
+    "syntax": "[normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "gridContainersWithMasonryLayoutInTheirInlineAxis",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-tracks"
+  },
   "left": {
     "syntax": "<length> | <percentage> | auto",
     "media": "visual",
@@ -6336,6 +6368,22 @@
     "order": "perGrammar",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-type"
+  },
+  "masonry-auto-flow": {
+    "syntax": "[ pack | next ] || [definite-first | ordered ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "pack",
+    "appliesto": "gridContainersWithMasonryLayout",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/masonry-auto-flow"
   },
   "math-style": {
     "syntax": "normal | compact",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -701,6 +701,15 @@
     "fr": "conteneurs de grille",
     "ru": "сеточные контейнеры"
   },
+  "gridContainersWithMasonryLayout": {
+    "en-US": "Grid containers with masonry layout"
+  },
+  "gridContainersWithMasonryLayoutInTheirBlockAxis": {
+    "en-US": "Grid containers with masonry layout in their block axis"
+  },
+  "gridContainersWithMasonryLayoutInTheirInlineAxis": {
+    "en-US": "Grid containers with masonry layout in their inline axis"
+  },
   "gridItemsAndBoxesWithinGridContainer": {
     "de": "Gridelemente und absolut positionierte Boxen, deren beinhaltender Block ein Gridcontainer ist",
     "en-US": "grid items and absolutely-positioned boxes whose containing block is a grid container",


### PR DESCRIPTION
I am documenting the masonry value for `grid-template-columns` and `grid-template-rows` and the associated new properties in CSS Grid 3: mdn/sprints#3836

Much of this is implemented behind a flag in Firefox 77 and it's starting to get author interest.

Related PR for the L3 spec: mdn/kumascript#1437
PR for BCD: https://github.com/mdn/browser-compat-data/pull/7249

This PR adds info for the following new properties, which I'm going to document:

- `masonry-auto-flow`
- `align-tracks`
- `justify-tracks`