### PR TITLE
fix: scroll-timeline-axis and scroll-timeline-name are properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8610,7 +8610,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type-y"
   },
   "scroll-timeline": {
-    "syntax": "<scroll-timeline-name> || <scroll-timeline-axis>",
+    "syntax": "<'scroll-timeline-name'> || <'scroll-timeline-axis'>",
     "media": "visual",
     "inherited": false,
     "animationType": [

--- a/css/properties.json
+++ b/css/properties.json
@@ -8635,7 +8635,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline"
   },
   "scroll-timeline-axis": {
-    "syntax": "block | inline | vertical | horizontal",
+    "syntax": "[ block | inline | vertical | horizontal ]#",
     "media": "interactive",
     "inherited": false,
     "animationType": "notAnimatable",
@@ -8651,7 +8651,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis"
   },
   "scroll-timeline-name": {
-    "syntax": "none | <custom-ident>",
+    "syntax": "none | <custom-ident>#",
     "media": "interactive",
     "inherited": false,
     "animationType": "notAnimatable",


### PR DESCRIPTION
https://github.com/mdn/data/pull/609 incorrectly recorded the `scroll-timeline` syntax as `<scroll-timeline-name> || <scroll-timeline-axis>`.  This is incorrect as `scroll-timeline-axis` and `scroll-timeline-name` are properties and need to be quoted as such.