### PR TITLE
feat(css): add legacy `-webkit-user-select` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1686,6 +1686,22 @@
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
+  "-webkit-user-select": {
+    "syntax": "auto | text | none | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/user-select"
+  },
   "accent-color": {
     "syntax": "auto | <color>",
     "media": "interactive",
@@ -10550,7 +10566,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/unicode-bidi"
   },
   "user-select": {
-    "syntax": "auto | text | none | contain | all",
+    "syntax": "auto | text | none | all",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the `-webkit-user-select` property is a vendor-prefixed alias for `user-select` property, note that per bcd, the vendor-prefixed alias is supported in all major browsers, and Safari only support the vendor-prefixed alias, so it is worth to add it back

also, remove the not supported `contain` value from `user-select` property syntax

reported in https://github.com/frenic/csstype/issues/191

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/user-select
https://drafts.csswg.org/css-ui/#propdef-user-select

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
