### PR TITLE
Update the `overflow-clip-margin` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7387,7 +7387,7 @@
     ],
     "initial": "0px",
     "appliesto": "allElements",
-    "computed": "theComputedLength",
+    "computed": "theComputedLengthAndVisualBox",
     "order": "perGrammar",
     "status": "standard"
   },

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -153,7 +153,7 @@
         "specifiedIntegerOrAbsoluteLength",
         "specifiedValueClipped0To1",
         "specifiedValueNumberClipped0To1",
-        "theComputedLength",
+        "theComputedLengthAndVisualBox",
         "theKeywordListStyleImageNoneOrComputedValue",
         "translucentValuesRGBAOtherwiseRGB",
         "twoAbsoluteLengthOrPercentages",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1618,8 +1618,8 @@
     "ja": "テキストフィールド",
     "ru": "текстовые поля"
   },
-  "theComputedLength": {
-    "en-US": "the computed <length>"
+  "theComputedLengthAndVisualBox": {
+    "en-US": "the computed &lt;length&gt; and a &lt;visual-box&gt; keyword"
   },
   "theKeywordListStyleImageNoneOrComputedValue": {
     "en-US": "The keyword <code>none</code> or the computed &lt;image&gt;"


### PR DESCRIPTION
### Description

This PR updates the computed value key of the `overflow-clip-margin` property.

### Motivation

### Additional details

The spec:
https://w3c.github.io/csswg-drafts/css-overflow/#overflow-clip-margin

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/25906.