### PR TITLE
Add `<calc-constant>` to CSS Syntaxes

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -96,7 +96,10 @@
     "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
   },
   "calc-value": {
-    "syntax": "<number> | <dimension> | <percentage> | ( <calc-sum> )"
+    "syntax": "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
+  },
+  "calc-constant": {
+    "syntax": "e | pi | infinity | -infinity | NaN"
   },
   "cf-final-image": {
     "syntax": "<image> | <color>"


### PR DESCRIPTION
Source: https://w3c.github.io/csswg-drafts/css-values-4/#calc-syntax