### PR TITLE
fix: -moz-user-focus defaults to none

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1138,7 +1138,7 @@
     "groups": [
       "Mozilla Extensions"
     ],
-    "initial": "none",
+    "initial": "normal",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",


### PR DESCRIPTION
### Description

CSS [`-moz-user-focus`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-user-focus) default value changed from `none` to `normal` in FF123 in https://bugzilla.mozilla.org/show_bug.cgi?id=1868552

### Motivation

Because the behaviour changed.

### Additional details

Hold off on this - there is another issue in same release which may affect this. See https://bugzilla.mozilla.org/show_bug.cgi?id=1871745#c13

### Related issues and pull requests

https://github.com/mdn/content/issues/31928

https://bugzilla.mozilla.org/show_bug.cgi?id=1868552


