### PR TITLE
Add text-spacing-trim property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9592,6 +9592,22 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-size-adjust"
   },
+  "text-spacing-trim": {
+    "syntax": "space-all | normal | space-first | trim-start | trim-both | trim-all | auto",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-spacing-trim"
+  },
   "text-transform": {
     "syntax": "none | capitalize | uppercase | lowercase | full-width | full-size-kana",
     "media": "visual",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Chrome supports the [`text-spacing-trim`](https://drafts.csswg.org/css-text-4/#text-spacing-trim-property) property as of version 123 (see the [ChromeStatus entry](https://chromestatus.com/feature/5170044014690304)).

This PR adds data for the property.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
