### PR TITLE
Add `<function-token>` to CSS Syntaxes

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -314,6 +314,9 @@
   "font-weight-absolute": {
     "syntax": "normal | bold | <number [1,1000]>"
   },
+  "function-token": {
+    "syntax": "<ident-token>("
+  },
   "frequency-percentage": {
     "syntax": "<frequency> | <percentage>"
   },


### PR DESCRIPTION
Source: https://www.w3.org/TR/css-syntax-3/#function-token-diagram