### PR TITLE
add hyphenate-limit-chars property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5566,6 +5566,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphenate-character"
   },
+  "hyphenate-limit-chars": {
+    "syntax": "[ auto | <integer> ]{1,3}",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphenate-limit-chars"
+  },
   "hyphens": {
     "syntax": "none | manual | auto",
     "media": "visual",


### PR DESCRIPTION
As part of my work on the [CSS `hyphenate-limit-chars` property](https://docs.google.com/document/d/1aLdSuLdZEMjdnMpeyBRdwwZyLr1JMbQ39Nk0ZWumLBU/edit#) (added to Chrome in version 109), I have added it to `properties.json`, so that it will pick up the data required to create the formal definition section of the page.