### PR TITLE
Add  data for `font-variant-emoji`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5036,6 +5036,26 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian"
   },
+  "font-variant-emoji": {
+    "syntax": "normal | text | emoji | unicode",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard"
+  },
   "font-variant-ligatures": {
     "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
     "media": "visual",


### PR DESCRIPTION
### Description

This PR adds the data for the `font-variant-emoji` CSS property.

### Motivation

See https://github.com/mdn/content/issues/25441.

### Additional details

  1. Many properties in CSS Font Module lack a `media` field, but I followed the examples of other `font-variant-*` setting the `media` field to `visual`.
  2. The `alsoAppliesTo` field ***might not*** be correct due to the phrasing in the spec. See https://github.com/w3c/csswg-drafts/issues/8635.

### Related issues and pull requests