### PR TITLE
fix(css): Add missing syntax for scope

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -710,11 +710,20 @@
   "scaleZ()": {
     "syntax": "scaleZ( [ <number> | <percentage> ] )"
   },
+  "scope-start": {
+    "syntax": "<selector-list>"
+  },
+  "scope-end": {
+    "syntax": "<selector-list>"
+  },
   "scroll()": {
     "syntax": "scroll( [ <axis> || <scroller> ]? )"
   },
   "scroller": {
     "syntax": "root | nearest | self"
+  },
+  "selector-list": {
+    "syntax": "<complex-selector-list>"
   },
   "self-position": {
     "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

reported in https://github.com/mdn/data/pull/597/

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

https://drafts.csswg.org/css-cascade-6/#at-ruledef-scope
https://drafts.csswg.org/css-cascade-6/#typedef-scope-start
https://drafts.csswg.org/css-cascade-6/#typedef-scope-end
https://drafts.csswg.org/selectors-4/#typedef-selector-list

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

/cc @lahmatiy 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
