### PR TITLE
Add `listEachItemIdentifyerOrNoneAuto` for `en-US`

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -924,7 +924,7 @@
     "ru": "список, каждый элемент которого содержит 2 ключевых слова, по одному на размер"
   },
   "listEachItemIdentifyerOrNoneAuto": {
-    "en-US": "list, each item either a case-sensitive CSS identifier or the keywords <code>none</code>, <code>auto</code>"
+    "en-US": "a list, each item either a case-sensitive CSS identifier or the keywords <code>none</code>, <code>auto</code>"
   },
   "listEachItemTwoKeywordsOriginOffsets": {
     "de": "a list, each item consisting of two keywords representing the origin undtwo offsets from that origin, each given as an absolute length (if given a {{xref_csslength}}), otherwise as a percentage",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -923,6 +923,9 @@
     "ja": "1 つの方向につき 2 つのキーワードで構成される項目のリスト",
     "ru": "список, каждый элемент которого содержит 2 ключевых слова, по одному на размер"
   },
+  "listEachItemIdentifyerOrNoneAuto": {
+    "en-US": "list, each item either a case-sensitive CSS identifier or the keywords <code>none</code>, <code>auto</code>"
+  },
   "listEachItemTwoKeywordsOriginOffsets": {
     "de": "a list, each item consisting of two keywords representing the origin undtwo offsets from that origin, each given as an absolute length (if given a {{xref_csslength}}), otherwise as a percentage",
     "en-US": "a list, each item consisting of two keywords representing the origin and two offsets from that origin, each given as an absolute length (if given a {{xref_csslength}}), otherwise as a percentage",


### PR DESCRIPTION
### Description

This PR adds the `listEachItemIdentifyerOrNoneAuto` l10n key for `en-US`.

### Motivation

This key is [used](https://github.com/mdn/data/blob/main/css/properties.json#L1977) to show the computed value for the `animation-timeline` CSS property.

### Additional details

The definition of `animation-timeline` in CSS Animations Level 2:
https://w3c.github.io/csswg-drafts/css-animations-2/#animation-timeline

### Related issues and pull requests