### PR TITLE
feat(css): add missing pseudo elements

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -944,6 +944,23 @@
     ],
     "status": "standard"
   },
+  "::details-content": {
+    "syntax": "::details-content",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "experimental"
+  },
+  "::file-selector-button": {
+    "syntax": "::file-selector-button",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::file-selector-button"
+  },
   "::first-letter": {
     "syntax": "::first-letter",
     "groups": [
@@ -970,6 +987,15 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::grammar-error"
+  },
+  "::highlight()": {
+    "syntax": "::highlight( <custom-ident> )",
+    "groups": [
+      "Pseudo-elements",
+      "Selectors"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::highlight"
   },
   "::marker": {
     "syntax": "::marker",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

https://drafts.csswg.org/css-pseudo/#selectordef-details-content
https://github.com/mdn/browser-compat-data/blob/main/css/selectors/details-content.json
https://drafts.csswg.org/css-pseudo/#selectordef-file-selector-button
https://github.com/mdn/browser-compat-data/blob/main/css/selectors/file-selector-button.json
https://drafts.csswg.org/css-pseudo/#selectordef-highlight-custom-ident
https://github.com/mdn/browser-compat-data/blob/main/css/selectors/highlight.json

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

part of the https://github.com/mdn/data/issues/241

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
