### PR TITLE
fix -webkit-tap-highlight-color property's 'inherited' data

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1570,7 +1570,7 @@
   "-webkit-tap-highlight-color": {
     "syntax": "<color>",
     "media": "visual",
-    "inherited": false,
+    "inherited": true,
     "animationType": "discrete",
     "percentages": "no",
     "groups": [


### PR DESCRIPTION
false -> true, as it is an inherited property according to its [specs](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW5)

Closes mdn/content#10886