### PR TITLE
Fix `theKeywordListStyleImageNoneOrComputedValue`

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1610,7 +1610,7 @@
     "en-US": "the computed <length>"
   },
   "theKeywordListStyleImageNoneOrComputedValue": {
-    "en": "The keyword list-style-image/none or the computed <>"
+    "en-US": "The keyword <code>none</code> or the computed &lt;image&gt;"
   },
   "transform": {
     "de": "Transformation",


### PR DESCRIPTION
### Description

This PR fixes the `theKeywordListStyleImageNoneOrComputedValue` l10n key for `en-US`.

### Motivation

This key is [used](https://github.com/mdn/data/blob/main/css/properties.json#L6080) to show the computed value for the `list-style-image` CSS property.

### Additional details

The definition of `list-style-image` in CSS Lists and Counters Module Level 3:
https://w3c.github.io/csswg-drafts/css-lists/#image-markers

### Related issues and pull requests