### PR TITLE
fix(css): overflow-wrap applies to text elements

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7562,7 +7562,7 @@
       "CSS Text"
     ],
     "initial": "normal",
-    "appliesto": "nonReplacedInlineElements",
+    "appliesto": "textElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "standard",


### PR DESCRIPTION
### Description

According to the current standard, the property is not applied to inline elements, but to text. See: https://www.w3.org/TR/css-text-3/#overflow-wrap-property

### Motivation

Aligning MDN documentation with current version of W3C standard.

### Additional details

In the [2018 version](https://www.w3.org/TR/2018/WD-css-text-3-20180920/#ref-for-inline-box%E2%91%A6) of the "CSS Text Module Level 3", the `overflow-wrap` property was applied to _inline boxes_. This was updated in the [2020 revision](https://www.w3.org/TR/2020/CR-css-text-3-20201222/#overflow-wrap-property), changing its application to _text_.