### PR TITLE
feat(css): Update syntax for `*-conic-gradient()`

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -136,7 +136,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix"
   },
   "conic-gradient()": {
-    "syntax": "conic-gradient( [ [ [ from <angle> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list> )",
+    "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )",
     "groups": [
       "CSS Images"
     ],
@@ -530,7 +530,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rem"
   },
   "repeating-conic-gradient()": {
-    "syntax": "repeating-conic-gradient( [ from <angle> ]? [ at <position> ]?, <angular-color-stop-list> )",
+    "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )",
     "groups": [
       "CSS Images"
     ],

--- a/css/functions.json
+++ b/css/functions.json
@@ -136,7 +136,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix"
   },
   "conic-gradient()": {
-    "syntax": "conic-gradient( [ from <angle> ]? [ at <position> ]?, <angular-color-stop-list> )",
+    "syntax": "conic-gradient( [ [ [ from <angle> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list> )",
     "groups": [
       "CSS Images"
     ],

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -207,7 +207,7 @@
     "syntax": "<compound-selector>#"
   },
   "conic-gradient()": {
-    "syntax": "conic-gradient( [ from <angle> ]? [ at <position> ]?, <angular-color-stop-list> )"
+    "syntax": "conic-gradient( [ [ [ from <angle> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list> )"
   },
   "content-distribution": {
     "syntax": "space-between | space-around | space-evenly | stretch"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -207,7 +207,10 @@
     "syntax": "<compound-selector>#"
   },
   "conic-gradient()": {
-    "syntax": "conic-gradient( [ [ [ from <angle> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list> )"
+    "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
+  },
+  "conic-gradient-syntax": {
+    "syntax": "[ [ [ from [ <angle> | <zero> ] ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list>"
   },
   "content-distribution": {
     "syntax": "space-between | space-around | space-evenly | stretch"
@@ -768,7 +771,7 @@
     "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
   },
   "repeating-conic-gradient()": {
-    "syntax": "repeating-conic-gradient( [ from <angle> ]? [ at <position> ]?, <angular-color-stop-list> )"
+    "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
   },
   "repeating-linear-gradient()": {
     "syntax": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

using `<conic-gradient-syntax>` to both present `conic-gradient()` and `repeat-conic-gradient()`
add `<color-interpolation-method>` to support for the new interpolation color space syntax, which is supported in all major browsers
also add `<zero>` to present `0` generic value

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/conic-gradient
https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/repeat-conic-gradient
https://drafts.csswg.org/css-images-4/#conic-gradients
https://drafts.csswg.org/css-images-4/#repeating-gradients

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/stylelint/stylelint/issues/8347

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
