### PR TITLE
Add `relativeToWidthAndHeight` for `en-US`

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1433,6 +1433,9 @@
     "en-US": "relative to the scroll container's scrollport",
     "ja": "スクロールコンテナーのスクロールポートに対する相対値"
   },
+  "relativeToWidthAndHeight": {
+    "en-US": "relative to the width and the height of the element's reference box"
+  },
   "repeatableList": {
     "de": "mehrfache Werte der folgenden Eigenschaften: ",
     "en-US": "a repeatable list of ",


### PR DESCRIPTION
### Description

This PR adds the `relativeToWidthAndHeight` l10n key for `en-US`.

### Motivation

This key is [used](https://github.com/yarusome/mdn-data/blob/main/css/properties.json#L6982) to show how the precentages are solved by the `offset-anchor` CSS property.

### Additional details

The definition of `offset-anchor` in Motion Path Module Level 1:
https://drafts.fxtf.org/motion/#offset-anchor-property

### Related issues and pull requests