### PR TITLE
feat(css): Update syntax for `[-webkit]-mask-{clip,origin}`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1423,7 +1423,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image"
   },
   "-webkit-mask-origin": {
-    "syntax": "<coord-box>#",
+    "syntax": "[ <coord-box> | border | padding | content ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -1375,7 +1375,7 @@
     "status": "nonstandard"
   },
   "-webkit-mask-clip": {
-    "syntax": "[ <coord-box> | border | padding | content | text ]#",
+    "syntax": "[ <coord-box> | no-clip | border | padding | content | text ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -1423,7 +1423,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image"
   },
   "-webkit-mask-origin": {
-    "syntax": "[ <box> | border | padding | content ]#",
+    "syntax": "<coord-box>#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -7176,7 +7176,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-mode"
   },
   "mask-origin": {
-    "syntax": "<geometry-box>#",
+    "syntax": "<coord-box>#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",

--- a/css/properties.json
+++ b/css/properties.json
@@ -1375,7 +1375,7 @@
     "status": "nonstandard"
   },
   "-webkit-mask-clip": {
-    "syntax": "[ <box> | border | padding | content | text ]#",
+    "syntax": "[ <coord-box> | border | padding | content | text ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -7112,7 +7112,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-width"
   },
   "mask-clip": {
-    "syntax": "[ <geometry-box> | no-clip ]#",
+    "syntax": "[ <coord-box> | no-clip ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the syntax for `mask-cli` and `mask-origin` has update to using `<coord-box>` type

the spec change happens in https://github.com/w3c/fxtf-drafts/commit/1c75a54c68e937275f55ce3990def0ddc4b3b7e4, as the margin-box value is not intended to be supported

> -webkit-mask-clip also support the new view-box,stroke-box,fill-box value
> -webkit-mask-origin also support the new view-box,stroke-box,fill-box value

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin
https://drafts.fxtf.org/css-masking/#the-mask-origin

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
