### PR TITLE
Fix fit-content syntax

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5338,7 +5338,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation"
   },
   "height": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6450,7 +6450,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-block-size"
   },
   "max-height": {
-    "syntax": "none | <length-percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
+    "syntax": "none | <length-percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6497,7 +6497,7 @@
     "status": "experimental"
   },
   "max-width": {
-    "syntax": "none | <length-percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
+    "syntax": "none | <length-percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6529,7 +6529,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-block-size"
   },
   "min-height": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6561,7 +6561,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-inline-size"
   },
   "min-width": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -9059,7 +9059,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/widows"
   },
   "width": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",

--- a/css/properties.json
+++ b/css/properties.json
@@ -5338,7 +5338,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation"
   },
   "height": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6450,7 +6450,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-block-size"
   },
   "max-height": {
-    "syntax": "none | <length-percentage> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "none | <length-percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6497,7 +6497,7 @@
     "status": "experimental"
   },
   "max-width": {
-    "syntax": "none | <length-percentage> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "none | <length-percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6529,7 +6529,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-block-size"
   },
   "min-height": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -6561,7 +6561,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-inline-size"
   },
   "min-width": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -9059,7 +9059,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/widows"
   },
   "width": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content [ (<length-percentage>) ]?",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",


### PR DESCRIPTION
`fit-content` is a function but we can use it without parenthesises and arguments
https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content

So, I suggest these changes to the syntax

Thanks!