### PR TITLE
Adds new small-caps keyword to font-synthesis

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4770,7 +4770,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-style"
   },
   "font-synthesis": {
-    "syntax": "none | [ weight || style ]",
+    "syntax": "none | [ weight || style || small-caps ]",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8611

The small-caps keyword is in Fonts Level 5.