### PR TITLE
Remove abandoned value + fix renamed ones

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -249,15 +249,6 @@
         "order": "uniqueOrder",
         "status": "standard"
       },
-      "font-variant": {
-        "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-        "media": "all",
-        "initial": "normal",
-        "percentages": "no",
-        "computed": "asSpecified",
-        "order": "orderOfAppearance",
-        "status": "standard"
-      },
       "line-gap-override": {
         "syntax": "normal | <percentage>",
         "media": "all",
@@ -474,17 +465,6 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@scope"
-  },
-  "@scroll-timeline": {
-    "syntax": "@scroll-timeline <timeline-name> { <declaration-list> }",
-    "interfaces": [
-      "ScrollTimeline"
-    ],
-    "groups": [
-      "CSS Animations"
-    ],
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@scroll-timeline"
   },
   "@starting-style": {
     "syntax": "@starting-style {\n  <declaration-list> | <group-rule-body>\n}",

--- a/css/properties.json
+++ b/css/properties.json
@@ -2390,21 +2390,6 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-size"
   },
-  "block-overflow": {
-    "syntax": "clip | ellipsis | <string>",
-    "media": "visual",
-    "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "CSS Overflow"
-    ],
-    "initial": "clip",
-    "appliesto": "blockContainers",
-    "computed": "asSpecified",
-    "order": "perGrammar",
-    "status": "experimental"
-  },
   "block-size": {
     "syntax": "<'width'>",
     "media": "visual",
@@ -9952,22 +9937,6 @@
     "order": "perGrammar",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space-collapse"
-  },
-  "white-space-trim": {
-    "syntax": "none | discard-before || discard-after || discard-inner",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "CSS Text"
-    ],
-    "initial": "none",
-    "appliesto": "inlineBoxesAndBlockContainers",
-    "computed": "asSpecified",
-    "order": "perGrammar",
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space-trim"
   },
   "widows": {
     "syntax": "<integer>",

--- a/css/selectors.json
+++ b/css/selectors.json
@@ -432,15 +432,6 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-child"
   },
