### PR TITLE
animation-timeline - add scroll syntaxes

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -56,6 +56,9 @@
   "auto-track-list": {
     "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
   },
+  "axis": {
+    "syntax": "block | inline | vertical | horizontal"
+  },
   "baseline-position": {
     "syntax": "[ first | last ]? baseline"
   },
@@ -686,6 +689,9 @@
   "scaleZ()": {
     "syntax": "scaleZ( [ <number> | <percentage> ] )"
   },
+  "scroller": {
+    "syntax": "root | nearest"
+  },
   "self-position": {
     "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
   },
@@ -741,7 +747,7 @@
     "syntax": "running | paused"
   },
   "single-animation-timeline": {
-    "syntax": "auto | none | <timeline-name>"
+    "syntax": "auto | none | <timeline-name> | scroll(<axis>? <scroller>?)"
   },
   "single-transition": {
     "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"


### PR DESCRIPTION
The `scroll()` functional notication is added as an option for animation-timeline in https://w3c.github.io/csswg-drafts/scroll-animations-1/#funcdef-scroll

The original spec https://w3c.github.io/csswg-drafts/css-animations-2/#propdef-animation-timeline does not add this as an option - it just specifies syntax in terms of `<single-animation-timeline>`

Wasn't clear to me if it is OK to merge the cross-spec options, but that's what I've done :-). 

I don't think I need to do anything else for `scroll()` in this repo right? The content is already picking up the formal syntax from somewhere and none of the data for CSS properties etc is used for this in the spec.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/15467