### PR TITLE
Update word-spacing computed value

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9548,7 +9548,7 @@
     ],
     "initial": "normal",
     "appliesto": "allElements",
-    "computed": "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
+    "computed": "absoluteLength",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -140,7 +140,6 @@
         "normalizedAngle",
         "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
         "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
-        "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal",
         "optimumValueOfAbsoluteLengthOrNormal",
         "percentageAsSpecifiedAbsoluteLengthOrNone",
         "percentageAsSpecifiedOrAbsoluteLength",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1126,13 +1126,6 @@
     "ja": "1 つから 4 つのパーセント値 (指定通り) または絶対的な長さ。指定されていれば続けてキーワード <code>fill</code>",
     "ru": "одно к четырём процентам (как указано) или абсолютной длине(ам), плюс ключевое слово <code>fill</code>, если указано"
   },
-  "optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal": {
-    "de": "ein optimaler, minimaler und maximaler Wert, jeder bestehend aus entweder einer absoluten Länge, einem Prozentwert oder dem Schlüsselwort <code>normal</code>",
-    "en-US": "an optimum, minimum, and maximum value, each consisting of either an absolute length, a percentage, or the keyword <code>normal</code>",
-    "fr": "trois valeurs, optimale, minimale et maximale, chacune consitant en une longueur absolue, un pourcentage ou le mot-clé <code>normal</code>",
-    "ja": "それぞれ絶対指定の length、percentage、キーワード <code>normal</code>のいずれかである、最適値、最小値、最大値",
-    "ru": "оптимальное, минимальное и максимальное значения, каждое из которых абсолютная длина, проценты или ключевое слово <code>normal</code>"
-  },
   "optimumValueOfAbsoluteLengthOrNormal": {
     "de": "ein optimaler Wert, der entweder aus einer absoluten Länge oder dem Schlüsselwort <code>normal</code> besteht",
     "en-US": "an optimum value consisting of either an absolute length or the keyword <code>normal</code>",


### PR DESCRIPTION
See https://github.com/mdn/content/pull/21861, percentages were removed as a value for this property, so this PR updates "Computed value" to match the spec: https://w3c.github.io/csswg-drafts/css-text/#word-spacing-property.

No other property needs the optimumMinAndMaxValueOfAbsoluteLengthPercentageOrNormal value, so I also removed the definition of it.

Since we pull formal syntax from the spec now, that part was already correct :).
