### PR TITLE
feat(css): Add `accent-color` css property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1687,6 +1687,22 @@
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
+  "accent-color": {
+    "syntax": "auto | <color>",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asAutoOrColor",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/accent-color"
+  },
   "align-content": {
     "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
     "media": "visual",


### PR DESCRIPTION
Added the `accent-color` property from https://drafts.csswg.org/css-ui-4/#widget-accent. I'm currently making the relevant PRs to add this to MDN. As the mdn_url is a 404 currently I don't know if I'm meant to include it in this PR or not. Happy to remove if necessary.