### PR TITLE
Add computed table to padding-block/padding-inline

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7382,14 +7382,20 @@
     "syntax": "<'padding-left'>{1,2}",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "length",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asLength",
+    "initial": [
+      "padding-block-start",
+      "padding-block-end"
+    ],
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": [
+      "padding-block-start",
+      "padding-block-end"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block"
@@ -7404,7 +7410,7 @@
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
     "computed": "asLength",
     "order": "uniqueOrder",
     "status": "standard",
@@ -7420,7 +7426,7 @@
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
     "computed": "asLength",
     "order": "uniqueOrder",
     "status": "standard",
@@ -7450,14 +7456,20 @@
     "syntax": "<'padding-left'>{1,2}",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "length",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "0",
-    "appliesto": "allElements",
-    "computed": "asLength",
+    "initial": [
+      "padding-inline-start",
+      "padding-inline-end"
+    ],
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": [
+      "padding-inline-start",
+      "padding-inline-end"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline"
@@ -7472,7 +7484,7 @@
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
     "computed": "asLength",
     "order": "uniqueOrder",
     "status": "standard",
@@ -7488,7 +7500,7 @@
       "CSS Logical Properties"
     ],
     "initial": "0",
-    "appliesto": "allElements",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
     "computed": "asLength",
     "order": "uniqueOrder",
     "status": "standard",


### PR DESCRIPTION
Partial fix for #477

Updates the padding-block and padding-inline properties to be marked as shorthands with the computed table. The spec [lists them as shorthands for -start and -end](https://w3c.github.io/csswg-drafts/css-logical-1/#propdef-padding-block) so I felt it makes sense to put that in the table here.

This helps fix frenic/csstype#93 and I hoped to reopen discussion since the issues haven't been worked on for a year. Microsoft's CSS-in-JS library (and other CSS libraries) need shorthands to be clearly marked [to avoid issues](https://github.com/frenic/glitz/#shorthand-properties).

If this computed table is inaccurate I'd like to explore other alternatives. If it is, I can update other logical shorthand properties to match.