### PR TITLE
plus-lighter in mix-blend-mode

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6661,7 +6661,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-width"
   },
   "mix-blend-mode": {
-    "syntax": "<blend-mode>",
+    "syntax": "<blend-mode> | plus-lighter",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
plus-lighter value is present in [specification](https://drafts.fxtf.org/compositing/#mix-blend-mode) and [implemented](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode#browser_compatibility) on chromium and firefox.

Specification also includes plus-darker value, but it is not supported anywhere, so I think it shouldnt be added yet.