### PR TITLE
adding ::target-text

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -614,6 +614,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:target"
   },
+  "::target-text": {
+    "syntax": "::target-text",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::target-text"
+  },
   ":target-within": {
     "syntax": ":target-within",
     "groups": [


### PR DESCRIPTION
Adding the ::target-text pseudo. I'll be creating the rest of the docs.

Spec: https://drafts.csswg.org/css-pseudo/#selectordef-target-text
Chrome Status: https://www.chromestatus.com/feature/5689463273422848