### PR TITLE
Correct animation types

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2316,7 +2316,7 @@
     "syntax": "<bg-size>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableListOfSimpleListOfLpc",
+    "animationType": "repeatableList",
     "percentages": "relativeToBackgroundPositioningArea",
     "groups": [
       "CSS Backgrounds and Borders"
@@ -6739,7 +6739,7 @@
     "syntax": "<position>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableListOfSimpleListOfLpc",
+    "animationType": "repeatableList",
     "percentages": "referToSizeOfMaskPaintingArea",
     "groups": [
       "CSS Masking"
@@ -6771,7 +6771,7 @@
     "syntax": "<bg-size>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableListOfSimpleListOfLpc",
+    "animationType": "repeatableList",
     "percentages": "no",
     "groups": [
       "CSS Masking"
@@ -7043,7 +7043,7 @@
     "syntax": "<position>",
     "media": "visual",
     "inherited": true,
-    "animationType": "repeatableListOfSimpleListOfLpc",
+    "animationType": "repeatableList",
     "percentages": "referToWidthAndHeightOfElement",
     "groups": [
       "CSS Images"

--- a/css/properties.json
+++ b/css/properties.json
@@ -1999,7 +1999,7 @@
     "syntax": "auto | <ratio>",
     "media": "all",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Basic User Interface"
@@ -2134,7 +2134,7 @@
     "syntax": "<blend-mode>#",
     "media": "none",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "Compositing and Blending"
@@ -2155,7 +2155,7 @@
     "syntax": "<box>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "repeatableList",
     "percentages": "no",
     "groups": [
       "CSS Backgrounds and Borders"
@@ -2218,7 +2218,7 @@
     "syntax": "<box>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "repeatableList",
     "percentages": "no",
     "groups": [
       "CSS Backgrounds and Borders"
@@ -2239,7 +2239,7 @@
     "syntax": "<bg-position>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "repeatableListOfSimpleListOfLpc",
+    "animationType": "repeatableList",
     "percentages": "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
     "groups": [
       "CSS Backgrounds and Borders"
@@ -2263,7 +2263,7 @@
     "syntax": "[ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "repeatableList",
     "percentages": "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageWidth",
     "groups": [
       "CSS Backgrounds and Borders"
@@ -2279,7 +2279,7 @@
     "syntax": "[ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "repeatableList",
     "percentages": "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
     "groups": [
       "CSS Backgrounds and Borders"
@@ -2399,7 +2399,11 @@
     "syntax": "<'border-top-width'> || <'border-top-style'> || <color>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": [
+      "border-block-width",
+      "border-block-style",
+      "border-block-color"
+    ],
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -2423,7 +2427,7 @@
     "syntax": "<'border-top-color'>{1,2}",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -2455,7 +2459,7 @@
     "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
@@ -2499,7 +2503,7 @@
     "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "color",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -2531,7 +2535,7 @@
     "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "byComputedValueType",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
@@ -2575,7 +2579,7 @@
     "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "color",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -2607,7 +2611,7 @@
     "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "byComputedValueType",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
@@ -2837,7 +2841,13 @@
     "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": [
+      "border-image-outset",
+      "border-image-repeat",
+      "border-image-slice",
+      "border-image-source",
+      "border-image-width"
+    ],
     "percentages": [
       "border-image-slice",
       "border-image-width"
@@ -2966,7 +2976,11 @@
     "syntax": "<'border-top-width'> || <'border-top-style'> || <color>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": [
+      "border-inline-color",
+      "border-inline-style",
+      "border-inline-width"
+    ],
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -3018,7 +3032,7 @@
     "syntax": "<'border-top-color'>{1,2}",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -3050,7 +3064,7 @@
     "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
@@ -3066,7 +3080,7 @@
     "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "color",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -3098,7 +3112,7 @@
     "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "byComputedValueType",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
@@ -3142,7 +3156,7 @@
     "syntax": "<'border-top-color'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "color",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Logical Properties"
@@ -3174,7 +3188,7 @@
     "syntax": "<'border-top-width'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "length",
+    "animationType": "byComputedValueType",
     "percentages": "logicalWidthOfContainingBlock",
     "groups": [
       "CSS Logical Properties"
@@ -4030,22 +4044,6 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color"
   },
-  "print-color-adjust": {
-    "syntax": "economy | exact",
-    "media": "visual",
-    "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "CSS Color"
-    ],
-    "initial": "economy",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "perGrammar",
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/print-color-adjust"
-  },
   "color-scheme": {
     "syntax": "normal | [ light | dark | <custom-ident> ]+ && only?",
     "media": "visual",
@@ -4247,7 +4245,7 @@
     "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
     "media": "all",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Containment"
@@ -4428,7 +4426,7 @@
     "syntax": "visible | auto | hidden",
     "media": "all",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Containment"
@@ -4444,7 +4442,7 @@
     "syntax": "[ <counter-name> <integer>? ]+ | none",
     "media": "all",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Counter Styles"
@@ -4460,7 +4458,7 @@
     "syntax": "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
     "media": "all",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Counter Styles"
@@ -4476,7 +4474,7 @@
     "syntax": "[ <counter-name> <integer>? ]+ | none",
     "media": "all",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Counter Styles"
@@ -4511,7 +4509,7 @@
     "syntax": "ltr | rtl",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Writing Modes"
@@ -4635,7 +4633,10 @@
     "syntax": "<'flex-direction'> || <'flex-wrap'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": [
+      "flex-direction",
+      "flex-wrap"
+    ],
     "percentages": "no",
     "groups": [
       "CSS Flexible Box Layout"
@@ -4994,7 +4995,7 @@
     "syntax": "normal | italic | oblique <angle>?",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg",
     "percentages": "no",
     "groups": [
       "CSS Fonts"
@@ -5265,7 +5266,18 @@
     "syntax": "<'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": [
+      "grid-template-rows",
+      "grid-template-columns",
+      "grid-template-areas",
+      "grid-auto-rows",
+      "grid-auto-columns",
+      "grid-auto-flow",
+      "grid-column-gap",
+      "grid-row-gap",
+      "column-gap",
+      "row-gap"
+    ],
     "percentages": [
       "grid-template-rows",
       "grid-template-columns",
@@ -5334,7 +5346,7 @@
     "syntax": "<track-size>+",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "referToDimensionOfContentArea",
     "groups": [
       "CSS Grid Layout"
@@ -5366,7 +5378,7 @@
     "syntax": "<track-size>+",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "referToDimensionOfContentArea",
     "groups": [
       "CSS Grid Layout"
@@ -5547,7 +5559,11 @@
     "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": [
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas"
+    ],
     "percentages": [
       "grid-template-columns",
       "grid-template-rows"
@@ -5670,7 +5686,7 @@
     "syntax": "[ auto | <integer> ]{1,3}",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Text"
@@ -5765,7 +5781,7 @@
     "syntax": "normal | [ <number> <integer>? ]",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Inline"
@@ -5962,7 +5978,7 @@
     "syntax": "auto | isolate",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "Compositing and Blending"
@@ -6130,7 +6146,7 @@
     "syntax": "<length>",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Fonts"
@@ -6146,7 +6162,11 @@
     "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": [
+      "list-style-image",
+      "list-style-position",
+      "list-style-type"
+    ],
     "percentages": "no",
     "groups": [
       "CSS Lists and Counters"
@@ -6990,7 +7010,7 @@
     "syntax": "<blend-mode> | plus-lighter",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "Compositing and Blending"
@@ -7192,7 +7212,7 @@
     "syntax": "<integer>",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Fragmentation"
@@ -7280,7 +7300,7 @@
       "interactive"
     ],
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Basic User Interface"
@@ -7976,6 +7996,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position"
   },
+  "print-color-adjust": {
+    "syntax": "economy | exact",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "economy",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/print-color-adjust"
+  },
   "quotes": {
     "syntax": "none | auto | [ <string> <string> ]+",
     "media": "visual",
@@ -8061,7 +8097,7 @@
     "syntax": "start | center | space-between | space-around",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Ruby"
@@ -8077,7 +8113,7 @@
     "syntax": "separate | collapse | auto",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Ruby"
@@ -8125,7 +8161,7 @@
     "syntax": "auto | <color>{2}",
     "media": "visual",
     "inherited": true,
-    "animationType": "color",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Scrollbars"
@@ -8157,7 +8193,7 @@
     "syntax": "auto | thin | none",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Scrollbars"
@@ -8173,10 +8209,10 @@
     "syntax": "auto | smooth",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
-      "CSSOM View"
+      "CSS Overflow"
     ],
     "initial": "auto",
     "appliesto": "scrollingBoxes",
@@ -9173,7 +9209,7 @@
     "syntax": "mixed | upright | sideways",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Writing Modes"
@@ -9245,7 +9281,7 @@
     "syntax": "none | auto | <percentage>",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "referToSizeOfFont",
     "groups": [
       "CSS Text"
@@ -9335,7 +9371,7 @@
     "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "Pointer Events"
@@ -9417,7 +9453,7 @@
     "syntax": "<single-transition>#",
     "media": "interactive",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Transitions"
@@ -9443,7 +9479,7 @@
     "syntax": "<time>#",
     "media": "interactive",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Transitions"
@@ -9459,7 +9495,7 @@
     "syntax": "<time>#",
     "media": "interactive",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Transitions"
@@ -9475,7 +9511,7 @@
     "syntax": "none | <single-transition-property>#",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Transitions"
@@ -9491,7 +9527,7 @@
     "syntax": "<easing-function>#",
     "media": "interactive",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Transitions"
@@ -9524,7 +9560,7 @@
     "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
     "media": "visual",
     "inherited": false,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Writing Modes"
@@ -9625,7 +9661,7 @@
     "syntax": "<integer>",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "byComputedValueType",
     "percentages": "no",
     "groups": [
       "CSS Fragmentation"
@@ -9726,7 +9762,7 @@
     "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "CSS Writing Modes"

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -33,7 +33,7 @@
         "number",
         "position",
         "rectangle",
-        "repeatableListOfSimpleListOfLpc",
+        "repeatableList",
         "shadowList",
         "simpleListOfLpc",
         "simpleListOfLpcDifferenceLpc",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -18,6 +18,7 @@
         "angleOrBasicShapeOrPath",
         "basicShapeOtherwiseNo",
         "byComputedValueType",
+        "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg",
         "color",
         "discrete",
         "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -561,7 +561,7 @@
     "ja": "計算値の型による"
   },
   "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg": {
-    "en-US": "by computed value type; <code>normal</code> animates as <code>oblique 0deg</code>" 
+    "en-US": "by computed value type; <code>normal</code> animates as <code>oblique 0deg</code>"
   },
   "canonicalOrder": {
     "de": "Kanonische Reihenfolge",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -562,7 +562,7 @@
   },
   "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg": {
      "en-US": "by computed value type; <code>normal</code> animates as <code>oblique 0deg</code>" 
-  }
+  },
   "canonicalOrder": {
     "de": "Kanonische Reihenfolge",
     "en-US": "Canonical order",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -560,6 +560,9 @@
     "en-US": "by computed value type",
     "ja": "計算値の型による"
   },
+  "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg": {
+     "en-US": "by computed value type; <code>normal</code> animates as <code>oblique 0deg</code>" 
+  }
   "canonicalOrder": {
     "de": "Kanonische Reihenfolge",
     "en-US": "Canonical order",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -561,7 +561,7 @@
     "ja": "計算値の型による"
   },
   "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg": {
-     "en-US": "by computed value type; <code>normal</code> animates as <code>oblique 0deg</code>" 
+    "en-US": "by computed value type; <code>normal</code> animates as <code>oblique 0deg</code>" 
   },
   "canonicalOrder": {
     "de": "Kanonische Reihenfolge",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1455,10 +1455,6 @@
     "ja": "反復可能リスト",
     "ru": "повторяющийся список из "
   },
-  "repeatableListOfSimpleListOfLpc": {
-    "en-US": "repeatable list of simple list of length, percentage, or calc",
-    "ja": "長さ、パーセント値、 calc の単純なリストの反復可能リスト"
-  },
   "replacedElements": {
     "de": "ersetzte Elemente",
     "en-US": "replaced elements",


### PR DESCRIPTION
### Description

This PR corrects the animation types for various CSS properties, mainly which were mistaken as "discrete".

**Note:** During the cleanup:

  1. I found that `block-overflow` and `overflow-clip-box` don't exist on either the specs or MDN. Should I detele them?
  2. I also found that `point-events` has conflicting definitions in [Scalable Vector Graphics (SVG) 2](https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty) and [CSS Basic User Interface Module Level 4](https://w3c.github.io/csswg-drafts/css-ui-4/#pointer-events-control). Which one should I align to?
  3. I left the incorrect animation type for `overflow-clip-margin` intact because there's a spec change between CSS Overflow Module [Level 3](https://w3c.github.io/csswg-drafts/css-overflow-3/#overflow-clip-margin) and [Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#overflow-clip-margin).

I do think it's important to use webref for automation now, and there should be a way to combine this with community-driven l10n.

### Motivation

### Additional details

The spec links (sorry for flooding in a single PR :pray:):

| Specs | Properties |
| - | - |
| [Compatibility Standard](https://compat.spec.whatwg.org/#touch-action) | `touch-action` |
| [Compositing and Blending Level 2](https://drafts.fxtf.org/compositing-2/#property-index) | `(background\|mix)-blend-mode`, `isolation` |
| [CSS Backgrounds and Borders Module Level 3](https://w3c.github.io/csswg-drafts/css-backgrounds-3/#property-index) | `background-(clip\|origin\|position\|size)`, `border-image` |
| [CSS Backgrounds and Borders Module Level 4](https://w3c.github.io/csswg-drafts/css-backgrounds-3/#property-index) | `background-position-(x\|y)` |
| [CSS Basic User Interface Module Level 4](https://w3c.github.io/csswg-drafts/css-ui-4/#property-index) | `outline-style` |
| [CSS Box Sizing Module Level 4](https://w3c.github.io/csswg-drafts/css-sizing-4/#property-index) | `aspect-ratio` |
| [CSS Containment Module Level 2](https://w3c.github.io/csswg-drafts/css-contain-2/#property-index) | `contain`, `content-visibility` |
| [CSS Flexible Box Layout Module Level 1](https://w3c.github.io/csswg-drafts/css-flexbox-1/#property-index) | `flex-flow` |
| [CSS Fonts Module Level 4](https://w3c.github.io/csswg-drafts/css-fonts-4/#property-index) | `font-style` |
| [CSS Fragmentation Module Level 3](https://w3c.github.io/csswg-drafts/css-break-3/#property-index) | `orphans`, `widows` |
| [CSS Grid Layout Module Level 2](https://w3c.github.io/csswg-drafts/css-grid-2/#grid-shorthand) | `grid`, `grid-auto-(columns\|rows)`, `grid-template` |
| [CSS Images Module Level 3](https://w3c.github.io/csswg-drafts/css-images-3/#property-index) | `object-position` |
| [CSS Inline Layout Module Level 3](https://w3c.github.io/csswg-drafts/css-inline-3/#property-index) | `initial-letter` |
| [CSS Lists and Counters Module Level 3](https://w3c.github.io/csswg-drafts/css-lists-3/#property-index) | `counter-(increment\|reset\|set)`, `list-style` |
| [CSS Logical Properties and Values Level 1](https://w3c.github.io/csswg-drafts/css-logical-1/#property-index) | `border-(block\|inline)(-(end\|start))?(-(color\|width))?` |
| [CSS Masking Module Level 1](https://drafts.fxtf.org/css-masking-1/#property-index) | `mask-(position\|size)` |
| [CSS Mobile Text Size Adjustment Module Level 1](https://w3c.github.io/csswg-drafts/css-size-adjust-1/#property-index) | `text-size-adjust` |
| [CSS Overflow Module Level 3](https://w3c.github.io/csswg-drafts/css-overflow-3/#property-index) | `scroll-behavior` |
| [CSS Ruby Annotation Layout Module Level 1](https://w3c.github.io/csswg-drafts/css-ruby-1/#property-index) | `ruby-(align\|merge)` |
| [CSS Scrollbars Styling Module Level 1](https://w3c.github.io/csswg-drafts/css-scrollbars-1/#property-index) | `scrollbar-(color\|width)` |
| [CSS Text Module Level 4](https://w3c.github.io/csswg-drafts/css-text-4/#property-index) | `hyphenate-limit-chars` |
| [CSS Transitions](https://w3c.github.io/csswg-drafts/css-transitions/#property-index) | `transition(-(delay\|duration\|property\|timing-function))?` |
| [CSS Will Change Module Level 1](https://w3c.github.io/csswg-drafts/css-will-change-1/#property-index) | `will-change` |
| [CSS Writing Modes Level 4](https://w3c.github.io/csswg-drafts/css-writing-modes-4/#property-index) | `direction`, `text-orientation`, `unicode-bidi`, `writing-mode` |


### Related issues and pull requests

Fixes #584.

**Note:** This PR doesn't address the infra problem in the issue above.