### PR TITLE
fix(css): stroke-opacity syntax correction

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9574,7 +9574,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-miterlimit"
   },
   "stroke-opacity": {
-    "syntax": "<opacity>",
+    "syntax": "<'opacity'>",
     "media": "visual",
     "inherited": true,
     "animationType": "byComputedValueType",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Corrected `storoke-opacity` syntax error.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->
[CSS Fill and Stroke Module Level 3](https://drafts.fxtf.org/fill-stroke-3/#stroke-opacity)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- https://github.com/csstree/csstree/issues/299#issuecomment-2452827326
