### PR TITLE
feat(ci): Update depbot to check GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,21 @@
 version: 2
+
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "automated pr"
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "automated pr"
+      - "dependencies"
+      - "github actions"


### PR DESCRIPTION
There are warnings that actions used in this repo use deprecated Node versions. Adding depbot for `github-actions` ecosystem.

See https://github.com/mdn/content/blob/main/.github/dependabot.yml for reference