### PR TITLE
Update all property syntax for new keyword revert-layer

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1768,7 +1768,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-tracks"
   },
   "all": {
-    "syntax": "initial | inherit | unset | revert",
+    "syntax": "initial | inherit | unset | revert | revert-layer",
     "media": "noPracticalMedia",
     "inherited": false,
     "animationType": "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",


### PR DESCRIPTION
A new global keyword was introduced in FF97, `revert-layer`.

This keyword can applied to any CSS property, including the `all` CSS property.

This PR modifies the Formal syntax for the `all` property.

#### Related issues

Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for the new `revert-layer` page: https://github.com/mdn/content/pull/14287

#### Supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

