### PR TITLE
feat(css): remove non-supported caption-side values

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3988,7 +3988,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside"
   },
   "caption-side": {
-    "syntax": "top | bottom | block-start | block-end | inline-start | inline-end",
+    "syntax": "top | bottom",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

per bcd and mdn doc, these logical values havn't been supported by any platform

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
