### PR TITLE
fix(css): Update the default/initial value of `offset-position`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7271,7 +7271,7 @@
     "groups": [
       "CSS Motion Path"
     ],
-    "initial": "auto",
+    "initial": "normal",
     "appliesto": "transformableElements",
     "computed": "forLengthAbsoluteValueOtherwisePercentage",
     "order": "perGrammar",


### PR DESCRIPTION
### Description

This PR updates the initial value of [`offset-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-position) property from `auto` to `normal`.

**Sources:**

- Spec: https://drafts.fxtf.org/motion/#offset-position-property
- Change in spec from `auto` to `normal`: https://github.com/w3c/fxtf-drafts/commit/fc81ee1361077c9f14cc73c3f99346f704762d4d
- Change implemented in Firefox:
    - https://bugzilla.mozilla.org/show_bug.cgi?id=1835434
    - https://bugzilla.mozilla.org/show_bug.cgi?id=1559232

To test:
1. Open this example in Playground (Firefox 122 beta, releasing on Jan 23): [Comparing various offset starting positions](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-position#comparing_various_offset_starting_positions).
2. Unset the value of `offset-position` to see the default value (default position with `normal` is (50%, 50%) of the containing block).

### Motivation

The examples shown in content are currently based on the `offset-position`'s earlier default value `auto` and are not behaving as expected. The default value impacts the behavior of other properties like `ray()` in `offset-path` that depend on `offset-position`. I'll be opening a corresponding content PR to adjust the examples to show the updated/expected behavior.



