### PR TITLE
move pointer-events

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7494,7 +7494,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "Pointer Events"
+      "CSS Basic User Interface"
     ],
     "initial": "auto",
     "appliesto": "allElements",


### PR DESCRIPTION
Moving the `pointer-events` CSS property to CSS Basic User Interface as per the WG resolution.

This fixes: https://github.com/mdn/content/issues/3027