### PR TITLE
feat(css): Add missing `<try-size>` syntax for `position-try-order` property

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -902,6 +902,9 @@
   "translateZ()": {
     "syntax": "translateZ( <length> )"
   },
+  "try-size": {
+    "syntax": "most-width | most-height | most-block-size | most-inline-size"
+  },
   "type-or-unit": {
     "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | px | deg | grad | rad | turn | ms | s | Hz | kHz | %"
   },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-anchor-position-1/#propdef-position-try-order
https://drafts.csswg.org/css-anchor-position-1/#typedef-try-size

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

reported in https://github.com/mdn/data/pull/597

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
