### PR TITLE
properties-schema: elementsForWhichLayoutContainmentCanApply

### DIFF
--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -119,6 +119,7 @@
         "asSpecifiedURLsAbsolute",
         "asSpecifiedWithExceptionOfResolution",
         "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn",
+        "asSpecifiedWithLengthValuesComputed",
         "asSpecifiedWithVarsSubstituted",
         "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
         "autoOrRectangle",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -199,6 +199,7 @@
         "childrenOfBoxElements",
         "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
         "elementsForWhichLayoutContainmentCanApply",
+        "elementsForWhichSizeContainmentCanApply",
         "elementsWithDisplayBoxOrInlineBox",
         "elementsWithDisplayMarker",
         "elementsWithDisplayMozBoxMozInlineBox",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -655,6 +655,9 @@
     "ja": "この一括指定のそれぞれのプロパティとして ({{cssxref(\"unicode-bidi\")}} と {{cssxref(\"direction\")}}) を除いたすべてのプロパティ",
     "ru": "как у каждого из подсвойств этого свойства (все свойства, кроме {{cssxref(\"unicode-bidi\")}} и {{cssxref(\"direction\")}})"
   },
+  "elementsForWhichSizeContainmentCanApply": {
+    "en-US": "elements for which size containment can apply"
+  },
   "elementsWithDisplayBoxOrInlineBox": {
     "de": "Elemente mit einem CSS {{cssxref(\"display\")}} Wert von <code>box</code> oder <code>inline-box</code>",
     "en-US": "elements with a CSS {{cssxref(\"display\")}} value of <code>box</code> or <code>inline-box</code>",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -433,6 +433,9 @@
     "en-US": "as specified, with &lt;length&gt;s made absolute, and normal computing to zero except on multi-column elements",
     "ja": "指定通りで、 &lt;length&gt; は絶対長になり、 normal の計算値は段組み要素を除き 0 になる"
   },
+  "asSpecifiedWithLengthValuesComputed": {
+    "en-US": "as specified, with &lt;length&gt;s values computed"
+  },  
   "asSpecifiedWithVarsSubstituted": {
     "de": "wie angegeben, wobei Variablen ersetzt werden",
     "en-US": "as specified with variables substituted",


### PR DESCRIPTION
This is to allow addition of the contain-intrinsic-width, contain-intrinsic-height, contain-intrinsic-block-size, contain-intrinsic-inline-size in https://w3c.github.io/csswg-drafts/css-sizing-4/#intrinsic-size-override 