### PR TITLE
fix: correct scroll-timeline-axis and mask-repeat initial value

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8627,7 +8627,7 @@
     "groups": [
       "CSS Animations"
     ],
-    "initial": "none",
+    "initial": "block",
     "appliesto": "scrollContainers",
     "computed": "asSpecified",
     "order": "perGrammar",

--- a/css/properties.json
+++ b/css/properties.json
@@ -6624,7 +6624,7 @@
     "groups": [
       "CSS Masking"
     ],
-    "initial": "no-repeat",
+    "initial": "repeat",
     "appliesto": "allElementsSVGContainerElements",
     "computed": "consistsOfTwoDimensionKeywords",
     "order": "perGrammar",


### PR DESCRIPTION
1. The current scroll-animations spec says the initial value is 'block'. https://w3c.github.io/csswg-drafts/scroll-animations/#scroll-timeline-axis. `none` does not look like a legal value to me.
2. The `mask-repeat` initial value is  `repeat`: https://drafts.fxtf.org/css-masking/#the-mask-repeat
    You can even check that on the MDN page that says the initial value is `no-repeat` by setting `mask-repeat` to `initial`.