### PR TITLE
CSS: Adds keyword to "offset-position"

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7200,7 +7200,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-path"
   },
   "offset-position": {
-    "syntax": "auto | <position>",
+    "syntax": "normal | auto | <position>",
     "media": "visual",
     "inherited": false,
     "animationType": "position",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

The syntax for [`offset-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-position) property has changed.
A new keyword (`normal`) has been added: https://drafts.fxtf.org/motion/#offset-position-property.

### Related issues and pull requests

Related content update: https://github.com/mdn/content/pull/27726
Related BCD update: https://github.com/mdn/browser-compat-data/pull/20250
Doc issue tracker: https://github.com/mdn/content/issues/27174
Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1559232
