### PR TITLE
renaming timing-function to easing-function

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1914,7 +1914,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-play-state"
   },
   "animation-timing-function": {
-    "syntax": "<timing-function>#",
+    "syntax": "<easing-function>#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -8909,7 +8909,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-property"
   },
   "transition-timing-function": {
-    "syntax": "<timing-function>#",
+    "syntax": "<easing-function>#",
     "media": "interactive",
     "inherited": false,
     "animationType": "discrete",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -645,7 +645,7 @@
     "syntax": "[ left | right ] || [ top | bottom ]"
   },
   "single-animation": {
-    "syntax": "<time> || <timing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
+    "syntax": "<time> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
   },
   "single-animation-direction": {
     "syntax": "normal | reverse | alternate | alternate-reverse"
@@ -660,7 +660,7 @@
     "syntax": "running | paused"
   },
   "single-transition": {
-    "syntax": "[ none | <single-transition-property> ] || <time> || <timing-function> || <time>"
+    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
   },
   "single-transition-property": {
     "syntax": "all | <custom-ident>"
@@ -710,7 +710,7 @@
   "time-percentage": {
     "syntax": "<time> | <percentage>"
   },
-  "timing-function": {
+  "easing-function": {
     "syntax": "linear | <cubic-bezier-timing-function> | <step-timing-function>"
   },
   "track-breadth": {


### PR DESCRIPTION
Working on this issue, renaming `<timing-function>` to `<easing-function>` in the data: https://github.com/mdn/sprints/issues/1351 