### PR TITLE
feat(css): Fix/Add synatx for `font-palette` `<palette-identifier>` `palette-mix()`

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -123,7 +123,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@document"
   },
   "@font-palette-values": {
-    "syntax": "@font-palette-values <dashed-ident> {  <declaration-list> }",
+    "syntax": "@font-palette-values <dashed-ident> { <declaration-list> }",
     "groups": [
       "CSS Fonts"
     ],

--- a/css/functions.json
+++ b/css/functions.json
@@ -316,6 +316,14 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/paint"
   },
+  "palette-mix()": {
+    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette/palette-mix"
+  },
   "perspective()": {
     "syntax": "perspective( <length> )",
     "groups": [

--- a/css/properties.json
+++ b/css/properties.json
@@ -5116,10 +5116,10 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing"
   },
   "font-palette": {
-    "syntax": "normal | light | dark | <palette-identifier>",
+    "syntax": "normal | light | dark | <palette-identifier> | <palette-mix()>",
     "media": "visual",
     "inherited": true,
-    "animationType": "byComputedValueType",
+    "animationType": "byComputedValue",
     "percentages": "no",
     "groups": [
       "CSS Fonts"

--- a/css/properties.json
+++ b/css/properties.json
@@ -5133,7 +5133,8 @@
       "::first-line",
       "::placeholder"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette"
   },
   "font-variation-settings": {
     "syntax": "normal | [ <string> <number> ]#",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -17,6 +17,7 @@
         "angleBasicShapeOrPath",
         "angleOrBasicShapeOrPath",
         "basicShapeOtherwiseNo",
+        "byComputedValue",
         "byComputedValueType",
         "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg",
         "color",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -608,6 +608,9 @@
   "path()": {
     "syntax": "path( [ <fill-rule>, ]? <string> )"
   },
+  "palette-identifier": {
+    "syntax": "<dashed-ident>"
+  },
   "paint()": {
     "syntax": "paint( <ident>, <declaration-value>? )"
   },

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -593,6 +593,9 @@
     "ru": "блочные элементы",
     "zh-CN": "盒元素"
   },
+  "byComputedValue": {
+    "en-US": "by computed value"
+  },
   "byComputedValueType": {
     "en-US": "by computed value type",
     "ja": "計算値の型による",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

see https://github.com/mdn/data/issues/675

add missing syntax for `<palette-identifier>`, see https://drafts.csswg.org/css-fonts/#typedef-font-palette-palette-identifier

add mdn_url for `font-palette`

update synatx of `font-palette` to support new `palette-mix()` usage, which is supported since chromium M121 per BCD
and change animation type to *by computed value*, which happens since chromium M121 per BCD

add missing data for `palette-mix()`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/data/issues/675

Reported in https://github.com/mdn/data/pull/597/

/cc @lahmatiy 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
