### PR TITLE
feat: added auto value to text-emphasis-position property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9878,7 +9878,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color"
   },
   "text-emphasis-position": {
-    "syntax": "auto | [ over | under ] && [ right | left ]",
+    "syntax": "auto | [ over | under ] && [ right | left ]?",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9878,7 +9878,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color"
   },
   "text-emphasis-position": {
-    "syntax": "[ over | under ] && [ right | left ]",
+    "syntax": "auto | [ over | under ] && [ right | left ]",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9886,7 +9886,7 @@
     "groups": [
       "CSS Text Decoration"
     ],
-    "initial": "over right",
+    "initial": "auto",
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "uniqueOrder",


### PR DESCRIPTION
### Description

Added the `auto` value for the formal syntax of `text-emphasis-position` property

### Motivation

Working on [#36125](https://github.com/mdn/content/issues/36125)

### Additional details

- [RESOLVED: add `auto` value for `text-emphasis-position`](https://github.com/w3c/csswg-drafts/issues/1198#issuecomment-2358986319)
- [Open Chromium issue #368047813](https://issues.chromium.org/issues/368047813)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/24670)
