### PR TITLE
added page property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7660,7 +7660,7 @@
     "media": "paged",
     "inherited": false,
     "animationType": "discrete",
-    "percentages": "n/a",
+    "percentages": "no",
     "groups": [
       "CSS Pages"
     ],

--- a/css/properties.json
+++ b/css/properties.json
@@ -7655,6 +7655,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-top"
   },
+  "page": {
+    "syntax": "auto | <custom-ident>",
+    "media": "paged",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "n/a",
+    "groups": [
+      "CSS Pages"
+    ],
+    "initial": "auto",
+    "appliesto": "blockElementsInNormalFlow",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page"
+  },
   "page-break-after": {
     "syntax": "auto | always | avoid | left | right | recto | verso",
     "media": [


### PR DESCRIPTION
### Description

Added the `page` property for use with the `@page` at-rule

### Motivation

Adding the named page docs for MDN 

### Additional details

### Related issues and pull requests

[MDN Issue](https://github.com/mdn/content/issues/23682)
[Content PR](https://github.com/mdn/content/pull/24485)
[BCD PR](https://github.com/mdn/browser-compat-data/pull/18922)
