### PR TITLE
fix(css): follow canonical order in border and outline sections

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2453,9 +2453,9 @@
     "media": "visual",
     "inherited": false,
     "animationType": [
-      "border-color",
+      "border-width",
       "border-style",
-      "border-width"
+      "border-color"
     ],
     "percentages": "no",
     "groups": [
@@ -7419,31 +7419,31 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/orphans"
   },
   "outline": {
-    "syntax": "[ <'outline-color'> || <'outline-style'> || <'outline-width'> ]",
+    "syntax": "[ <'outline-width'> || <'outline-style'> || <'outline-color'> ]",
     "media": [
       "visual",
       "interactive"
     ],
     "inherited": false,
     "animationType": [
-      "outline-color",
       "outline-width",
-      "outline-style"
+      "outline-style",
+      "outline-color"
     ],
     "percentages": "no",
     "groups": [
       "CSS Basic User Interface"
     ],
     "initial": [
-      "outline-color",
+      "outline-width",
       "outline-style",
-      "outline-width"
+      "outline-color"
     ],
     "appliesto": "allElements",
     "computed": [
-      "outline-color",
       "outline-width",
-      "outline-style"
+      "outline-style",
+      "outline-color"
     ],
     "order": "orderOfAppearance",
     "status": "standard",


### PR DESCRIPTION
- related to the PR https://github.com/mdn/content/pull/34995

The desired sub-properties order is `width style color.`