### PR TITLE
Add oklab() and oklch()

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -264,7 +264,7 @@
       "CSS Color"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklab"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklab"
   },
   "oklch()": {
     "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )",
@@ -272,7 +272,7 @@
       "CSS Color"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklch"
   },
   "opacity()": {
     "syntax": "opacity( [ <number-percentage> ] )",

--- a/css/functions.json
+++ b/css/functions.json
@@ -258,6 +258,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax"
   },
+  "oklab()": {
+    "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )",
+    "groups": [
+      "CSS Color"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklab"
+  },
+  "oklch()": {
+    "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )",
+    "groups": [
+      "CSS Color"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch"
+  },
   "opacity()": {
     "syntax": "opacity( [ <number-percentage> ] )",
     "groups": [


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add `oklch()` and `oklab()` color function from [CSS Colors 4 spec](https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch) (syntax schemas was copied from the CSS spec).

### Motivation

To fix CSS linters which use MDN data (like [`csstree`](https://github.com/csstree/csstree/issues/244)).

### Additional details

Safari, upcoming Chrome 111 and Firefox Nightly already support them.
