### PR TITLE
feat(css): Add data for css `@view-transition` at-rule

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -531,5 +531,27 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@supports"
+  },
+  "@view-transition": {
+    "syntax": "@view-transition {\n  <declaration-list>\n}",
+    "interfaces": [
+      "CSSViewTransitionRule"
+    ],
+    "groups": [
+      "CSS View Transitions"
+    ],
+    "descriptors": {
+      "navigation": {
+        "syntax": "auto | none",
+        "media": "all",
+        "initial": "none",
+        "percentages": "no",
+        "computed": "asSpecified",
+        "order": "uniqueOrder",
+        "status": "standard"
+      }
+    },
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@view-transition"
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the data is in mdn web docs and bcd, but not in data yet

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/@view-transition
https://drafts.csswg.org/css-view-transitions-2/#at-view-transition-rule

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
