### PR TITLE
Add page-size syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -521,6 +521,9 @@
   "page-selector": {
     "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
   },
+  "page-size": {
+    "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
+  },
   "path()": {
     "syntax": "path( [ <fill-rule>, ]? <string> )"
   },


### PR DESCRIPTION
I noticed `<page-size>` this was missing from the [`size` property](https://github.com/mdn/data/blob/61fa5b22ae6e0474cd96e4ce69fa4b3e15f9ccda/css/at-rules.json#L316)

https://drafts.csswg.org/css-page/#typedef-page-size-page-size