### PR TITLE
Remove numerical bounds from <number> types

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -180,7 +180,7 @@
     "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
   },
   "cubic-bezier-timing-function": {
-    "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
+    "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number>, <number>, <number>, <number>)"
   },
   "deprecated-system-color": {
     "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonFace | ButtonHighlight | ButtonShadow | ButtonText | CaptionText | GrayText | Highlight | HighlightText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
@@ -285,7 +285,7 @@
     "syntax": "[ normal | small-caps ]"
   },
   "font-weight-absolute": {
-    "syntax": "normal | bold | <number [1,1000]>"
+    "syntax": "normal | bold | <number>"
   },
   "frequency-percentage": {
     "syntax": "<frequency> | <percentage>"


### PR DESCRIPTION
The rendered version of the bounded types displays incorrectly, causing a hard-to-read syntax description. A better fix may be to enhance the transformation tool but this will at least make everything readable.