### PR TITLE
Update 'Animation type' for animation properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1823,7 +1823,7 @@
     "syntax": "<time>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1839,7 +1839,7 @@
     "syntax": "<single-animation-direction>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1855,7 +1855,7 @@
     "syntax": "<time>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1871,7 +1871,7 @@
     "syntax": "<single-animation-fill-mode>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1887,7 +1887,7 @@
     "syntax": "<single-animation-iteration-count>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1903,7 +1903,7 @@
     "syntax": "[ none | <keyframes-name> ]#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1919,7 +1919,7 @@
     "syntax": "<single-animation-play-state>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1935,7 +1935,7 @@
     "syntax": "<easing-function>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1951,7 +1951,7 @@
     "syntax": "<single-animation-timeline>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "not animatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"

--- a/css/properties.json
+++ b/css/properties.json
@@ -1787,7 +1787,7 @@
     "syntax": "<single-animation>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1823,7 +1823,7 @@
     "syntax": "<time>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1839,7 +1839,7 @@
     "syntax": "<single-animation-direction>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1855,7 +1855,7 @@
     "syntax": "<time>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1871,7 +1871,7 @@
     "syntax": "<single-animation-fill-mode>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1887,7 +1887,7 @@
     "syntax": "<single-animation-iteration-count>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1903,7 +1903,7 @@
     "syntax": "[ none | <keyframes-name> ]#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1919,7 +1919,7 @@
     "syntax": "<single-animation-play-state>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1935,7 +1935,7 @@
     "syntax": "<easing-function>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"
@@ -1951,7 +1951,7 @@
     "syntax": "<single-animation-timeline>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "not animatable",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Animations"


### PR DESCRIPTION
### Summary
This PR updates the 'Animation type' value from discrete to `not animatable` for the following properties:

- animation-name - spec link with supporting info: https://drafts.csswg.org/css-animations/#animation-name
- animation-duration - https://drafts.csswg.org/css-animations/#animation-duration
- animation-timing-function - https://drafts.csswg.org/css-animations/#animation-timing-function
- animation-delay - https://drafts.csswg.org/css-animations/#animation-delay
- animation-direction - https://drafts.csswg.org/css-animations/#animation-direction
- animation-iteration-count - https://drafts.csswg.org/css-animations/#animation-iteration-count
- animation-fill-mode - https://drafts.csswg.org/css-animations/#animation-fill-mode
- animation-play-state - https://drafts.csswg.org/css-animations/#animation-play-state
- animation-timeline - https://drafts.csswg.org/css-animations-2/#animation-timeline
- animation - https://drafts.csswg.org/css-animations/#animation

### Motivation
https://github.com/mdn/content/issues/16994#issuecomment-1167337979