### PR TITLE
border-image-outset applied to ::first-letter removed

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2880,9 +2880,6 @@
     "appliesto": "allElementsExceptTableElementsWhenCollapse",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "alsoAppliesTo": [
-      "::first-letter"
-    ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-outset"
   },


### PR DESCRIPTION
According to the official doc - https://www.w3.org/TR/css-backgrounds-3/#border-image-outset, and testing I have done personally, the CSS border-image-outset property doesn't apply to the ::first-letter of the paragraph tag, it doesn't display any border image at all or even creates a distance between the paragraph's border image and its border box.