### PR TITLE
Add CSS @property at-role

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -328,6 +328,11 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page"
   },
+  "@property": {
+    "syntax": "@property <custom-property-name> {\n  <declaration-list>\n}",
+    "status": "experimental"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property"
+  },
   "@supports": {
     "syntax": "@supports <supports-condition> {\n  <group-rule-body>\n}",
     "interfaces": [

--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -330,7 +330,7 @@
   },
   "@property": {
     "syntax": "@property <custom-property-name> {\n  <declaration-list>\n}",
-    "status": "experimental"
+    "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property"
   },
   "@supports": {


### PR DESCRIPTION
To fix the scripting error on https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@property

Warns about the missing formal syntax generated by **{{csssyntax}}**.