### PR TITLE
feat(css): Update syntax for `background-clip`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2240,7 +2240,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-blend-mode"
   },
   "background-clip": {
-    "syntax": "<box>#",
+    "syntax": "<bg-clip>#",
     "media": "visual",
     "inherited": false,
     "animationType": "repeatableList",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -74,6 +74,9 @@
   "basic-shape": {
     "syntax": "<inset()> | <circle()> | <ellipse()> | <polygon()> | <path()>"
   },
+  "bg-clip": {
+    "syntax": "<visual-box> | border-area | text"
+  },
   "bg-image": {
     "syntax": "none | <image>"
   },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

update syntax for this property to be align with latest spec

in [stable version](https://drafts.csswg.org/css-backgrounds/#propdef-background-clip), its syntax is defined as `<visual-box>#`, whcih defines support for `border-box`, `padding-box` and `content-box` values
in [latest version](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-clip), its syntax is defined as `<bg-clip>#`, which additional defines support for `border-area` and `text` values

per bcd, `border-area` value is supported by Safari and `text` is supported in all major platform at present

see also https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip and related issue at csstree  https://github.com/csstree/csstree/issues/190

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Takes place of https://github.com/mdn/data/pull/744 as the original one seems not to be working anymore

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
