### PR TITLE
Add caret and caret-shape CSS properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3906,6 +3906,30 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caption-side"
   },
+  "caret": {
+    "syntax": "<'caret-color'> || <'caret-shape'>",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": [
+      "caret-color",
+      "caret-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": [
+      "caret-color",
+      "caret-shape"
+    ],
+    "appliesto": "elementsThatAcceptInput",
+    "computed": [
+      "caret-color",
+      "caret-shape"
+    ],
+    "order": "perGrammar",
+    "status": "standard"
+  },
   "caret-color": {
     "syntax": "auto | <color>",
     "media": "interactive",
@@ -3921,6 +3945,21 @@
     "order": "perGrammar",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caret-color"
+  },
+  "caret-shape": {
+    "syntax": "auto | bar | block | underscore",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "elementsThatAcceptInput",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard"
   },
   "clear": {
     "syntax": "none | left | right | both | inline-start | inline-end",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -201,6 +201,7 @@
         "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
         "elementsForWhichLayoutContainmentCanApply",
         "elementsForWhichSizeContainmentCanApply",
+        "elementsThatAcceptInput",
         "elementsWithDisplayBoxOrInlineBox",
         "elementsWithDisplayMarker",
         "elementsWithDisplayMozBoxMozInlineBox",
@@ -255,11 +256,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "enum": [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ]
+        "enum": ["::first-letter", "::first-line", "::placeholder"]
       }
     },
     "order": {
@@ -275,12 +272,7 @@
       ]
     },
     "status": {
-      "enum": [
-        "standard",
-        "nonstandard",
-        "experimental",
-        "obsolete"
-      ]
+      "enum": ["standard", "nonstandard", "experimental", "obsolete"]
     },
     "mdn_url": {
       "type": "string",
@@ -329,11 +321,7 @@
             "uniqueItems": true,
             "items": {
               "type": "string",
-              "enum": [
-                "interactive",
-                "paged",
-                "visual"
-              ]
+              "enum": ["interactive", "paged", "visual"]
             }
           }
         ]

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -256,7 +256,11 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "enum": ["::first-letter", "::first-line", "::placeholder"]
+        "enum": [
+          "::first-letter",
+          "::first-line",
+          "::placeholder"
+        ]
       }
     },
     "order": {
@@ -272,7 +276,12 @@
       ]
     },
     "status": {
-      "enum": ["standard", "nonstandard", "experimental", "obsolete"]
+      "enum": [
+        "standard",
+        "nonstandard",
+        "experimental",
+        "obsolete"
+      ]
     },
     "mdn_url": {
       "type": "string",
@@ -321,7 +330,11 @@
             "uniqueItems": true,
             "items": {
               "type": "string",
-              "enum": ["interactive", "paged", "visual"]
+              "enum": [
+                "interactive",
+                "paged",
+                "visual"
+              ]
             }
           }
         ]


### PR DESCRIPTION
Adds properties from [CSS Basic User Interface](https://www.w3.org/TR/css-ui-4/#insertion-caret) spec.

Since "elements that accept input" wasn't already listed as an `appliesto` option, I added it to the schema. Are additional steps needed?