### PR TITLE
chore(css): remove `column-fill: balance-all`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4193,7 +4193,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-count"
   },
   "column-fill": {
-    "syntax": "auto | balance | balance-all",
+    "syntax": "auto | balance",
     "media": "visualInContinuousMediaNoEffectInOverflowColumns",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
### Description

Removes an value that has not been implemented by any browser.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See:
- https://github.com/mdn/content/pull/34561
- https://github.com/mdn/browser-compat-data/pull/23578
- https://github.com/mdn/interactive-examples/pull/2853
