### PR TITLE
feat(css): correct ray() syntax + add ray-size type

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -621,7 +621,10 @@
     "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
   },
   "ray()": {
-    "syntax": "{ <angle> && [closest-side | closest-corner | farthest-side | farthest-corner | sides] && contain? && [at [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]]"
+    "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
+  },
+  "ray-size": {
+    "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
   },
   "relative-selector": {
     "syntax": "<combinator>? <complex-selector>"


### PR DESCRIPTION
### Description

Fixes the `ray()` syntax and adds the missing `ray-size` type.

### Additional details

https://drafts.fxtf.org/motion/#funcdef-ray

### Related issues and pull requests
Fixes https://github.com/mdn/data/issues/722