### PR TITLE
feat(css): add mdn_url for features with documentations

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5133,7 +5133,8 @@
       "::first-line",
       "::placeholder"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette"
   },
   "font-variation-settings": {
     "syntax": "normal | [ <string> <number> ]#",
@@ -5463,7 +5464,8 @@
       "::first-line",
       "::placeholder"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-emoji"
   },
   "font-variant-ligatures": {
     "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
@@ -6087,7 +6089,8 @@
     "appliesto": "allElements",
     "computed": "asSpecifiedWithExceptionOfResolution",
     "order": "uniqueOrder",
-    "status": "experimental"
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-resolution"
   },
   "ime-mode": {
     "syntax": "auto | normal | active | inactive | disabled",
@@ -7562,7 +7565,8 @@
     "appliesto": "transformableElements",
     "computed": "forLengthAbsoluteValueOtherwisePercentage",
     "order": "perGrammar",
-    "status": "experimental"
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-position"
   },
   "offset-rotate": {
     "syntax": "[ auto | reverse ] || <angle>",
@@ -7770,7 +7774,8 @@
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "perGrammar",
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-anchor"
   },
   "overflow-block": {
     "syntax": "visible | hidden | clip | scroll | auto",
@@ -7785,7 +7790,8 @@
     "appliesto": "blockContainersFlexContainersGridContainers",
     "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
     "order": "perGrammar",
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-block"
   },
   "overflow-clip-box": {
     "syntax": "padding-box | content-box",
@@ -7816,7 +7822,8 @@
     "appliesto": "allElements",
     "computed": "theComputedLengthAndVisualBox",
     "order": "perGrammar",
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-clip-margin"
   },
   "overflow-inline": {
     "syntax": "visible | hidden | clip | scroll | auto",
@@ -7831,7 +7838,8 @@
     "appliesto": "blockContainersFlexContainersGridContainers",
     "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
     "order": "perGrammar",
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-inline"
   },
   "overflow-wrap": {
     "syntax": "normal | break-word | anywhere",

--- a/css/types.json
+++ b/css/types.json
@@ -161,7 +161,8 @@
     "groups": [
       "CSS Types"
     ],
-    "status": "standard"
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ident"
   },
   "image": {
     "groups": [


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

these features has its documentations, so it's fine to add a mdn_url key

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

test with @mdn/browser-compat-data@5.6.18 and mdn-data@2.12.2 using https://github.com/skyclouds2001/mdn-tools/blob/master/mdn-data-css-check.js

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
