### PR TITLE
Fix initial value of appearance

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1972,7 +1972,7 @@
     "groups": [
       "CSS Basic User Interface"
     ],
-    "initial": "auto",
+    "initial": "none",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "perGrammar",


### PR DESCRIPTION
Initial value is `auto` and no more `none`.

Fixes #554