### PR TITLE
Update `:host()`, `:host-context()`, and `::slotted()` syntax to `compound-selector`

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -297,7 +297,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:has"
   },
   ":host()": {
-    "syntax": ":host( <compound-selector-list> )",
+    "syntax": ":host( <compound-selector> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -306,7 +306,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host()"
   },
   ":host-context()": {
-    "syntax": ":host-context( <compound-selector-list> )",
+    "syntax": ":host-context( <compound-selector> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -1024,7 +1024,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::selection"
   },
   "::slotted": {
-    "syntax": "::slotted( <compound-selector-list> )",
+    "syntax": "::slotted( <compound-selector> )",
     "groups": [
       "Pseudo-elements",
       "Selectors"


### PR DESCRIPTION
The `:host()`, `::host-context()`, and `::slotted()` pseudo-classes now take a `compound-selector`, instead of a `compound-selector-list`.

Change: https://github.com/w3c/csswg-drafts/pull/5673/files
Discussion: https://github.com/w3c/csswg-drafts/issues/2158
Latest spec sections:
https://drafts.csswg.org/css-scoping/#selectordef-host-function
https://drafts.csswg.org/css-scoping/#selectordef-host-context
https://drafts.csswg.org/css-scoping/#selectordef-slotted