### PR TITLE
fix(css): correct syntax for scale related css functions

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -450,7 +450,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/saturate"
   },
   "scale()": {
-    "syntax": "scale( <number> , <number>? )",
+    "syntax": "scale( [ <number> | <percentage> ]#{1,2} )",
     "groups": [
       "CSS Transforms"
     ],
@@ -458,7 +458,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale"
   },
   "scale3d()": {
-    "syntax": "scale3d( <number> , <number> , <number> )",
+    "syntax": "scale3d( [ <number> | <percentage> ]#{3} )",
     "groups": [
       "CSS Transforms"
     ],
@@ -466,7 +466,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale3d"
   },
   "scaleX()": {
-    "syntax": "scaleX( <number> )",
+    "syntax": "scaleX( [ <number> | <percentage> ] )",
     "groups": [
       "CSS Transforms"
     ],
@@ -474,7 +474,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleX"
   },
   "scaleY()": {
-    "syntax": "scaleY( <number> )",
+    "syntax": "scaleY( [ <number> | <percentage> ] )",
     "groups": [
       "CSS Transforms"
     ],
@@ -482,7 +482,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleY"
   },
   "scaleZ()": {
-    "syntax": "scaleZ( <number> )",
+    "syntax": "scaleZ( [ <number> | <percentage> ] )",
     "groups": [
       "CSS Transforms"
     ],


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

note that only those data in functions.json are not correct, those in syntaxes.json are correct

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

found with https://github.com/skyclouds2001/mdn-tools/blob/master/checks/function-consistent-check.js and reported in https://github.com/skyclouds2001/mdn-tools/blob/master/results/inconsistent_function.json

https://drafts.csswg.org/css-transforms-2/#funcdef-scale
https://drafts.csswg.org/css-transforms-2/#funcdef-scalex
https://drafts.csswg.org/css-transforms-2/#funcdef-scaley
https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d
https://drafts.csswg.org/css-transforms-2/#funcdef-scalez

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
