### PR TITLE
chore: add deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MDN data
 
+> NOTE: We are in the process of deprecating the `mdn/data` package in favour of [`w3c/webref`](https://github.com/w3c/webref). If this could present a problem to your project, please reach out to use via our [GitHub discussions](https://github.com/mdn/mdn-community/discussions/categories/platform). Thank you.
+
 [https://github.com/mdn/data](https://github.com/mdn/data)
 
 Maintained by the [MDN team at Mozilla](https://wiki.mozilla.org/MDN).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MDN data
 
-> NOTE: We are in the process of deprecating the `mdn/data` package in favour of [`w3c/webref`](https://github.com/w3c/webref). If this could present a problem to your project, please reach out to use via our [GitHub discussions](https://github.com/mdn/mdn-community/discussions/categories/platform). Thank you.
+> **Note:** We are in the process of deprecating the `mdn/data` package in favor of [`w3c/webref`](https://github.com/w3c/webref). If this could present a problem to your project, please contact us via our [GitHub discussions](https://github.com/mdn/mdn-community/discussions/categories/platform). Thank you.
 
 [https://github.com/mdn/data](https://github.com/mdn/data)
 


### PR DESCRIPTION
Add a note about `mdn/data` being deprecated in favour of `webref`