### PR TITLE
added text-wrap-mode & t-w-style

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9513,6 +9513,38 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
   },
+  "text-wrap-mode": {
+    "syntax": "auto | wrap | nowrap",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "wrap",
+    "appliesto": "text",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
+  },
+  "text-wrap-style": {
+    "syntax": "auto | balance | stable | pretty",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "textAndBlockContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
+  },
   "timeline-scope": {
     "syntax": "none | <dashed-ident>#",
     "media": "interactive",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9527,7 +9527,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap-mode"
   },
   "text-wrap-style": {
     "syntax": "auto | balance | stable | pretty",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9543,7 +9543,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap-style"
   },
   "timeline-scope": {
     "syntax": "none | <dashed-ident>#",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9523,7 +9523,7 @@
       "CSS Text"
     ],
     "initial": "wrap",
-    "appliesto": "text",
+    "appliesto": "textAndBlockContainers",
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",


### PR DESCRIPTION
### Description

Added `text-wrap-mode` and `text-wrap-style`

### Motivation

Working on the [Convert text-wrap CSS property to a shorthand](https://github.com/mdn/content/issues/32341) Issue

### Related issues and pull requests
- [Content PR](https://github.com/mdn/content/pull/32728)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/22621)
- Firefox Release note PR - coming soon
- [Interactive examples PR](https://github.com/mdn/interactive-examples/pull/2746)