### PR TITLE
changing group for Box Sizing

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3780,7 +3780,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Basic User Interface"
+      "CSS Box Model"
     ],
     "initial": "content-box",
     "appliesto": "allElementsAcceptingWidthOrHeight",


### PR DESCRIPTION
The `box-sizing` property isn't part of CSS Basic UI now - https://www.w3.org/TR/css-ui-4/#interaction

This PR moves it into the Box Model group which I think will fix the fact that the page on MDN has a fairly odd and unrelated collection of things in the sidebar: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing

I will fix the spec link on the page in a PR on the content repo.