### PR TITLE
docs: add details about release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 Thanks for taking the time to contribute to [MDN Web Docs](https://developer.mozilla.org)! :tada:
 This file lists some general guidelines to help you contribute effectively.
 
+## Publishing a release
+
+Details about publishing a release can be found in the [publishing guide](./docs/publishing.md).
+
 ## Types of contribution
 
 There are many ways you can help improve this repository! For example:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,40 +1,13 @@
 # Publishing a new version of MDN `mdn-data`
 
-Repo admins publish new releases of [mdn-data](https://www.npmjs.com/package/mdn-data) on npm. This is then used by MDN to generate various sidebars as well as other things.
+Releases are published on GitHub and to the npm registry as the [mdn-data](https://www.npmjs.com/package/mdn-data) package.
+This is then used by MDN to generate sidebars [as well as other features](https://github.com/search?q=repo%3Amdn%2Fyari%20mdn-data&type=code) such as info boxes on pages.
 
-Any admin can complete the following steps to publish a new version, but please coordinate releases with [@ddbeck](https://github.com/ddbeck) or [@Rumyra](https://github.com/Rumyra).
+In order to publish a release:
 
-The steps in this process assume:
+1. Commits need to adhere to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and only `fix:` and `feat:` commits are considered.
+2. The [publish-release.yml](https://github.com/mdn/data/blob/main/.github/workflows/publish-release.yml) workflow reuses the [mdn/workflows workflow](https://github.com/mdn/workflows/blob/main/.github/workflows/publish-release.yml) by the same name.
+3. The workflow uses [`release-please`](https://github.com/googleapis/release-please), which opens a release pull request if there are relevant commits (following the conventions described in **step 1**) on the `main` branch since the last-published version.
+4. When the pull request from **step 3** is merged, `release-please` creates a GitHub release and a package is published to npm via the [publish-release.yml](https://github.com/mdn/data/blob/main/.github/workflows/publish-release.yml) workflow.
 
-- `NPM_TOKEN` is set in the repository secrets. If the token is invalidated or unset, a member of the `@mdn` organization on npm must [create a new token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) and [add it to the repository's secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository).
-
-## Prepare for the release
-
-Prepare for a release by creating a pull request to update metadata for the release. See [#507](https://github.com/mdn/data/pull/507) as an example.
-
-1. Start a new branch for the upcoming release. For example, run `git switch -c release-YYYY-MM-DD`, where `YYYY-MM-DD` is the target release date.
-
-2. Increment the package version with `npm version --no-git-tag-version` and commit the change.
-
-   For example, to increment the version for a routine data update with no breaking changes or new features, run `npm version --no-git-tag-version patch`, then commit the changes to the package metadata files.
-
-   If needed, you can repeat this step on the same branch, using a `minor` or `major` argument (instead of `patch`), to increment the version for newly-introduced features or breaking changes.
-
-3. Push the release branch to your remote, open a pull request, and then review/merge it.
-
-## Publish to npm
-
-1. Start a draft [release on GitHub](https://github.com/mdn/data/releases).
-
-   - In the _Tag version_ and _Release title_ fields, enter `vX.Y.Z` where `X.Y.Z` is the version number you'd like to publish. Do not use an existing value, but instead
-     select an increment from the previous release. For example, if the previous release
-     was `v2.0.20`, use `v2.0.21` for the _Tag version_ and _Release title_ fields.
-   - You can leave the _Describe this release_ field blank, or add notes as you wish.
-
-   _Note_: If you're not ready to publish to npm, click **Save draft** in GitHub and resume this process later.
-
-2. Click **Publish release** to create the tag and trigger the workflow that publishes to npm. Wait for the [`npm publish` GitHub Actions workflow](https://github.com/mdn/data/actions/workflows/npm-publish.yml) to finish successfully.
-
-3. Check [`mdn-data` on npm](https://www.npmjs.com/package/mdn-data) to see if the release shows up correctly.
-
-The package is now published. 🎉
+After these steps have completed, you may check [`mdn-data` on npm](https://www.npmjs.com/package/mdn-data) to see if the release shows up correctly. 🎉


### PR DESCRIPTION
The release process is updated to use `release-please`. This PR updates the contribution docs to reflect the current process.