### PR TITLE
Add property and pseudo-elements for View Transitions Module L1

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -58,6 +58,7 @@
       "CSS Types",
       "CSS Units",
       "CSS Variables",
+      "CSS View Transitions",
       "CSS Will Change",
       "CSS Writing Modes",
       "CSSOM View",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9457,6 +9457,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/vertical-align"
   },
+  "view-transition-name": {
+    "syntax": "none | <custom-ident>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS View Transitions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-transition-name"
+  },
   "visibility": {
     "syntax": "visible | hidden | collapse",
     "media": "visual",

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -1040,5 +1040,50 @@
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::spelling-error"
+  },
+  "::view-transition": {
+    "syntax": "::view-transition",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition"
+  },
+  "::view-transition-group": {
+    "syntax": "::view-transition-group(* | <custom-ident>)",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-group"
+  },
+  "::view-transition-image-pair": {
+    "syntax": "::view-transition-image-pair(* | <custom-ident>)",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-image-pair"
+  },
+  "::view-transition-new": {
+    "syntax": "::view-transition-new(* | <custom-ident>)",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-new"
+  },
+  "::view-transition-old": {
+    "syntax": "::view-transition-old(* | <custom-ident>)",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-old"
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR adds data for the new property and pseudo-elements defined in the [View Transitions Module Level 1](https://www.w3.org/TR/css-view-transitions-1/), which is available in Chrome 111+.

See my [research document](https://docs.google.com/document/d/1EtWDm0UAvEu4qIO0sPd035I9mbRDYV39fTti04FxvtI/edit#) for more information.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
