### PR TITLE
fix(css): Fix mdn_url for selectors and types

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -53,23 +53,23 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Selector_list"
   },
-  "Adjacent sibling combinator": {
+  "Next-sibling combinator": {
     "syntax": "A + B",
     "groups": [
       "Combinators",
       "Selectors"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Adjacent_sibling_combinator"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Next-sibling_combinator"
   },
-  "General sibling combinator": {
+  "Subsequent-sibling combinator": {
     "syntax": "A ~ B",
     "groups": [
       "Combinators",
       "Selectors"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/General_sibling_combinator"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Subsequent-sibling_combinator"
   },
   "Child combinator": {
     "syntax": "A > B",
@@ -303,7 +303,7 @@
       "Selectors"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host()"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host_function"
   },
   ":host-context()": {
     "syntax": ":host-context( <compound-selector> )",
@@ -312,7 +312,7 @@
       "Selectors"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host-context()"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host-context"
   },
   ":hover": {
     "syntax": ":hover",
@@ -666,8 +666,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-browse"
+    "status": "nonstandard"
   },
   "::-ms-check": {
     "syntax": "::-ms-check",
@@ -676,8 +675,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-check"
+    "status": "nonstandard"
   },
   "::-ms-clear": {
     "syntax": "::-ms-clear",
@@ -686,8 +684,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-clear"
+    "status": "nonstandard"
   },
   "::-ms-expand": {
     "syntax": "::-ms-expand",
@@ -696,8 +693,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-expand"
+    "status": "nonstandard"
   },
   "::-ms-fill": {
     "syntax": "::-ms-fill",
@@ -706,8 +702,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-fill"
+    "status": "nonstandard"
   },
   "::-ms-fill-lower": {
     "syntax": "::-ms-fill-lower",
@@ -716,8 +711,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-fill-lower"
+    "status": "nonstandard"
   },
   "::-ms-fill-upper": {
     "syntax": "::-ms-fill-upper",
@@ -726,8 +720,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-fill-upper"
+    "status": "nonstandard"
   },
   "::-ms-reveal": {
     "syntax": "::-ms-reveal",
@@ -736,8 +729,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-reveal"
+    "status": "nonstandard"
   },
   "::-ms-thumb": {
     "syntax": "::-ms-thumb",
@@ -746,8 +738,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-thumb"
+    "status": "nonstandard"
   },
   "::-ms-ticks-after": {
     "syntax": "::-ms-ticks-after",
@@ -756,8 +747,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-ticks-after"
+    "status": "nonstandard"
   },
   "::-ms-ticks-before": {
     "syntax": "::-ms-ticks-before",
@@ -766,8 +756,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-ticks-before"
+    "status": "nonstandard"
   },
   "::-ms-tooltip": {
     "syntax": "::-ms-tooltip",
@@ -776,8 +765,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-tooltip"
+    "status": "nonstandard"
   },
   "::-ms-track": {
     "syntax": "::-ms-track",
@@ -786,8 +774,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-track"
+    "status": "nonstandard"
   },
   "::-ms-value": {
     "syntax": "::-ms-value",
@@ -796,8 +783,7 @@
       "Selectors",
       "Microsoft Extensions"
     ],
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-value"
+    "status": "nonstandard"
   },
   "::-moz-progress-bar": {
     "syntax": "::-moz-progress-bar",
@@ -930,8 +916,7 @@
       "Pseudo-elements",
       "Selectors"
     ],
-    "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::cue-region"
+    "status": "standard"
   },
   "::first-letter": {
     "syntax": "/* CSS3 syntax */\n::first-letter\n\n/* CSS2 syntax */\n:first-letter",

--- a/css/types.json
+++ b/css/types.json
@@ -283,6 +283,6 @@
       "CSS Types"
     ],
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url_value"
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

fix mdn_url for selectors and types

for *Adjacent sibling combinator* and *Subsequent-sibling combinator*, rename and fix mdn_url to match the mdn/content

for IE-specifed feature, simply remove the mdn_url key

for non-existed mdn docs, remove the mdn_url key

for redirected mdn docs, update the mdn_url key

found using https://github.com/skyclouds2001/mdn-tools/blob/master/checks/mdn_url-check.js and result store in https://github.com/skyclouds2001/mdn-tools/blob/master/results/incorrect_mdn_url.json

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
