### PR TITLE
chore(css): remove not-supported values for `text-spacing-trim`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10105,7 +10105,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-size-adjust"
   },
   "text-spacing-trim": {
-    "syntax": "space-all | normal | space-first | trim-start | trim-both | trim-all | auto",
+    "syntax": "space-all | normal | space-first | trim-start",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the `trim-both` `trim-all` `auto` values are in spec but not supported by any platform yet

see spec https://drafts.csswg.org/css-text-4/#propdef-text-spacing-trim and mdn docs https://developer.mozilla.org/en-US/docs/Web/CSS/text-spacing-trim

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

see also https://github.com/skyclouds2001/mdn-tools/blob/master/docs/not-fully-supported-feature.md

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
