### PR TITLE
chore(css): Fix group key for `text-overflow`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10045,7 +10045,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Basic User Interface"
+      "CSS Overflow"
     ],
     "initial": "clip",
     "appliesto": "blockContainerElements",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

it should be CSS Overflow, not CSS Basic User Interface

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
