### PR TITLE
fix(css): added the forgiving-selector-list production for :is() and :has() functional pseudo-classes

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -288,7 +288,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:focus-within"
   },
   ":has": {
-    "syntax": ":has( <relative-selector-list> )",
+    "syntax": ":has( <forgiving-relative-selector-list> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -351,7 +351,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:invalid"
   },
   ":is": {
-    "syntax": ":is( <complex-selector-list> )",
+    "syntax": ":is( <forgiving-selector-list> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"


### PR DESCRIPTION
This two pseudo-classes use a forgiving-selector-list. It is important, because forgiving and non-forgiving lists handle erroneous selectors differently.

I have wrote about it in russian here - https://t.me/css_mind/15.

And it's also written in the specification - https://drafts.csswg.org/selectors/#forgiving-selector

I won't be able to figure out how to insert this token into the `css/syntaxes.json`, because the spec describes it in prose. Can you help me with this?) I can write an article about it, if you prefer.