### PR TITLE
Fix -moz-force-broken-image-icon formal syntax since rendering appears broken

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -950,7 +950,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-float-edge"
   },
   "-moz-force-broken-image-icon": {
-    "syntax": "<integer [0,1]>",
+    "syntax": "0 | 1",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
Currently, [the page for -moz-force-broken-image-icon](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-force-broken-image-icon#formal_syntax) displays this for the formal syntax: 
![image](https://user-images.githubusercontent.com/2413436/131850468-62603fa3-0bbe-4895-ac97-b69cc3ff206a.png)
where we can see an unmatched angle bracket.

This change should be sufficient to fix this.

Note; reported on Twitter https://twitter.com/nhoizey/status/1433332949236264961
