### PR TITLE
feat(css): alsoAppliesTo data for bg-pos-x/bg-pos-y

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2329,6 +2329,11 @@
     "appliesto": "allElements",
     "computed": "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
     "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-x"
   },
@@ -2345,6 +2350,11 @@
     "appliesto": "allElements",
     "computed": "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
     "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-y"
   },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Copy the `alsoAppliesTo` data from `background-position` to `background-position-x` and `background-position-y`, an obvious derivation from the shorthand property.

### Motivation

Provide more complete/detailed "Formal definition" data for MDN CSS property reference.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
