### PR TITLE
Add syntaxes to CSS trigonometric functions

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -3,7 +3,7 @@
     "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
   },
   "acos()": {
-    "syntax": "acos( [ <number> | <angle> ] )"
+    "syntax": "acos( <calc-sum> )"
   },
   "alpha-value": {
     "syntax": "<number> | <percentage>"
@@ -24,13 +24,13 @@
     "syntax": "scroll-position | contents | <custom-ident>"
   },
   "asin()": {
-    "syntax": "asin( [ <number> | <angle> ] )"
+    "syntax": "asin( <calc-sum> )"
   },
   "atan()": {
-    "syntax": "atan( [ <number> | <angle> ] )"
+    "syntax": "atan( <calc-sum> )"
   },
   "ata2n()": {
-    "syntax": "atan2( [ <number> | <dimension> | <percentage> ] [, <number> | <dimension> | <percentage> ]? )"
+    "syntax": "atan2( <calc-sum>, <calc-sum> )"
   },
   "attachment": {
     "syntax": "scroll | fixed | local"
@@ -177,7 +177,7 @@
     "syntax": "contrast( [ <number-percentage> ] )"
   },
   "cos()": {
-    "syntax": "cos( [ <number> | <angle> ] )"
+    "syntax": "cos( <calc-sum> )"
   },
   "counter": {
     "syntax": "<counter()> | <counters()>"
@@ -693,7 +693,7 @@
     "syntax": "[ left | right ] || [ top | bottom ]"
   },
   "sin()": {
-    "syntax": "sin( [ <number> | <angle> ] )"
+    "syntax": "sin( <calc-sum> )"
   },
   "single-animation": {
     "syntax": "<time> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
@@ -750,7 +750,7 @@
     "syntax": "<string> | <image> | <custom-ident>"
   },
   "tan()": {
-    "syntax": "tan( [ <number> | <angle> ] )"
+    "syntax": "tan( <calc-sum> )"
   },
   "target": {
     "syntax": "<target-counter()> | <target-counters()> | <target-text()>"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -2,6 +2,9 @@
   "absolute-size": {
     "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
   },
+  "acos()": {
+    "syntax": "acos( [ <number> | <angle> ] )"
+  },
   "alpha-value": {
     "syntax": "<number> | <percentage>"
   },
@@ -19,6 +22,15 @@
   },
   "animateable-feature": {
     "syntax": "scroll-position | contents | <custom-ident>"
+  },
+  "asin()": {
+    "syntax": "asin( [ <number> | <angle> ] )"
+  },
+  "atan()": {
+    "syntax": "atan( [ <number> | <angle> ] )"
+  },
+  "ata2n()": {
+    "syntax": "atan2( [ <number> | <dimension> | <percentage> ] [, <number> | <dimension> | <percentage> ]? )"
   },
   "attachment": {
     "syntax": "scroll | fixed | local"
@@ -163,6 +175,9 @@
   },
   "contrast()": {
     "syntax": "contrast( [ <number-percentage> ] )"
+  },
+  "cos()": {
+    "syntax": "cos( [ <number> | <angle> ] )"
   },
   "counter": {
     "syntax": "<counter()> | <counters()>"
@@ -677,6 +692,9 @@
   "side-or-corner": {
     "syntax": "[ left | right ] || [ top | bottom ]"
   },
+  "sin()": {
+    "syntax": "sin( [ <number> | <angle> ] )"
+  },
   "single-animation": {
     "syntax": "<time> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
   },
@@ -730,6 +748,9 @@
   },
   "symbol": {
     "syntax": "<string> | <image> | <custom-ident>"
+  },
+  "tan()": {
+    "syntax": "tan( [ <number> | <angle> ] )"
   },
   "target": {
     "syntax": "<target-counter()> | <target-counters()> | <target-text()>"


### PR DESCRIPTION
Part of the documentation work on [CSS trigonometric functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions#trigonometric_functions).

[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) those CSS functions. [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1190444) will follow soon.