### PR TITLE
fix(css/functions): update path mdn_url

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -306,7 +306,7 @@
       "CSS Motion Path"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/path"
   },
   "paint()": {
     "syntax": "paint( <ident>, <declaration-value>? )",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Updates the `mdn_url` for the `path()` function.

### Motivation

The MDN page was moved.

### Additional details

Noticed this when running `yarn build --locale en-us --quiet` in yari.

### Related issues and pull requests

See also: https://github.com/mdn/content/pull/33843