### PR TITLE
border-image-slice applied to ::first-letter removed

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2918,9 +2918,6 @@
     "appliesto": "allElementsExceptTableElementsWhenCollapse",
     "computed": "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
     "order": "percentagesOrLengthsFollowedByFill",
-    "alsoAppliesTo": [
-      "::first-letter"
-    ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-slice"
   },


### PR DESCRIPTION
According to the official doc - https://www.w3.org/TR/css-backgrounds-3/#border-image-slice, and testing I have done personally, the CSS border-image-slice property doesn't apply to the ::first-letter of the paragraph tag, it doesn't display any border image at all or even creates a border image slice.