### PR TITLE
docs(fx112-css): Add syntax for ray() function

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -330,7 +330,7 @@
     "groups": [
       "CSS Motion Path"
     ],
-    "status": "nonstandard",
+    "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ray"
   },
   "repeating-linear-gradient()": {

--- a/css/functions.json
+++ b/css/functions.json
@@ -325,6 +325,14 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/radial-gradient"
   },
+  "ray()": {
+    "syntax": "ray( <angle> && <ray-size>? && contain? )",
+    "groups": [
+      "CSS Motion Path"
+    ],
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ray"
+  },
   "repeating-linear-gradient()": {
     "syntax": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
     "groups": [

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -617,6 +617,9 @@
   "ratio": {
     "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
   },
+  "ray()": {
+    "syntax": "ray( <angle> && <ray-size>? && contain? )"
+  },
   "relative-selector": {
     "syntax": "<combinator>? <complex-selector>"
   },


### PR DESCRIPTION
- This PR creates an entry for the `ray()` function. 
- `"mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ray"`
    - A new page for ray() is being created via the content PR https://github.com/mdn/content/pull/26266
- `"status": "experimental"`
   - Firefox: `ray()` is available behind the flag `layout.css.motion-path-ray.enabled` 
   - Chrome: some `offset-path: ray()` functionality is available with "Experimental Web Platform features" enabled

### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/25358
Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1820071
Spec: https://drafts.fxtf.org/motion/#ray-function
