### PR TITLE
Adding data for `@font-palette-values` and `font-palette`

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -123,7 +123,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@document"
   },
   "@font-palette-values": {
-    "syntax": "@font-palette-values <dashed-ident> {\n  <declaration-list>\n}",
+    "syntax": "@font-palette-values <dashed-ident> {  <declaration-list> }",
     "groups": [
       "CSS Fonts"
     ],

--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -122,6 +122,43 @@
     "status": "nonstandard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@document"
   },
+  "@font-palette-values": {
+    "syntax": "@font-palette-values <dashed-ident> {\n  <declaration-list>\n}",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "descriptors": {
+      "base-palette": {
+        "syntax": "light | dark | <integer [0,∞]>",
+        "media": "all",
+        "initial": "n/a (required)",
+        "percentages": "no",
+        "computed": "asSpecified",
+        "order": "uniqueOrder",
+        "status": "standard"
+      },
+      "font-family": {
+        "syntax": "<family-name>#",
+        "media": "all",
+        "initial": "n/a (required)",
+        "percentages": "no",
+        "computed": "asSpecified",
+        "order": "orderOfAppearance",
+        "status": "standard"
+      },
+      "override-colors": {
+        "syntax": "[ <integer [0,∞]> <absolute-color-base> ]#",
+        "media": "all",
+        "initial": "n/a (required)",
+        "percentages": "no",
+        "computed": "asSpecified",
+        "order": "orderOfAppearance",
+        "status": "standard"
+      }
+    },
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-palette-values"
+  },
   "@font-face": {
     "syntax": "@font-face {\n  [ font-family: <family-name>; ] ||\n  [ src: <src>; ] ||\n  [ unicode-range: <unicode-range>; ] ||\n  [ font-variant: <font-variant>; ] ||\n  [ font-feature-settings: <font-feature-settings>; ] ||\n  [ font-variation-settings: <font-variation-settings>; ] ||\n  [ font-stretch: <font-stretch>; ] ||\n  [ font-weight: <font-weight>; ] ||\n  [ font-style: <font-style>; ] ||\n  [ size-adjust: <size-adjust>; ] ||\n  [ ascent-override: <ascent-override>; ] ||\n  [ descent-override: <descent-override>; ] ||\n  [ line-gap-override: <line-gap-override>; ]\n}",
     "interfaces": [

--- a/css/properties.json
+++ b/css/properties.json
@@ -4810,6 +4810,26 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing"
   },
+  "font-palette": {
+    "syntax": "normal | light | dark | <palette-identifier>",
+    "media": "visual",
+    "inherited": "yes",
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard"
+  },
   "font-variation-settings": {
     "syntax": "normal | [ <string> <number> ]#",
     "media": "visual",

--- a/css/properties.json
+++ b/css/properties.json
@@ -4813,7 +4813,7 @@
   "font-palette": {
     "syntax": "normal | light | dark | <palette-identifier>",
     "media": "visual",
-    "inherited": "yes",
+    "inherited": true,
     "animationType": "discrete",
     "percentages": "no",
     "groups": [


### PR DESCRIPTION
### Description

This PR adds the data for the `@font-palette-values` at-rule and the `font-palette` property.

### Motivation

See https://github.com/mdn/content/issues/25441.

### Additional details

The spec text for `@font-palette-values`:
https://w3c.github.io/csswg-drafts/css-fonts/#font-palette-values
The spec text for `font-palette`:
https://w3c.github.io/csswg-drafts/css-fonts/#font-palette-prop

See https://github.com/w3c/csswg-drafts/issues/8635.

### Related issues and pull requests