### PR TITLE
adds missing pseudos

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -131,7 +131,7 @@
       "Pseudo-classes",
       "Selectors"
     ],
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:any-link"
   },
   ":checked": {
@@ -142,6 +142,15 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:checked"
+  },
+  ":current": {
+    "syntax": ":current",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experiment",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:current"
   },
   ":blank": {
     "syntax": ":blank",
@@ -242,6 +251,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:fullscreen"
   },
+  ":future": {
+    "syntax": ":future",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:future"
+  },
   ":focus": {
     "syntax": ":focus",
     "groups": [
@@ -257,7 +275,7 @@
       "Pseudo-classes",
       "Selectors"
     ],
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:focus-visible"
   },
   ":focus-within": {
@@ -266,7 +284,7 @@
       "Pseudo-classes",
       "Selectors"
     ],
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:focus-within"
   },
   ":has": {
@@ -387,6 +405,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:link"
   },
+  ":local-link": {
+    "syntax": ":local-link",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:local-link"
+  },
   ":not": {
     "syntax": ":not( <complex-selector-list> )",
     "groups": [
@@ -405,6 +432,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-child"
   },
+  ":nth-col": {
+    "syntax": ":nth-col",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-col"
+  },
   ":nth-last-child": {
     "syntax": ":nth-last-child( <nth> [ of <complex-selector-list> ]? )",
     "groups": [
@@ -413,6 +449,15 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-child"
+  },
+  ":nth-last-col": {
+    "syntax": ":nth-last-col",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-col"
   },
   ":nth-last-of-type": {
     "syntax": ":nth-last-of-type( <nth> )",
@@ -468,6 +513,24 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:out-of-range"
   },
+  ":past": {
+    "syntax": ":past",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:past"
+  },
+  ":paused": {
+    "syntax": ":paused",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:paused"
+  },
   ":placeholder-shown": {
     "syntax": ":placeholder-shown",
     "groups": [
@@ -476,6 +539,15 @@
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown"
+  },
+  ":playing": {
+    "syntax": ":checked",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:playing"
   },
   ":read-only": {
     "syntax": ":read-only",
@@ -541,6 +613,24 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:target"
+  },
+  ":target-within": {
+    "syntax": ":target-within",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:target-within"
+  },
+  ":user-invalid": {
+    "syntax": ":user-invalid",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-invalid"
   },
   ":valid": {
     "syntax": ":valid",

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -149,7 +149,7 @@
       "Pseudo-classes",
       "Selectors"
     ],
-    "status": "experiment",
+    "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:current"
   },
   ":blank": {


### PR DESCRIPTION
Working on https://github.com/mdn/sprints/issues/1686 there are a bunch of missing pseudos from the Level 4 specification, this adds them to the data.

I also changed the experimental flag on three pseudos which now seem to have two implementations.