### PR TITLE
Add `<rounding-strategy>` to CSS Syntaxes

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -662,6 +662,9 @@
   "round()": {
     "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
   },
+  "rounding-strategy": {
+    "syntax": "nearest | up | down | to-zero"
+  },
   "saturate()": {
     "syntax": "saturate( <number-percentage> )"
   },


### PR DESCRIPTION
Source: https://w3c.github.io/csswg-drafts/css-values-4/#calc-syntax