### PR TITLE
adds :user-valid pseudo

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -641,6 +641,15 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-invalid"
   },
+  ":user-valid": {
+    "syntax": ":user-valid",
+    "groups": [
+      "Pseudo-classes",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-valid"
+  },
   ":valid": {
     "syntax": ":valid",
     "groups": [


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/3455

This PR adds the syntax for `:user-valid`.