### PR TITLE
Update counter related syntaxes according to specs

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4187,7 +4187,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain"
   },
   "content": {
-    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ <string> ]?",
+    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> ]+ ]?",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",
@@ -4219,7 +4219,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/content-visibility"
   },
   "counter-increment": {
-    "syntax": "[ <custom-ident> <integer>? ]+ | none",
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",
@@ -4235,7 +4235,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-increment"
   },
   "counter-reset": {
-    "syntax": "[ <custom-ident> <integer>? ]+ | none",
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",
@@ -4251,7 +4251,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-reset"
   },
   "counter-set": {
-    "syntax": "[ <custom-ident> <integer>? ]+ | none",
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -153,7 +153,7 @@
     "syntax": "space-between | space-around | space-evenly | stretch"
   },
   "content-list": {
-    "syntax": "[ <string> | contents | <image> | <quote> | <target> | <leader()> ]+"
+    "syntax": "[ <string> | contents | <image> | <counter> | <quote> | <target> | <leader()> ]+"
   },
   "content-position": {
     "syntax": "center | start | end | flex-start | flex-end"
@@ -164,8 +164,14 @@
   "contrast()": {
     "syntax": "contrast( [ <number-percentage> ] )"
   },
+  "counter": {
+    "syntax": "<counter()> | <counters()>"
+  },
   "counter()": {
-    "syntax": "counter( <custom-ident>, <counter-style>? )"
+    "syntax": "counter( <counter-name>, <counter-style>? )"
+  },
+  "counter-name": {
+    "syntax": "<custom-ident>"
   },
   "counter-style": {
     "syntax": "<counter-style-name> | symbols()"
@@ -174,7 +180,7 @@
     "syntax": "<custom-ident>"
   },
   "counters()": {
-    "syntax": "counters( <custom-ident>, <string>, <counter-style>? )"
+    "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
   },
   "cross-fade()": {
     "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"


### PR DESCRIPTION
Counter related syntaxes are outdated. For instance, according to current state in mdn-data, `counter()` and `counters()` functions can't be used for `content` property (see [issue](https://github.com/csstree/validator/issues/24)).

This PR updates syntaxes according to [CSS Generated Content Module Level 3](https://www.w3.org/TR/css-content-3/) (2 August 2019) and [CSS Lists and Counters Module Level 3](https://www.w3.org/TR/css-lists-3/) (17 November 2020).