### PR TITLE
Page orientation 24390

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -361,6 +361,18 @@
         "order": "orderOfAppearance",
         "status": "standard"
       },
+      "page-orientation": {
+        "syntax": "upright | rotate-left | rotate-right ",
+        "media": [
+          "visual",
+          "paged"
+        ],
+        "initial": "upright",
+        "percentages": "no",
+        "computed": "asSpecified",
+        "order": "orderOfAppearance",
+        "status": "standard"
+      },
       "size": {
         "syntax": "<length>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
         "media": [


### PR DESCRIPTION
### Description

Added the `page-orientation` descriptor to the `@page` at-rule

### Motivation

Documenting the `page-orientation descriptor`

### Related issues and pull requests

[Content Issue](https://github.com/mdn/content/issues/24390)
Content PR - coming soon
BCD PR - coming soon
[Spec URL](https://drafts.csswg.org/css-page-3/#page-orientation-prop)
