### PR TITLE
fix(css): replace value 'center' with '0% 0%' for mask-position inital value

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6874,7 +6874,7 @@
     "groups": [
       "CSS Masking"
     ],
-    "initial": "center",
+    "initial": "0% 0%",
     "appliesto": "allElementsSVGContainerElements",
     "computed": "consistsOfTwoKeywordsForOriginAndOffsets",
     "order": "perGrammar",


### PR DESCRIPTION
…l value

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

The page says that the mask-position Initial value is center, but when I tested it in Chrome, Firefox, etc., it was not center.
So I changed the initial value of the mask-position property from center to 0% 0%.

### Motivation

It will be helpful for people working with CSS by referring to the mdn document.

### Additional details

https://github.com/mdn/data/issues/713
https://developer.mozilla.org/en-US/docs/Web/CSS/mask-position

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
