### PR TITLE
feat(css): Remove `azimuth` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2099,22 +2099,6 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio"
   },
-  "azimuth": {
-    "syntax": "<angle> | [ [ left-side | far-left | left | center-left | center | center-right | right | far-right | right-side ] || behind ] | leftwards | rightwards",
-    "media": "aural",
-    "inherited": true,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "CSS Speech"
-    ],
-    "initial": "center",
-    "appliesto": "allElements",
-    "computed": "normalizedAngle",
-    "order": "orderOfAppearance",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/azimuth"
-  },
   "backdrop-filter": {
     "syntax": "none | <filter-function-list>",
     "media": "visual",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the `azimuth` proeprty is never supported by any browser per BCD, it is also not in current active [spec](https://drafts.csswg.org/css-speech/), the mdn document (and [BCD](https://github.com/mdn/browser-compat-data/pull/6945)) has gone for a long time

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
