### PR TITLE
feat(css): Add data for `text-box-*`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9774,6 +9774,51 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-anchor"
   },
+  "text-box": {
+    "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "normal",
+    "appliesto": "blockContainersAndInlineBoxes",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "text-box-edge": {
+    "syntax": "auto | <text-edge>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersAndInlineBoxes",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "text-box-trim": {
+    "syntax": "none | trim-start | trim-end | trim-both",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainersAndInlineBoxes",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
   "text-combine-upright": {
     "syntax": "none | all | [ digits <integer>? ]",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -171,6 +171,7 @@
         "specifiedValueNumberClipped0To1",
         "theComputedLengthAndVisualBox",
         "theKeywordListStyleImageNoneOrComputedValue",
+        "theSpecifiedKeyword",
         "translucentValuesRGBAOtherwiseRGB",
         "twoAbsoluteLengthOrPercentages",
         "twoAbsoluteLengths"
@@ -207,6 +208,7 @@
         "beforeAndAfterPseudos",
         "blockContainerElements",
         "blockContainers",
+        "blockContainersAndInlineBoxes",
         "blockContainersAndMultiColumnContainers",
         "blockContainersExceptMultiColumnContainers",
         "blockContainersExceptTableWrappers",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -881,6 +881,9 @@
   "target-text()": {
     "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
   },
+  "text-edge": {
+    "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
+  },
   "time-percentage": {
     "syntax": "<time> | <percentage>"
   },

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -553,6 +553,9 @@
     "ru": "блочные контейнеры",
     "zh-CN": "区块容器"
   },
+  "blockContainersAndInlineBoxes": {
+    "en-US": "Block containers and inline boxes"
+  },
   "blockContainersAndMultiColumnContainers": {
     "de": "Blockcontainer und mehrspaltige Container",
     "en-US": "Block containers and multi-column containers",
@@ -1786,6 +1789,9 @@
   },
   "theKeywordListStyleImageNoneOrComputedValue": {
     "en-US": "The keyword <code>none</code> or the computed &lt;image&gt;"
+  },
+  "theSpecifiedKeyword": {
+    "en-US": "the specified keyword"
   },
   "transform": {
     "de": "Transformation",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

these properties are supported in chrome M133 and Safari M18.2

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-inline/#typedef-text-edge
https://drafts.csswg.org/css-inline/#propdef-text-box
https://drafts.csswg.org/css-inline/#propdef-text-box-trim
https://drafts.csswg.org/css-inline/#propdef-text-box-edge

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
