### PR TITLE
feat(css): Update syntax for gradient related  features

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -33,13 +33,13 @@
     "syntax": "<angle> | <percentage>"
   },
   "angular-color-hint": {
-    "syntax": "<angle-percentage>"
+    "syntax": "<angle-percentage> | <zero>"
   },
   "angular-color-stop": {
-    "syntax": "<color> && <color-stop-angle>?"
+    "syntax": "<color> <color-stop-angle>?"
   },
   "angular-color-stop-list": {
-    "syntax": "[ <angular-color-stop> [, <angular-color-hint>]? ]# , <angular-color-stop>"
+    "syntax": "<angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#?"
   },
   "animateable-feature": {
     "syntax": "scroll-position | contents | <custom-ident>"
@@ -168,13 +168,13 @@
     "syntax": "<color-stop-length> | <color-stop-angle>"
   },
   "color-stop-angle": {
-    "syntax": "<angle-percentage>{1,2}"
+    "syntax": "[ <angle-percentage> | <zero> ]{1,2}"
   },
   "color-stop-length": {
     "syntax": "<length-percentage>{1,2}"
   },
   "color-stop-list": {
-    "syntax": "[ <linear-color-stop> [, <linear-color-hint>]? ]# , <linear-color-stop>"
+    "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
   },
   "colorspace-params": {
     "syntax": "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

for `<angular-color-hint>` and `<color-stop-angle>`, add support for the new `<zero>` type support
for `<color-stop-list>` and `<angular-color-stop-list>`, this is a synxta simplify and equally change
fix syntax of `<angular-color-stop>`, as `&&` allow two values appears in any order, but the two values must appear in the exact order

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-images-4/#typedef-color-stop-list
https://drafts.csswg.org/css-images-4/#typedef-angular-color-stop-list

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/stylelint/stylelint/issues/8347

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
