### PR TITLE
fix(css): Fix syntax for `text-wrap`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10123,14 +10123,17 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-position"
   },
   "text-wrap": {
-    "syntax": "<'text-wrap-mode> || <'text-wrap-style'>",
+    "syntax": "<'text-wrap-mode'> || <'text-wrap-style'>",
     "media": "visual",
     "inherited": true,
     "animationType": [
       "text-wrap-mode",
       "text-wrap-style"
     ],
-    "percentages": "no",
+    "percentages": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
     "groups": [
       "CSS Text"
     ],
@@ -10145,7 +10148,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
   },
   "text-wrap-mode": {
-    "syntax": "auto | wrap | nowrap",
+    "syntax": "wrap | nowrap",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -10148,7 +10148,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
   },
   "text-wrap-mode": {
-    "syntax": "wrap |  nowrap",
+    "syntax": "wrap | nowrap",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -10148,7 +10148,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
   },
   "text-wrap-mode": {
-    "syntax": "wrap | nowrap",
+    "syntax": "wrap |  nowrap",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

add missing `'` symbol for `text-wrap`

remove non-supported value `auto` for `text-wrap-mode`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-text-4/#propdef-text-wrap-mode
https://drafts.csswg.org/css-text-4/#propdef-text-wrap
https://drafts.csswg.org/css-text-4/#propdef-text-wrap-style

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

reported in https://github.com/mdn/data/pull/597/

/cc @lahmatiy 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
