### PR TITLE
feat(css): Update syntax for `view-timeline`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10553,7 +10553,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/vertical-align"
   },
   "view-timeline": {
-    "syntax": "[ <'view-timeline-name'> <'view-timeline-axis'>? ]#",
+    "syntax": "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
     "media": "visual",
     "inherited": false,
     "animationType": [
@@ -10610,7 +10610,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-inset"
   },
   "view-timeline-name": {
-    "syntax": "none | <dashed-ident>#",
+    "syntax": "[ none | <dashed-ident> ]#",
     "media": "interactive",
     "inherited": false,
     "animationType": "notAnimatable",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Fix syntax for `view-timeline` to add support for `view-timeline-inset` as a value, and fix the syntax for `view-timeline-name` as `none` keyword vaue cna also accept multiple values

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline
https://drafts.csswg.org/scroll-animations/#propdef-view-timeline
https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline-name
https://drafts.csswg.org/scroll-animations/#propdef-view-timeline-name

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/stylelint/stylelint/issues/8100

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
