### PR TITLE
Change for percentage property for `inset`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5485,7 +5485,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
-    "percentages": "logicalHeightOfContainingBlock",
+    "percentages": "logicalHeightOrWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],


### PR DESCRIPTION
`logicalHeightOrWidthOfContainingBlock` has been created in both 
https://github.com/mdn/data/blob/master/css/properties.schema.json 
and 
https://github.com/mdn/data/blob/master/l10n/css.json.

According to the documentation `inset` percentage value is relative to the containing block’s size in the corresponding axis (e.g. width for left or right, height for top and bottom)

Now on the page dedicated to this property, it says the following:
__Percentages	logical-height of containing block__
which is not entirely true.