### PR TITLE
feat: update `text-wrap` to be a shorthand property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10104,17 +10104,23 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-position"
   },
   "text-wrap": {
-    "syntax": "wrap | nowrap | balance | stable | pretty",
+    "syntax": "<'text-wrap-mode> || <'text-wrap-style'>",
     "media": "visual",
     "inherited": true,
-    "animationType": "discrete",
+    "animationType": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
     "percentages": "no",
     "groups": [
       "CSS Text"
     ],
     "initial": "wrap",
     "appliesto": "textAndBlockContainers",
-    "computed": "asSpecified",
+    "computed": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
     "order": "perGrammar",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"


### PR DESCRIPTION
### Description

Specification: https://drafts.csswg.org/css-text-4/#propdef-text-wrap.
Make `text-wrap` a shorthand property of `text-wrap-mode` and `text-wrap-style`.

### Motivation

Practically this will mean `text-wrap: auto` becomes valid according to the `properties.json` syntax.

### Additional details

N/A

### Related issues and pull requests

N/A
