### PR TITLE
feat(css): add missing css functions

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -1,4 +1,22 @@
 {
+  "abs()": {
+    "syntax": "abs( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs"
+  },
+  "acos()": {
+    "syntax": "acos( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/acos"
+  },
   "anchor()": {
     "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )",
     "groups": [
@@ -14,6 +32,33 @@
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor-size"
+  },
+  "asin()": {
+    "syntax": "asin( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/asin"
+  },
+  "atan()": {
+    "syntax": "atan( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/atan"
+  },
+  "atan2()": {
+    "syntax": "atan2( <calc-sum>, <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/atan2"
   },
   "attr()": {
     "syntax": "attr( <attr-name> <type-or-unit>? [, <attr-fallback> ]? )",
@@ -91,6 +136,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/contrast"
   },
+  "cos()": {
+    "syntax": "cos( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cos"
+  },
   "counter()": {
     "syntax": "counter( <counter-name>, <counter-style>? )",
     "groups": [
@@ -149,6 +203,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env"
   },
+  "exp()": {
+    "syntax": "exp( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/exp"
+  },
   "fit-content()": {
     "syntax": "fit-content( <length-percentage [0,∞]> )",
     "groups": [
@@ -190,6 +253,15 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/hue-rotate"
+  },
+  "hypot()": {
+    "syntax": "hypot( <calc-sum># )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hypot"
   },
   "image()": {
     "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )",
@@ -240,6 +312,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/linear-gradient"
   },
+  "log()": {
+    "syntax": "log( <calc-sum>, <calc-sum>? )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/log"
+  },
   "matrix()": {
     "syntax": "matrix( <number>#{6} )",
     "groups": [
@@ -282,6 +363,15 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax"
+  },
+  "mod()": {
+    "syntax": "mod( <calc-sum>, <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mod"
   },
   "oklab()": {
     "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )",
@@ -349,6 +439,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/polygon"
   },
+  "pow()": {
+    "syntax": "pow( <calc-sum>, <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/pow"
+  },
   "radial-gradient()": {
     "syntax": "radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )",
     "groups": [
@@ -365,6 +464,15 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ray"
+  },
+  "rem()": {
+    "syntax": "rem( <calc-sum>, <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rem"
   },
   "repeating-linear-gradient()": {
     "syntax": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
@@ -440,6 +548,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateZ"
   },
+  "round()": {
+    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/round"
+  },
   "saturate()": {
     "syntax": "saturate( <number-percentage> )",
     "groups": [
@@ -506,6 +623,24 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/sepia"
   },
+  "sign()": {
+    "syntax": "sign( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sign"
+  },
+  "sin()": {
+    "syntax": "sin( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sin"
+  },
   "skew()": {
     "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )",
     "groups": [
@@ -530,6 +665,15 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewY"
   },
+  "sqrt()": {
+    "syntax": "sqrt( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sqrt"
+  },
   "target-counter()": {
     "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )",
     "groups": [
@@ -550,6 +694,15 @@
       "CSS Miscellaneous"
     ],
     "status": "nonstandard"
+  },
+  "tan()": {
+    "syntax": "tan( <calc-sum> )",
+    "groups": [
+      "CSS Units",
+      "CSS Lengths"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/tan"
   },
   "translate()": {
     "syntax": "translate( <length-percentage> , <length-percentage>? )",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

his PR add css functions that are in syntaxes.json but not in functions.json to functions.json, which seems to be the current behavior

see also https://github.com/mdn/data/issues/811

note data is not check with spec but just simply copy from syntaxes.json

this PR is te follow up of https://github.com/mdn/data/pull/827, and this only cares about css math functions
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
