### PR TITLE
feat(css): Update syntax for `*-linear-gradient()`

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -355,7 +355,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark"
   },
   "linear-gradient()": {
-    "syntax": "linear-gradient( [ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list> )",
+    "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )",
     "groups": [
       "CSS Images"
     ],
@@ -538,7 +538,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-conic-gradient"
   },
   "repeating-linear-gradient()": {
-    "syntax": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
+    "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )",
     "groups": [
       "CSS Images"
     ],

--- a/css/functions.json
+++ b/css/functions.json
@@ -355,7 +355,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark"
   },
   "linear-gradient()": {
-    "syntax": "linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
+    "syntax": "linear-gradient( [ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list> )",
     "groups": [
       "CSS Images"
     ],

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -513,7 +513,7 @@
     "syntax": "<color> <color-stop-length>?"
   },
   "linear-gradient()": {
-    "syntax": "linear-gradient( [ [ <angle> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list> )"
+    "syntax": "linear-gradient( [ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list> )"
   },
   "log()": {
     "syntax": "log( <calc-sum>, <calc-sum>? )"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -513,7 +513,10 @@
     "syntax": "<color> <color-stop-length>?"
   },
   "linear-gradient()": {
-    "syntax": "linear-gradient( [ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list> )"
+    "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
+  },
+  "linear-gradient-syntax": {
+    "syntax": "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
   },
   "log()": {
     "syntax": "log( <calc-sum>, <calc-sum>? )"
@@ -771,7 +774,7 @@
     "syntax": "repeating-conic-gradient( [ from <angle> ]? [ at <position> ]?, <angular-color-stop-list> )"
   },
   "repeating-linear-gradient()": {
-    "syntax": "repeating-linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )"
+    "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
   },
   "repeating-radial-gradient()": {
     "syntax": "repeating-radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

using `<linear-gradient-syntax>` to both present `linear-gradient()` and `repeat-linear-gradient()`
add `<color-interpolation-method>` to support for the new interpolation color space syntax, which is supported in all major browsers
also add `<zero>` to present `0` generic value

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient
https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/repeating-linear-gradient
https://drafts.csswg.org/css-images-4/#linear-gradients
https://drafts.csswg.org/css-images-4/#repeating-gradients

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/stylelint/stylelint/issues/8347

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
