### PR TITLE
chore(ci): Add conventional commits guideline to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,8 @@
 <!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->
 
+<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
+<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->
+
 ### Description
 
 <!-- ✍️ Summarize your changes in one or two sentences -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ There are many ways you can help improve this repository! For example:
   Let us know if these look good to you.
 - **Localizing strings:** translations are in the [l10n folder](./l10n). You can add your locale.
 
+**Note**: Commits need to adhere to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and only `fix:` and `feat:` commits are considered.
+
 ### CSS data tasks
 
 - **Updating CSS data**: familiarize yourself with the [CSS schema files](./css/README.md) and add missing CSS data. An additional guide is provided in the [How to update the CSS JSON DB](./docs/updating_css_json.md) document.


### PR DESCRIPTION
Contributors are not following conventional commits so the releases are not happening frequently. The PR updates PR template and CONTRIBUTING docs.