### PR TITLE
Fix `aspect-ratio` syntax to support both `auto` and `<ratio>` in combination

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2085,7 +2085,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
   },
   "aspect-ratio": {
-    "syntax": "auto | <ratio>",
+    "syntax": "auto || <ratio>",
     "media": "all",
     "inherited": false,
     "animationType": "byComputedValueType",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixed incorrect syntax: `|` replaced with `||`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->
[aspect-ratio - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#formal_syntax)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Related issues:

- https://github.com/csstree/csstree/issues/293
- https://github.com/stylelint/stylelint/issues/8027


BEGIN_COMMIT_OVERRIDE
fix(css): aspect-ratio value supports both 'auto' and 'ratio' together
END_COMMIT_OVERRIDE