### PR TITLE
feat(css): Update syntax for sizing properties

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5980,7 +5980,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation"
   },
   "height": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -7288,7 +7288,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-block-size"
   },
   "max-height": {
-    "syntax": "none | <length-percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -7335,7 +7335,7 @@
     "status": "experimental"
   },
   "max-width": {
-    "syntax": "none | <length-percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -7367,7 +7367,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-block-size"
   },
   "min-height": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -7399,7 +7399,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-inline-size"
   },
   "min-width": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -10679,7 +10679,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/widows"
   },
   "width": {
-    "syntax": "auto | <length> | <percentage> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

sizing properties include `height` `max-height` `max-width` `min-height` `min-width` `width`

merge `<length> | <percentage>` to `<length-percentage [0,∞]>` per specification
update `fit-content(<length-percentage>)` to `fit-content(<length-percentage [0,∞]>)` per specification
add missing `<calc-size()>` function syntax, which is supported in chromium M129
add missing `<anchor-size()>` function syntax, which is supported in chromium M125
add non-standard `-webkit-fill-available` value, its standard value is `stretch`, which currently is not supported per BCD

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-sizing/#propdef-width
https://drafts.csswg.org/css-sizing/#propdef-height
https://drafts.csswg.org/css-sizing/#propdef-min-width
https://drafts.csswg.org/css-sizing/#propdef-min-height
https://drafts.csswg.org/css-sizing/#propdef-max-width
https://drafts.csswg.org/css-sizing/#propdef-max-height

https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch
https://drafts.csswg.org/css-sizing/#funcdef-width-fit-content
https://drafts.csswg.org/css-anchor-position/#anchor-size-fn

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
