### PR TITLE
border-image-repeat applied to ::first-letter removed

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2899,9 +2899,6 @@
     "appliesto": "allElementsExceptTableElementsWhenCollapse",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "alsoAppliesTo": [
-      "::first-letter"
-    ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-repeat"
   },


### PR DESCRIPTION
According to the official doc - [https://www.w3.org/TR/css-backgrounds-3/#border-image-repeat](https://www.w3.org/TR/css-backgrounds-3/#border-image-repeat), and testing I have done personally, the CSS border-image-repeat property doesn't apply just to the ::first-letter of the paragraph tag, it doesn't display any border image at all or even repeats what was placed on it.