### PR TITLE
feat(css): Add missing `<coord-box>` `<offset-path>` syntax for `offset-path` property

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -188,6 +188,9 @@
   "contrast()": {
     "syntax": "contrast( [ <number-percentage> ] )"
   },
+  "coord-box": {
+    "syntax": "<paint-box> | view-box"
+  },
   "cos()": {
     "syntax": "cos( <calc-sum> )"
   },
@@ -563,6 +566,9 @@
   "nth": {
     "syntax": "<an-plus-b> | even | odd"
   },
+  "offset-path": {
+    "syntax": "<ray()> | <url> | <basic-shape>"
+  },
   "opacity()": {
     "syntax": "opacity( [ <number-percentage> ] )"
   },
@@ -589,6 +595,9 @@
   },
   "page-size": {
     "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
+  },
+  "paint-box": {
+    "syntax": "<visual-box> | fill-box | stroke-box"
   },
   "path()": {
     "syntax": "path( [ <fill-rule>, ]? <string> )"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

https://drafts.fxtf.org/motion/#propdef-offset-path

https://drafts.fxtf.org/motion/#typedef-offset-path

https://www.w3.org/TR/css-box-4/#typedef-coord-box
https://www.w3.org/TR/css-box-4/#typedef-paint-box

reported in https://github.com/mdn/data/pull/597

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
