### PR TITLE
feat(css): Update `scrollbar-gutter` to match updated spec

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7729,7 +7729,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-color"
   },
   "scrollbar-gutter": {
-    "syntax": "auto | [ stable | always ] && both? && force?",
+    "syntax": "auto | stable && both-edges?",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -7738,7 +7738,7 @@
       "CSS Overflow"
     ],
     "initial": "auto",
-    "appliesto": "allElements",
+    "appliesto": "scrollingBoxes",
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",


### PR DESCRIPTION
The scrollbar-gutter spec has been simplified recently, this makes the changes to bring the syntax data up-to-date.

Based on: 
https://github.com/w3c/csswg-drafts/issues/6349

and https://github.com/w3c/csswg-drafts/issues/4674

and https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property as of 2021-07-17