### PR TITLE
fix(css): Fix scroll() definition format

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -696,7 +696,7 @@
     "syntax": "scaleZ( [ <number> | <percentage> ] )"
   },
   "scroll()": {
-    "syntax": "scroll([<axis> || <scroller>]?)"
+    "syntax": "scroll( [ <axis> || <scroller> ]? )"
   },
   "scroller": {
     "syntax": "root | nearest"


### PR DESCRIPTION
The definition was oddly formatted, which caused my parser to break.

### Description

The declaration was not properly formatted.

### Motivation

Im writing a strict parser for this format and it failed.

### Additional details

None

### Related issues and pull requests

None