### PR TITLE
chore: add CODEOWNERS for auto-adding reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is used to request PR reviews.
+
+# Default
+* @mdn/core-yari-content


### PR DESCRIPTION
We don't have auto-adding of reviewers in this repository yet, so adding codeowners so that PRs don't slip through the net for the moment.
