### PR TITLE
Add animation-composition to the properties database

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1819,6 +1819,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation"
   },
+  "animation-composition": {
+    "syntax": "<single-animation-composition>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "replace",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-composition"
+  },
   "animation-delay": {
     "syntax": "<time>#",
     "media": "visual",
@@ -1960,7 +1976,7 @@
     "appliesto": "allElements",
     "computed": "listEachItemIdentifyerOrNoneAuto",
     "order": "uniqueOrder",
-    "status": "standard",
+    "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline"
   },
   "appearance": {


### PR DESCRIPTION
1. This PR adds `animation-composition` to the database.

Source: https://drafts.csswg.org/css-animations-2/#animation-composition
Doc issue tracker: https://github.com/mdn/content/issues/18771

Notes about `animation-composition`:
- Not yet supported in the shorthand `animation` property
- Behind a preference in FF104
- Not yet implemented in Chrome and Safari

2. This PR also updates the "status" for `animation-timeline` (For reference: https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline)