### PR TITLE
feat(css): Remove mdn_url for some obsolute/experiemental features

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1563,8 +1563,7 @@
     "appliesto": "scrollingBoxes",
     "computed": "asSpecified",
     "order": "orderOfAppearance",
-    "status": "nonstandard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-overflow-scrolling"
+    "status": "nonstandard"
   },
   "-webkit-tap-highlight-color": {
     "syntax": "<color>",
@@ -1811,8 +1810,7 @@
     "appliesto": "allElements",
     "computed": "asSpecified",
     "order": "perGrammar",
-    "status": "experimental",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor-scope"
+    "status": "experimental"
   },
   "animation": {
     "syntax": "<single-animation>#",
@@ -6120,8 +6118,7 @@
     "appliesto": "textFields",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ime-mode"
+    "status": "obsolete"
   },
   "initial-letter": {
     "syntax": "normal | [ <number> <integer>? ]",
@@ -6152,8 +6149,7 @@
     "appliesto": "firstLetterPseudoElementsAndInlineLevelFirstChildren",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "experimental",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/initial-letter-align"
+    "status": "experimental"
   },
   "inline-size": {
     "syntax": "<'width'>",
@@ -9215,8 +9211,7 @@
     "appliesto": "allElements",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-coordinate"
+    "status": "obsolete"
   },
   "scroll-snap-destination": {
     "syntax": "<position>",
@@ -9231,8 +9226,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-destination"
+    "status": "obsolete"
   },
   "scroll-snap-points-x": {
     "syntax": "none | repeat( <length-percentage> )",
@@ -9247,8 +9241,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-points-x"
+    "status": "obsolete"
   },
   "scroll-snap-points-y": {
     "syntax": "none | repeat( <length-percentage> )",
@@ -9263,8 +9256,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecifiedRelativeToAbsoluteLengths",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-points-y"
+    "status": "obsolete"
   },
   "scroll-snap-stop": {
     "syntax": "normal | always",
@@ -9311,8 +9303,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type-x"
+    "status": "obsolete"
   },
   "scroll-snap-type-y": {
     "syntax": "none | mandatory | proximity",
@@ -9327,8 +9318,7 @@
     "appliesto": "scrollContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
-    "status": "obsolete",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type-y"
+    "status": "obsolete"
   },
   "scroll-timeline": {
     "syntax": "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

`-webkit-overflow-scrolling` has been removed from bcd via https://github.com/mdn/browser-compat-data/pull/23570 and removed from content via https://github.com/mdn/content/pull/34557
`anchor-scope` in [spec](https://drafts.csswg.org/css-anchor-position/#propdef-anchor-scope) and in [bcd](https://github.com/mdn/browser-compat-data/blob/main/css/properties/anchor-scope.json), but have not documented yet
`ime-mode` is in [spec](https://drafts.csswg.org/css-ui/#input-method-editor) but it is obsolete, and note it is in [bcd](https://github.com/mdn/browser-compat-data/blob/main/css/properties/ime-mode.json), but have not documented yet
`initial-letter-align` is in [spec](https://drafts.csswg.org/css-inline/#propdef-initial-letter-align), but has been removed from bcd via https://github.com/mdn/browser-compat-data/pull/23574 and removed from content via https://github.com/mdn/content/pull/34558
`scroll-snap-{coordinate,destination,points-x,points-y,type-x,type-y}` is removed from [spec](https://drafts.csswg.org/css-scroll-snap/) and is obsolete, and has been removed from bcd via https://github.com/mdn/browser-compat-data/pull/20146 and removed from content via https://github.com/mdn/content/pull/27434

found using https://github.com/skyclouds2001/mdn-tools/blob/master/checks/mdn_url-check.js
report in https://github.com/skyclouds2001/mdn-tools/blob/master/results/incorrect_mdn_url.json

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
