### PR TITLE
chore: add inline-size to contain property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4189,7 +4189,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/columns"
   },
   "contain": {
-    "syntax": "none | strict | content | [ size || layout || style || paint ]",
+    "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
This PR adds the `inline-size` value for the `contain` property

__notes:__

Relates to https://github.com/mdn/content/issues/18758
