### PR TITLE
Adding the data for the `container*` properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4348,6 +4348,66 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width"
   },
+  "container": {
+    "syntax": "<'container-name'> [ / <'container-type'> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "container-name",
+      "container-type"
+    ],
+    "percentages": [
+      "container-name",
+      "container-type"
+    ],
+    "groups": [
+      "CSS Containment"
+    ],
+    "initial": [
+      "container-name",
+      "container-type"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "container-name",
+      "container-type"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container"
+  },
+  "container-name": {
+    "syntax": "none | <custom-ident>+",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Containment"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "noneOrOrderedListOfIdentifiers",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-name"
+  },
+  "container-type": {
+    "syntax": "normal | size | inline-size",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Containment"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-type"
+  },
   "content": {
     "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> ]+ ]?",
     "media": "all",

--- a/css/properties.json
+++ b/css/properties.json
@@ -1974,7 +1974,7 @@
     ],
     "initial": "auto",
     "appliesto": "allElements",
-    "computed": "listEachItemIdentifyerOrNoneAuto",
+    "computed": "listEachItemIdentifierOrNoneAuto",
     "order": "uniqueOrder",
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline"

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -137,6 +137,7 @@
         "listEachItemIdentifierOrNoneAuto",
         "listEachItemTwoKeywordsOriginOffsets",
         "noneOrImageWithAbsoluteURI",
+        "noneOrOrderedListOfIdentifiers",
         "normalizedAngle",
         "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
         "oneToFourPercentagesOrAbsoluteLengthsPlusFill",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -134,7 +134,7 @@
         "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
         "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
         "listEachItemHasTwoKeywordsOnePerDimension",
-        "listEachItemIdentifyerOrNoneAuto",
+        "listEachItemIdentifierOrNoneAuto",
         "listEachItemTwoKeywordsOriginOffsets",
         "noneOrImageWithAbsoluteURI",
         "normalizedAngle",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1047,6 +1047,9 @@
     "ja": "<code>none</code> または画像の絶対化した URI",
     "ru": "<code>none</code> или изображение с абсолютным URI"
   },
+  "noneOrOrderedListOfIdentifiers": {
+    "en-US": "<code>none</code> or an ordered list of identifiers"
+  },
   "nonReplacedBlockAndInlineBlockElements": {
     "de": "nicht ersetzte Blocklevel Elemente und nicht ersetzte Inlineblock Elemente",
     "en-US": "non-replaced block-level elements and non-replaced inline-block elements",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -923,7 +923,7 @@
     "ja": "1 つの方向につき 2 つのキーワードで構成される項目のリスト",
     "ru": "список, каждый элемент которого содержит 2 ключевых слова, по одному на размер"
   },
-  "listEachItemIdentifyerOrNoneAuto": {
+  "listEachItemIdentifierOrNoneAuto": {
     "en-US": "a list, each item either a case-sensitive CSS identifier or the keywords <code>none</code>, <code>auto</code>"
   },
   "listEachItemTwoKeywordsOriginOffsets": {


### PR DESCRIPTION
### Description

This PR adds the data for the `container`, `container-name`, and `container-type` properties. It also corrects the spelling for the "listEachItemIdentifyerOrNoneAuto" key.

### Motivation

### Additional details

The spec links for these properties:
https://w3c.github.io/csswg-drafts/css-contain-3/#container-shorthand
https://w3c.github.io/csswg-drafts/css-contain-3/#container-name
https://w3c.github.io/csswg-drafts/css-contain-3/#container-type

CSSWG issue related to the computed value of `container-type`:
https://github.com/w3c/csswg-drafts/issues/8643

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/24786.