### PR TITLE
fix: CSS zoom should be a not animatable property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10281,7 +10281,7 @@
     "syntax": "normal | reset | <number> | <percentage>",
     "media": "visual",
     "inherited": false,
-    "animationType": "integer",
+    "animationType": "notAnimatable",
     "percentages": "no",
     "groups": [
       "Microsoft Extensions"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Fix the animatable type of CSS zoom to be not-animatable.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

According to the [WD of the CSS zoom property](https://drafts.csswg.org/css-viewport/#zoom-property), the animation type of the zoom property is not animatable.
Some browsers, such as Firefox, which recently started supporting zoom, treat it as animatable though.

Here is a capture of the WD page.
![image](https://github.com/user-attachments/assets/eb8f8cdf-e4c5-48df-9a70-53b16d1269c3)

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