-  ":nth-col": {
-    "syntax": ":nth-col",
-    "groups": [
-      "Pseudo-classes",
-      "Selectors"
-    ],
-    "status": "experimental",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-col"
-  },
   ":nth-last-child": {
     "syntax": ":nth-last-child( <nth> [ of <complex-selector-list> ]? )",
     "groups": [
@@ -449,15 +440,6 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-child"
-  },
-  ":nth-last-col": {
-    "syntax": ":nth-last-col",
-    "groups": [
-      "Pseudo-classes",
-      "Selectors"
-    ],
-    "status": "experimental",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-col"
   },
   ":nth-last-of-type": {
     "syntax": ":nth-last-of-type( <nth> )",

--- a/css/types.json
+++ b/css/types.json
@@ -111,6 +111,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-legacy"
   },
+  "easing-function": {
+    "groups": [
+      "CSS Animations",
+      "CSS Transitions",
+      "CSS Types"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function"
+  },
   "filter-function": {
     "groups": [
       "Filter Effects"
@@ -259,15 +268,6 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time-percentage"
-  },
-  "timing-function": {
-    "groups": [
-      "CSS Animations",
-      "CSS Transitions",
-      "CSS Types"
-    ],
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timing-function"
   },
   "transform-function": {
     "groups": [

--- a/docs/updating_css_json.md
+++ b/docs/updating_css_json.md
@@ -318,7 +318,7 @@ For shorthand properties, several entries are a list of the longhand properties 
 ```json
 {
   "animation": {
-    "syntax": "&lt;single-animation-name&gt; || &lt;time&gt; || &lt;timing-function&gt; || &lt;time&gt; || &lt;single-animation-iteration-count&gt; || &lt;single-animation-direction&gt; || &lt;single-animation-fill-mode&gt; || &lt;single-animation-play-state&gt;",
+    "syntax": "&lt;single-animation-name&gt; || &lt;time&gt; || &lt;easing-function&gt; || &lt;time&gt; || &lt;single-animation-iteration-count&gt; || &lt;single-animation-direction&gt; || &lt;single-animation-fill-mode&gt; || &lt;single-animation-play-state&gt;",
     "media": "visual",
     "inherited": false,
     "animatable": "no",

--- a/docs/updating_css_json.md
+++ b/docs/updating_css_json.md
@@ -313,39 +313,40 @@ The syntaxes for the values `<family-name>` and `<generic-family>` are stored li
 
 ## Example for a CSS shorthand property
 
-For shorthand properties, several entries are a list of the longhand properties associated to it.
+For shorthand properties, several entries are a list of the longhand properties associated with it.
 
 ```json
 {
-  "animation": {
-    "syntax": "&lt;single-animation-name&gt; || &lt;time&gt; || &lt;easing-function&gt; || &lt;time&gt; || &lt;single-animation-iteration-count&gt; || &lt;single-animation-direction&gt; || &lt;single-animation-fill-mode&gt; || &lt;single-animation-play-state&gt;",
+  "border": {
+    "syntax": "<line-width> || <line-style> || <color>",
     "media": "visual",
     "inherited": false,
-    "animatable": "no",
+    "animationType": [
+      "border-color",
+      "border-style",
+      "border-width"
+    ],
     "percentages": "no",
-    "groups": ["CSS Animations"],
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
     "initial": [
-      "animation-name",
-      "animation-duration",
-      "animation-timing-function",
-      "animation-delay",
-      "animation-iteration-count",
-      "animation-direction",
-      "animation-fill-mode",
-      "animation-play-state"
+      "border-width",
+      "border-style",
+      "border-color"
     ],
-    "appliesto": "allElementsAndPseudos",
+    "appliesto": "allElements",
     "computed": [
-      "animation-name",
-      "animation-duration",
-      "animation-timing-function",
-      "animation-delay",
-      "animation-direction",
-      "animation-iteration-count",
-      "animation-fill-mode",
-      "animation-play-state"
+      "border-width",
+      "border-style",
+      "border-color"
     ],
-    "order": "orderOfAppearance"
-  }
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border"
+  },
 }
 ```

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1216,10 +1216,10 @@
     "ja": "文法通り"
   },
   "position": {
-    "de": "<a href=\"/de/docs/Web/CSS/number#interpolation\" title=\"Werte des <position> Datentyps werden unabhängig für Abszisse und Ordinate interpoliert. Da die Geschwindigkeit für beide durch dieselbe <timing-function> bestimmt wird, wird der Punkt einer Linie folgen.\">Position</a>",
-    "en-US": "a <a href=\"/en-US/docs/Web/CSS/position_value#interpolation\" title=\"Values of the <position> data type are interpolated independently for the abscissa and ordinate. As the speed is defined by the same <timing-function> for both, the point will move following a line.\">position</a>",
-    "fr": "une <a href=\"/fr/docs/Web/CSS/position_value#interpolation\" title=\"Les valeurs de type <position> sont interpolées indépendamment pour les abscisses et pour les ordonnées. La vitesse est définie par la même <timing-function>, le point se déplacera donc suivant une ligne.\">position</a>",
-    "ja": "<a href=\"/en-US/docs/Web/CSS/position_value#interpolation\" title=\"<position> データ型の値は、横軸と縦軸に対して個別に補間されます。速度は両方とも同じ <timing-function> で定義されているので、点は線に沿って移動します。\">position</a>",
+    "de": "<a href=\"/de/docs/Web/CSS/number#interpolation\" title=\"Werte des <position> Datentyps werden unabhängig für Abszisse und Ordinate interpoliert. Da die Geschwindigkeit für beide durch dieselbe <easing-function> bestimmt wird, wird der Punkt einer Linie folgen.\">Position</a>",
+    "en-US": "a <a href=\"/en-US/docs/Web/CSS/position_value#interpolation\" title=\"Values of the <position> data type are interpolated independently for the abscissa and ordinate. As the speed is defined by the same <easing-function> for both, the point will move following a line.\">position</a>",
+    "fr": "une <a href=\"/fr/docs/Web/CSS/position_value#interpolation\" title=\"Les valeurs de type <position> sont interpolées indépendamment pour les abscisses et pour les ordonnées. La vitesse est définie par la même <easing-function>, le point se déplacera donc suivant une ligne.\">position</a>",
+    "ja": "<a href=\"/en-US/docs/Web/CSS/position_value#interpolation\" title=\"<position> データ型の値は、横軸と縦軸に対して個別に補間されます。速度は両方とも同じ <easing-function> で定義されているので、点は線に沿って移動します。\">position</a>",
     "ru": "<a href=\"/ru/docs/Web/CSS/position_value#interpolation\" title=\"Значении типа данных <позиция> интерполизуются независимо как абсцисса или ордината. Скорость определяется по одной <временной функции> для обоих координат, точка будет двигаться следуя линии.\">позиция</a>"
   },
   "positionedElements": {


### PR DESCRIPTION
Several features have been renamed or abandoned over the years.

Because they are listed incorrectly here, they lead to broken links in CSS/Reference.

This PR removed them and renamed `<timing-function>` into the `<easing-function>` as used everywhere.