### PR TITLE
fix(css): Fix syntax for white-space

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10590,7 +10590,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/visibility"
   },
   "white-space": {
-    "syntax": "normal | pre | nowrap | pre-wrap | pre-line | break-spaces | [ <'white-space-collapse'> || <'text-wrap'> || <'white-space-trim'> ]",
+    "syntax": "normal | pre | nowrap | pre-wrap | pre-line | break-spaces | [ <'white-space-collapse'> || <'text-wrap'> ]",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

currently white-space only available as a shorthand property for white-space-collapse and text-wrap only, not for white-space-trim (which didn't support by any browser at present)

https://github.com/mdn/browser-compat-data/blob/c933819e955e470ff5d6948842f7dbda3a62fae1/css/properties/white-space.json#L309-L347

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

reported in https://github.com/mdn/data/pull/597

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
