### PR TITLE
border-image-source applied to ::first-letter removed

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2937,9 +2937,6 @@
     "appliesto": "allElementsExceptTableElementsWhenCollapse",
     "computed": "noneOrImageWithAbsoluteURI",
     "order": "uniqueOrder",
-    "alsoAppliesTo": [
-      "::first-letter"
-    ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-source"
   },


### PR DESCRIPTION
According to the official doc - https://www.w3.org/TR/css-backgrounds-3/#border-image-source, and testing I have done personally, the CSS border-image-source property doesn't apply to the ::first-letter of the paragraph tag, it doesn't display any border image at all. 

It only applies to: *All elements, except internal table elements when border-collapse is collapse*