### PR TITLE
new value in percentages enum

### DIFF
--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -48,6 +48,7 @@
         "lengthsAsPercentages",
         "logicalHeightOfContainingBlock",
         "logicalWidthOfContainingBlock",
+        "logicalHeightOrWidthOfContainingBlock",
         "maxZoomFactor",
         "minZoomFactor",
         "no",


### PR DESCRIPTION
"logicalHeightOrWidthOfContainingBlock" to represent both values for percentage.
 It's needed for the other commit for the `inset` CSS property.