### PR TITLE
feat(css): Remove `overflow-clip-box` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7792,21 +7792,6 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-block"
   },
-  "overflow-clip-box": {
-    "syntax": "padding-box | content-box",
-    "media": "visual",
-    "inherited": false,
-    "animationType": "discrete",
-    "percentages": "no",
-    "groups": [
-      "Mozilla Extensions"
-    ],
-    "initial": "padding-box",
-    "appliesto": "allElements",
-    "computed": "asSpecified",
-    "order": "uniqueOrder",
-    "status": "nonstandard"
-  },
   "overflow-clip-margin": {
     "syntax": "<visual-box> || <length [0,∞]>",
     "media": "visual",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the feature is non-standard, not supported by any browser for a long time, and not in BCD and MDN content

see also https://github.com/mdn/browser-compat-data/pull/20148 for bcd changes

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
