### PR TITLE
fix(css): correct two syntax examples in selectors

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -541,7 +541,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown"
   },
   ":playing": {
-    "syntax": ":checked",
+    "syntax": ":playing",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -748,7 +748,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-clear"
   },
   "::-ms-expand": {
-    "syntax": "::-ms-clear",
+    "syntax": "::-ms-expand",
     "groups": [
       "Pseudo-elements",
       "Selectors",


### PR DESCRIPTION
`:playing` and `::-ms-expand` have syntax examples from other selector examples.