### PR TITLE
Data for the scrollbar-gutter property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7650,7 +7650,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS4 Overflow"
+      "CSS Overflow"
     ],
     "initial": "auto",
     "appliesto": "allElements",

--- a/css/properties.json
+++ b/css/properties.json
@@ -7643,6 +7643,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-color"
   },
+  "scrollbar-gutter": {
+    "syntax": "auto | [ stable | always ] && both? && force?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS4 Overflow"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter"
+  },
   "scrollbar-width": {
     "syntax": "auto | thin | none",
     "media": "visual",


### PR DESCRIPTION
This change adds the description of the scrollbar-gutter CSS property, as defined in the CSS4 Overflow spec.

* Spec: https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property
* MDN entry: https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter
  * Related issue: https://github.com/mdn/sprints/issues/3849
* Explainer: https://github.com/felipeerias/scrollbar-gutter-explainer

Thank you very much for your review. This is my first contribution, I hope I haven't missed anything 🙂