### PR TITLE
Add missed <layer-name> syntax

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -380,6 +380,9 @@
   "layer()": {
     "syntax": "layer( <layer-name> )"
   },
+  "layer-name": {
+    "syntax": "<ident> [ '.' <ident> ]*"
+  },
   "leader()": {
     "syntax": "leader( <leader-type> )"
   },


### PR DESCRIPTION
https://www.w3.org/TR/css-cascade-5/#typedef-layer-name