### PR TITLE
Wrap :dir arguments in group brace

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -180,7 +180,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:defined"
   },
   ":dir": {
-    "syntax": ":dir( ltr | rtl )",
+    "syntax": ":dir( [ ltr | rtl ] )",
     "groups": [
       "Pseudo-classes",
       "Selectors"


### PR DESCRIPTION
The syntax for the `:dir` pseudo class is incorrect.  The syntax is intended to reflect that `:dir` can accept either the `rtl` or `ltr` arguments.  However, the current syntax actually denotes two definitions: 
`:dir( ltr` and `rtl )`

The correct definition is:
`:dir( [ ltr | rtl ] )`