### PR TITLE
feat(css): Add data for experimental `speak-as` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9440,6 +9440,21 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-rendering"
   },
+  "speak-as": {
+    "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Speech"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "specifiedValue",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
   "stop-color": {
     "syntax": "<'color'>",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -167,6 +167,7 @@
         "sameAsMinWidthAndMinHeight",
         "sameAsWidthAndHeight",
         "specifiedIntegerOrAbsoluteLength",
+        "specifiedValue",
         "specifiedValueClipped0To1",
         "specifiedValueNumberClipped0To1",
         "theComputedLengthAndVisualBox",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1719,6 +1719,9 @@
     "ja": "指定された整数値または絶対的な長さ",
     "ru": "указанное целое число или абсолютная длина"
   },
+  "specifiedValue": {
+    "en-US": "specified value"
+  },
   "specifiedValueClipped0To1": {
     "de": "der angegebene Wert, auf den Bereich <code>[0,1]</code> abgeschnitten",
     "en-US": "the specified value, clipped in the range <code>[0,1]</code>",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

note the `speak-as` property is not the same as the `@counter-style/speak-as` descriptor

test for that property is in https://github.com/mdn/data/issues/218#issuecomment-2571535303

see https://github.com/mdn/browser-compat-data/blob/main/css/properties/speak-as.json for bcd, and only Safari support this feature t present

also refers to https://drafts.csswg.org/css-speech/#propdef-speak-as for spec definition

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
