### PR TITLE
Add lab() & lch() to color

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -102,7 +102,7 @@
     "syntax": "<url>"
   },
   "color": {
-    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>"
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>"
   },
   "color-stop": {
     "syntax": "<color-stop-length> | <color-stop-angle>"


### PR DESCRIPTION
Functions [lab](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lab()) & [lch](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lch()) are already defined in [color_value page](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) and supported on Safari. I see that [specification](https://www.w3.org/TR/css-color-4/#color-syntax) also mentiones &lt;oklab()> | &lt;oklch()>, but they aren't defined anywhere in MDN, should I add them too?