### PR TITLE
Fix broken 2.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Open Web data by the Mozilla Developer Network",
   "main": "index.js",
   "files": [
+    "api/index.js",
     "api/*.json",
+    "css/index.js",
     "css/*.json",
+    "l10n/index.js",
     "l10n/*.json"
   ],
   "repository": {


### PR DESCRIPTION
This PR changes "files" to include `.js` files explicitly. I don't know how does it work before. Looks like npm 6 doesn't fully respect `files` and implicitly include `readme.md` and `index.js` at any nesting level (not for package root only) for some reasons, but shouldn't. Npm 7 fixes it and `*/index.js` files are not including to the package as per `files`. I think `2.0.13` was published with npm 7 and it broken for `require()`.
```
> require('mdn-data')
Uncaught Error: Cannot find module './api'
Require stack:
- mdn-demo/node_modules/mdn-data/index.js
- <repl>
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:892:15)
    at Function.Module._load (internal/modules/cjs/loader.js:742:27)
    at Module.require (internal/modules/cjs/loader.js:964:19)
    at require (internal/modules/cjs/helpers.js:88:18) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'mdn-demo/node_modules/mdn-data/index.js',
    '<repl>'
  ]
}
```

You can try `npm publish --dry-run` to check which files will be included in the package without publishing it.

Please merge this PR and republish the package asap.