### PR TITLE
Add `referToSizeOfContainingBlock` for `en-US`

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1308,6 +1308,9 @@
     "ja": "囲みボックスの寸法に対する相対値",
     "ru": "ссылается на размер ограничительной рамки"
   },
+  "referToSizeOfContainingBlock": {
+    "en-US": "refer to the size of containing block"
+  },
   "referToSizeOfElement": {
     "de": "beziehen sich auf die Größe der Box selbst",
     "en-US": "refer to the size of the box itself",


### PR DESCRIPTION
### Description

This PR adds the `referToSizeOfContainingBlock` l10n key for `en-US`.

### Motivation

This key is [used](https://github.com/yarusome/mdn-data/blob/main/css/properties.json#L7030) to show how the percentages are resolved for the `offset-position` CSS property.

### Additional details

The definition of `offset-position` in Motion Path Module Level 1:
https://drafts.fxtf.org/motion/#offset-position-property

### Related issues and pull requests