### PR TITLE
Add `visual-box` syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -758,6 +758,9 @@
   "viewport-length": {
     "syntax": "auto | <length-percentage>"
   },
+  "visual-box": {
+    "syntax": "content-box | padding-box | border-box"
+  },
   "wq-name": {
     "syntax": "<ns-prefix>? <ident-token>"
   }


### PR DESCRIPTION
I noticed that `<visual-box>` was missing

Related: https://github.com/mdn/data/pull/464
Ping @rachelandrew 