### PR TITLE
fix(css): update "outline-style" syntax

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6948,7 +6948,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-offset"
   },
   "outline-style": {
-    "syntax": "auto | <'border-style'>",
+    "syntax": "auto | <'outline-line-style'>",
     "media": [
       "visual",
       "interactive"


### PR DESCRIPTION
 Formal Syntax incorrectly implies that all border-style values can be used. Fix https://github.com/mdn/data/issues/567

See for more info: https://www.w3.org/TR/css-ui-4/#typedef-outline-line-style