### PR TITLE
Fix `appliesto` for `content-visibility`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4374,7 +4374,7 @@
       "CSS Containment"
     ],
     "initial": "visible",
-    "appliesto": "elementsForWhichLayoutContainmentCanApply",
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",


### PR DESCRIPTION
### Description

This PR fixes the `appliesto` key for the `content-visibility` CSS property.

### Motivation

This key uses the non-existent `elementsForWhichLayoutContainmentCanApply` l10n key. Also, the spec shows that `content-visibility` applies to elements for which size, instead of layout, containment can apply.

### Additional details

The definition of `content-visibility` in CSS Containment Module Level 2:
https://w3c.github.io/csswg-drafts/css-contain/#content-visibility

### Related issues and pull requests