### PR TITLE
Add computed table to margin and inset

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7715,9 +7715,15 @@
     "groups": [
       "CSS Box Alignment"
     ],
-    "initial": "normal",
+    "initial": [
+      "align-content",
+      "justify-content"
+    ],
     "appliesto": "multilineFlexContainers",
-    "computed": "asSpecified",
+    "computed": [
+      "align-content",
+      "justify-content"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-content"

--- a/css/properties.json
+++ b/css/properties.json
@@ -5678,9 +5678,19 @@
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "auto",
+    "initial": [
+      "top",
+      "bottom",
+      "left",
+      "right"
+    ],
     "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
+    "computed": [
+      "top",
+      "bottom",
+      "left",
+      "right"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset"
@@ -5694,9 +5704,15 @@
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "auto",
+    "initial": [
+      "inset-block-start",
+      "inset-block-end"
+    ],
     "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
+    "computed": [
+      "inset-block-start",
+      "inset-block-end"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block"
@@ -5742,9 +5758,15 @@
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "auto",
+    "initial": [
+      "inset-inline-start",
+      "inset-inline-end"
+    ],
     "appliesto": "positionedElements",
-    "computed": "sameAsBoxOffsets",
+    "computed": [
+      "inset-inline-start",
+      "inset-inline-end"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline"
@@ -6071,14 +6093,20 @@
     "syntax": "<'margin-left'>{1,2}",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "length",
     "percentages": "dependsOnLayoutModel",
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "0",
+    "initial": [
+      "margin-block-start",
+      "margin-block-end"
+    ],
     "appliesto": "sameAsMargin",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "computed": [
+      "margin-block-start",
+      "margin-block-end"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block"
@@ -6139,14 +6167,20 @@
     "syntax": "<'margin-left'>{1,2}",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "length",
     "percentages": "dependsOnLayoutModel",
     "groups": [
       "CSS Logical Properties"
     ],
-    "initial": "0",
+    "initial": [
+      "margin-inline-start",
+      "margin-inline-end"
+    ],
     "appliesto": "sameAsMargin",
-    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "computed": [
+      "margin-inline-start",
+      "margin-inline-end"
+    ],
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline"


### PR DESCRIPTION
Partial fix for #477

Updates the margin-block, margin-inline, inset, inset-block, inset-inline, and place-content properties to be marked as shorthands with the computed table. The spec [lists them as shorthands for -start and -end](https://w3c.github.io/csswg-drafts/css-logical-1/#propdef-margin-block) so I felt it makes sense to put that in the table here.

This helps fix frenic/csstype#93 and builds off #612