### PR TITLE
fix(css): Remove ::first-line from margin* props

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6384,8 +6384,7 @@
     ],
     "order": "uniqueOrder",
     "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line"
+      "::first-letter"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin"
@@ -6458,8 +6457,7 @@
     "computed": "percentageAsSpecifiedOrAbsoluteLength",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line"
+      "::first-letter"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-bottom"
@@ -6532,8 +6530,7 @@
     "computed": "percentageAsSpecifiedOrAbsoluteLength",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line"
+      "::first-letter"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-left"
@@ -6552,8 +6549,7 @@
     "computed": "percentageAsSpecifiedOrAbsoluteLength",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line"
+      "::first-letter"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-right"
@@ -6572,8 +6568,7 @@
     "computed": "percentageAsSpecifiedOrAbsoluteLength",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line"
+      "::first-letter"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-top"
@@ -6592,8 +6587,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "alsoAppliesTo": [
-      "::first-letter",
-      "::first-line"
+      "::first-letter"
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-trim"


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Correct the `alsoAppliesTo` for the CSS `margin` and `margin-{top,bottom,left,right.trim}` properties.

### Motivation

The data claims that `margin*` properties apply to the `::first-line` pseudoelement, which is untrue. They apply to `::first-letter`, but not `::first-line`. As reported by @Akindin in mdn/content#31806.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes mdn/content#31806