### PR TITLE
feat(css): Update synatx for `background-origin`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2303,7 +2303,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-image"
   },
   "background-origin": {
-    "syntax": "<box>#",
+    "syntax": "<visual-box>#",
     "media": "visual",
     "inherited": false,
     "animationType": "repeatableList",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

spec has updated the syntax in https://github.com/w3c/csswg-drafts/commit/7dc439c83df8bd34885f74689f8cbc7dff77b5e0, which replace replaces `<box>` definition with `<visual-box>` reference. note the change does not affect the property's definiton.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/background-origin
https://drafts.csswg.org/css-backgrounds/#propdef-background-origin

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
