### PR TITLE
Replace positive-integer types with ranged notation

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -273,7 +273,7 @@
     "syntax": "<length-percentage>"
   },
   "fixed-repeat": {
-    "syntax": "repeat( [ <positive-integer> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
   },
   "fixed-size": {
     "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
@@ -720,7 +720,7 @@
     "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
   },
   "track-repeat": {
-    "syntax": "repeat( [ <positive-integer> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
   },
   "track-size": {
     "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( [ <length> | <percentage> ] )"


### PR DESCRIPTION
The type `<positive-integer>` is not a standard terminal type and should be replaced with ranged notation.

See also https://github.com/w3c/csswg-drafts/issues/355