### PR TITLE
feat(css): add missing css functions to syntaxes

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -11,8 +11,14 @@
   "alpha-value": {
     "syntax": "<number> | <percentage>"
   },
+  "anchor()": {
+    "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
+  },
   "anchor-name": {
     "syntax": "<dashed-ident>"
+  },
+  "anchor-size()": {
+    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
   },
   "angle-percentage": {
     "syntax": "<angle> | <percentage>"
@@ -320,6 +326,9 @@
   "final-bg-layer": {
     "syntax": "<'background-color'> || <bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <box> || <box>"
   },
+  "fit-content()": {
+    "syntax": "fit-content( <length-percentage [0,∞]> )"
+  },
   "fixed-breadth": {
     "syntax": "<length-percentage>"
   },
@@ -584,6 +593,12 @@
   "offset-path": {
     "syntax": "<ray()> | <url> | <basic-shape>"
   },
+  "oklab()": {
+    "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  "oklch()": {
+    "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
   "opacity()": {
     "syntax": "opacity( [ <number-percentage> ] )"
   },
@@ -628,6 +643,9 @@
   },
   "palette-identifier": {
     "syntax": "<dashed-ident>"
+  },
+  "palette-mix()": {
+    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
   },
   "path()": {
     "syntax": "path( [ <fill-rule>, ]? <string> )"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

reported in https://github.com/mdn/data/issues/819

current some css functions are in functions.json, but more css functions are in syntaxes.json, see https://github.com/skyclouds2001/mdn-tools/blob/master/results/missing_function.json for checking results

this PR add css functions that are in functions.json but not in syntaxes.json to syntaxes.json, which seems to be the current behavior

see also https://github.com/mdn/data/issues/811

note data is not check with spec but just simply copy from functions.json

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
