### PR TITLE
update ruby-position

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7664,7 +7664,7 @@
     "status": "experimental"
   },
   "ruby-position": {
-    "syntax": "over | under | inter-character",
+    "syntax": "[ alternate || [ over | under ] ] | inter-character",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",
@@ -7672,7 +7672,7 @@
     "groups": [
       "CSS Ruby"
     ],
-    "initial": "over",
+    "initial": "alternate",
     "appliesto": "rubyAnnotationsContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",


### PR DESCRIPTION
The syntax and initial value of `ruby-position` has changed in the spec: https://www.w3.org/TR/css-ruby-1/#rubypos

This PR updates these as part of https://github.com/mdn/content/issues/3457