### PR TITLE
chore(css): Remove non-existent 'CSS Flexible Lengths' group

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -21,7 +21,6 @@
       "CSS Device Adaptation",
       "CSS Display",
       "CSS Flexible Box Layout",
-      "CSS Flexible Lengths",
       "CSS Fonts",
       "CSS Fragmentation",
       "CSS Frequencies",

--- a/css/units.json
+++ b/css/units.json
@@ -65,7 +65,6 @@
   "fr": {
     "groups": [
       "CSS Units",
-      "CSS Flexible Lengths",
       "CSS Grid Layout"
     ],
     "status": "standard"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the group does not existed

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
