### PR TITLE
docs(typo): fix typo in atan2() function, format README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ or [sidebar navigation](https://developer.mozilla.org/en-US/docs/Web/API/Window)
 External tools have started to make use of this data as well.
 For example, the [CSSTree](https://github.com/csstree/csstree/) CSS parser.
 
-
 [![NPM version](https://img.shields.io/npm/v/mdn-data.svg)](https://www.npmjs.com/package/mdn-data)
 [![lint](https://github.com/mdn/data/actions/workflows/lint.yml/badge.svg)](https://github.com/mdn/data/actions/workflows/lint.yml)
 
@@ -23,22 +22,26 @@ and `css`. Inside each of these directories is one or more
 JSON files containing the data.
 
 ### api
+
 Contains data about Web APIs:
-* API inheritance (interface inheritance and mixin implementations)
+
+- API inheritance (interface inheritance and mixin implementations)
 
 ### css
- Contains data about:
-* CSS at-rules
-* CSS properties
-* CSS selectors
-* CSS syntaxes
-* CSS types
-* CSS units
+
+Contains data about:
+
+- CSS at-rules
+- CSS properties
+- CSS selectors
+- CSS syntaxes
+- CSS types
+- CSS units
 
 Read more about [CSS data](https://github.com/mdn/data/blob/master/css/readme.md) and the format of the files.
 
-
 ### l10n
+
 The l10n folder contains localization strings that are used in the various
 json files throughout this repository.
 
@@ -52,5 +55,6 @@ We're very happy to accept contributions to this data. Please familiarize yourse
 with the schema for the data you're editing, and send us a pull request. See also the [Contributing file](https://github.com/mdn/data/blob/master/CONTRIBUTING.md) for more information.
 
 ## See also
-* [https://github.com/mdn/browser-compat-data](https://github.com/mdn/browser-compat-data)
-for compatibility data for Web technologies
+
+- [https://github.com/mdn/browser-compat-data](https://github.com/mdn/browser-compat-data)
+  for compatibility data for Web technologies

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -32,7 +32,7 @@
   "atan()": {
     "syntax": "atan( <calc-sum> )"
   },
-  "ata2n()": {
+  "atan2()": {
     "syntax": "atan2( <calc-sum>, <calc-sum> )"
   },
   "attachment": {


### PR DESCRIPTION
__Description:__
This PR contains the following changes:

* typo `ata2n()` -> `atan2()`
* Format `README.md`