### PR TITLE
feat(css): Update `<alpha-value>` usage

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4766,7 +4766,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fill"
   },
   "fill-opacity": {
-    "syntax": "<opacity-value>",
+    "syntax": "<'opacity'>",
     "media": "visual",
     "inherited": true,
     "animationType": "byComputedValueType",

--- a/css/properties.json
+++ b/css/properties.json
@@ -4766,7 +4766,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fill"
   },
   "fill-opacity": {
-    "syntax": "<alpha-value>",
+    "syntax": "<opacity-value>",
     "media": "visual",
     "inherited": true,
     "animationType": "byComputedValueType",
@@ -7581,7 +7581,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-rotate"
   },
   "opacity": {
-    "syntax": "<alpha-value>",
+    "syntax": "<opacity-value>",
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValueType",
@@ -9398,7 +9398,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name"
   },
   "shape-image-threshold": {
-    "syntax": "<alpha-value>",
+    "syntax": "<opacity-value>",
     "media": "visual",
     "inherited": false,
     "animationType": "number",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -578,6 +578,9 @@
   "opacity()": {
     "syntax": "opacity( [ <number-percentage> ] )"
   },
+  "opacity-value": {
+    "syntax": "<number> | <percentage>"
+  },
   "overflow-position": {
     "syntax": "unsafe | safe"
   },

--- a/css/syntaxes.md
+++ b/css/syntaxes.md
@@ -40,7 +40,7 @@ Or, syntaxes might reference other syntaxes that are also defined in syntaxes.js
   "syntax": "<length> | <percentage>"
 },
 "shape-radius": {
-    "syntax": "<length-percentage> | closest-side | farthest-side"
+  "syntax": "<length-percentage> | closest-side | farthest-side"
 },
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

for css properties, `<alpha-value>` has been replaced with `<opacity-value>`

see https://github.com/w3c/csswg-drafts/commit/d995b3485fb98ee7557449fd0ca7c3e79a11c8c3 for `opacity`, rest seems to be so when added

`opacity` https://drafts.csswg.org/css-color/#transparency
`fill-opacity` https://drafts.fxtf.org/fill-stroke/#fill-opacity
`shape-image-threshold` https://drafts.csswg.org/css-shapes/#shape-image-threshold-property

also, for css functions, it still keep to use `<alpha-value>`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

suggest: merge https://github.com/mdn/data/pull/786 first

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
