### PR TITLE
New data type: overflow

### DIFF
--- a/css/types.json
+++ b/css/types.json
@@ -182,6 +182,13 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/number"
   },
+  "overflow": {
+    "groups": [
+      "CSS Types"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow_value"
+  },
   "percentage": {
     "groups": [
       "CSS Types"


### PR DESCRIPTION
adding `<overflow>` as a data type as 5 properties use the exact same group of keywords.

part of https://github.com/mdn/content/pull/26395