### PR TITLE
feat(css): Add missing syntax for `stroke` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4750,7 +4750,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/field-sizing"
   },
   "fill": {
-    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke",
+    "syntax": "<paint>",
     "media": "visual",
     "inherited": true,
     "animationType": "byComputedValueType",
@@ -9462,7 +9462,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-rendering"
   },
   "stroke": {
-    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke",
+    "syntax": "<paint>",
     "media": "visual",
     "inherited": true,
     "animationType": [

--- a/css/properties.json
+++ b/css/properties.json
@@ -9462,7 +9462,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-rendering"
   },
   "stroke": {
-    "syntax": "",
+    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke",
     "media": "visual",
     "inherited": true,
     "animationType": [

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -608,6 +608,9 @@
   "path()": {
     "syntax": "path( [ <fill-rule>, ]? <string> )"
   },
+  "paint": {
+    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
+  },
   "paint()": {
     "syntax": "paint( <ident>, <declaration-value>? )"
   },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

add a <paint> syntax and use it for both `stroke` and `fill` property

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

(`fill` and `stroke` takes the same value)

https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
https://svgwg.org/svg2-draft/painting.html#FillProperty
https://svgwg.org/svg2-draft/painting.html#StrokeProperty

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
