### PR TITLE
29786 ship light dark

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -123,7 +123,7 @@
     "syntax": "<url>"
   },
   "color": {
-    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>"
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <light-dark()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>"
   },
   "color-stop": {
     "syntax": "<color-stop-length> | <color-stop-angle>"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -425,6 +425,9 @@
   "length-percentage": {
     "syntax": "<length> | <percentage>"
   },
+  "light-dark()": {
+    "syntax": "light-dark( <color>, <color> )"
+  },
   "line-names": {
     "syntax": "'[' <custom-ident>* ']'"
   },


### PR DESCRIPTION
### Description

Added the `light-dark()` CSS color function syntax

### Motivation

Working on [Issue 29786](https://github.com/mdn/content/issues/29786) for the release of `light-dark()` CSS color function in Firefox 120

### Additional details

[Bugzilla 1856999](https://bugzilla.mozilla.org/show_bug.cgi?id=1856999)

### Related issues and pull requests

- [Content Pull Request](https://github.com/mdn/content/pull/30244)
- [BCD Pull Request](https://github.com/mdn/browser-compat-data/pull/21226)
