### PR TITLE
fix: change branch reference to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
Change branch reference to `main` from `master` in `lint.yml`
