### PR TITLE
Quote wildcard token in view-transition syntax

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -1051,7 +1051,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition"
   },
   "::view-transition-group": {
-    "syntax": "::view-transition-group(* | <custom-ident>)",
+    "syntax": "::view-transition-group('*' | <custom-ident>)",
     "groups": [
       "Pseudo-elements",
       "Selectors"
@@ -1060,7 +1060,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-group"
   },
   "::view-transition-image-pair": {
-    "syntax": "::view-transition-image-pair(* | <custom-ident>)",
+    "syntax": "::view-transition-image-pair('*' | <custom-ident>)",
     "groups": [
       "Pseudo-elements",
       "Selectors"
@@ -1069,7 +1069,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-image-pair"
   },
   "::view-transition-new": {
-    "syntax": "::view-transition-new(* | <custom-ident>)",
+    "syntax": "::view-transition-new('*' | <custom-ident>)",
     "groups": [
       "Pseudo-elements",
       "Selectors"
@@ -1078,7 +1078,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-new"
   },
   "::view-transition-old": {
-    "syntax": "::view-transition-old(* | <custom-ident>)",
+    "syntax": "::view-transition-old('*' | <custom-ident>)",
     "groups": [
       "Pseudo-elements",
       "Selectors"


### PR DESCRIPTION
### Description

According to the CSS value definition syntax, the wildcard token must be quoted unless used as a multiplier.  See the definition of the view-transition syntax [here](https://www.w3.org/TR/css-view-transitions-1/#typedef-pt-name-selector).
