### PR TITLE
chore(css): remove support for `white-space-collapse: discard`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10665,7 +10665,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space"
   },
   "white-space-collapse": {
-    "syntax": "collapse | discard | preserve | preserve-breaks | preserve-spaces | break-spaces",
+    "syntax": "collapse | preserve | preserve-breaks | preserve-spaces | break-spaces",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the `discard` value of `white-space-collapse` property is not supported by any platform at present

see https://drafts.csswg.org/css-text-4/#propdef-white-space-collapse for spec

see https://github.com/mdn/content/pull/37459 for mdn docs change

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

also see https://github.com/skyclouds2001/mdn-tools/blob/master/docs/not-fully-supported-feature.md

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
