### PR TITLE
chore(ci): Label idle issues can run weekly

### DIFF
--- a/.github/workflows/idle.yml
+++ b/.github/workflows/idle.yml
@@ -4,7 +4,7 @@ name: "Label idle issues"
 
 on:
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 9 * * 5"
 
 jobs:
   mark-as-idle:


### PR DESCRIPTION
Changing this from daily to weekly:

* `0 9 * * 5` -> https://crontab.guru/#0_9_*_*_5

