### PR TITLE
feat: CSS contain-intrinsic-* syntax updates

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4315,7 +4315,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain"
   },
   "contain-intrinsic-size": {
-    "syntax": "[ none | <length> | auto <length> ]{1,2}",
+    "syntax": "[ auto? [ none | <length> ] ]{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": [
@@ -4339,11 +4339,11 @@
       "contain-intrinsic-height"
     ],
     "order": "perGrammar",
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size"
   },
   "contain-intrinsic-block-size": {
-    "syntax": "none | <length> | auto <length>",
+    "syntax": "auto? [ none | <length> ]",
     "inherited": false,
     "animationType": "byComputedValueType",
     "percentages": "no",
@@ -4354,11 +4354,11 @@
     "appliesto": "elementsForWhichSizeContainmentCanApply",
     "computed": "asSpecifiedWithLengthValuesComputed",
     "order": "perGrammar",
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-block-size"
   },
   "contain-intrinsic-height": {
-    "syntax": "none | <length> | auto <length>",
+    "syntax": "auto? [ none | <length> ]",
     "inherited": false,
     "animationType": "byComputedValueType",
     "percentages": "no",
@@ -4369,11 +4369,11 @@
     "appliesto": "elementsForWhichSizeContainmentCanApply",
     "computed": "asSpecifiedWithLengthValuesComputed",
     "order": "perGrammar",
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height"
   },
   "contain-intrinsic-inline-size": {
-    "syntax": "none | <length> | auto <length>",
+    "syntax": "auto? [ none | <length> ]",
     "inherited": false,
     "animationType": "byComputedValueType",
     "percentages": "no",
@@ -4384,11 +4384,11 @@
     "appliesto": "elementsForWhichSizeContainmentCanApply",
     "computed": "asSpecifiedWithLengthValuesComputed",
     "order": "perGrammar",
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-inline-size"
   },
   "contain-intrinsic-width": {
-    "syntax": "none | <length> | auto <length>",
+    "syntax": "auto? [ none | <length> ]",
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValueType",
@@ -4400,7 +4400,7 @@
     "appliesto": "elementsForWhichSizeContainmentCanApply",
     "computed": "asSpecifiedWithLengthValuesComputed",
     "order": "perGrammar",
-    "status": "experimental",
+    "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width"
   },
   "container": {


### PR DESCRIPTION
This PR updates the syntax for all `contain-intrinsic-*` properties:


- Most adhere to `auto? [ none | <length> ]`  ->  an optional `auto` keyword followed by `none` or a `<length>`, e.g.:
  - `10px`
  - `auto none`
  - `auto 300px`
- `[ auto? [ none | <length> ] ]{1,2}` - an optional `auto` keyword with `none` or a `<length>`,  
  - `50px 250px`
  - `none none`
  - can be `auto 10px auto 10px` (for `auto width, auto height`)


Additionally setting all of these as standard now.

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/28292
- [ ] Examples: https://github.com/mdn/content/pull/28618
- [x] Relnote https://github.com/mdn/content/pull/28522
- [x] BCD - https://github.com/mdn/browser-compat-data/pull/20532


__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1835813