### PR TITLE
feat(css): Update syntax for at_font-palette-values/override-colors

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -147,7 +147,7 @@
         "status": "standard"
       },
       "override-colors": {
-        "syntax": "[ <integer [0,∞]> <color> ]#",
+        "syntax": "[ <integer [0,∞]>  <color> ]#",
         "media": "all",
         "initial": "n/a (required)",
         "percentages": "no",

--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -147,7 +147,7 @@
         "status": "standard"
       },
       "override-colors": {
-        "syntax": "[ <integer [0,∞]> <absolute-color-base> ]#",
+        "syntax": "[ <integer [0,∞]> <color> ]#",
         "media": "all",
         "initial": "n/a (required)",
         "percentages": "no",

--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -147,7 +147,7 @@
         "status": "standard"
       },
       "override-colors": {
-        "syntax": "[ <integer [0,∞]>  <color> ]#",
+        "syntax": "[ <integer [0,∞]> <color> ]#",
         "media": "all",
         "initial": "n/a (required)",
         "percentages": "no",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

spec at https://drafts.csswg.org/css-fonts/#override-color, the syntax change happens in https://github.com/w3c/csswg-drafts/commit/f608f7dd3eb4fbf605649e8eca4cc7b2ebd0dffc, see also https://github.com/w3c/csswg-drafts/issues/9555 and https://github.com/w3c/csswg-drafts/issues/7010

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

reported in https://github.com/mdn/data/pull/597/

/cc @lahmatiy 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
