### PR TITLE
feat(css): Add css `symbols()` function

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -733,6 +733,14 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sqrt"
   },
+  "symbols()": {
+    "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )",
+    "groups": [
+      "CSS Counter Styles"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/symbols"
+  },
   "tan()": {
     "syntax": "tan( <calc-sum> )",
     "groups": [

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -911,6 +911,12 @@
   "symbol": {
     "syntax": "<string> | <image> | <custom-ident>"
   },
+  "symbols()": {
+    "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
+  },
+  "symbols-type": {
+    "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
+  },
   "system-color": {
     "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
   },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

see https://developer.mozilla.org/en-US/docs/Web/CSS/symbols and https://drafts.csswg.org/css-counter-styles/#funcdef-symbols

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
