### PR TITLE
Make media optional in schema

### DIFF
--- a/css/at-rules.schema.json
+++ b/css/at-rules.schema.json
@@ -102,7 +102,6 @@
           },
           "required": [
             "syntax",
-            "media",
             "initial",
             "percentages",
             "computed",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -293,7 +293,6 @@
     "additionalProperties": false,
     "required": [
       "syntax",
-      "media",
       "inherited",
       "animationType",
       "percentages",


### PR DESCRIPTION
This ought to make `media` optional in the CSS schema. If I have understood it properly 🤞 .

We have not rendered `media` for a long time on MDN (https://github.com/mdn/kumascript/pull/1356) and I think the specs have stopped including it as well. So it's silly for the linter to complain about it.
