### PR TITLE
updating the syntax for image-set

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -339,7 +339,7 @@
     "syntax": "image-set( <image-set-option># )"
   },
   "image-set-option": {
-    "syntax": "[ <image> | <string> ] <resolution>"
+    "syntax": "[ <image> | <string> ] [ <resolution> || type(<string>) ]"
   },
   "image-src": {
     "syntax": "<url> | <string>"


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/4306

The `image-set()` function now accepts a `type()`.