### PR TITLE
feat(css): Update syntax for `<easing-function>`

### DIFF
--- a/css/definitions.json
+++ b/css/definitions.json
@@ -19,6 +19,7 @@
       "CSS Counter Styles",
       "CSS Custom Properties for Cascading Variables",
       "CSS Display",
+      "CSS Easing Functions",
       "CSS Environment Variables",
       "CSS Flexible Box Layout",
       "CSS Fonts",

--- a/css/functions.json
+++ b/css/functions.json
@@ -184,6 +184,14 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade"
   },
+  "cubic-bezier()": {
+    "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )",
+    "groups": [
+      "CSS Easing Functions"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function/cubic-bezier"
+  },
   "drop-shadow()": {
     "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )",
     "groups": [
@@ -353,6 +361,14 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark"
+  },
+  "linear()": {
+    "syntax": "linear( [ <number> && <percentage>{0,2} ]# )",
+    "groups": [
+      "CSS Easing Functions"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function/linear"
   },
   "linear-gradient()": {
     "syntax": "linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )",
@@ -732,6 +748,14 @@
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sqrt"
+  },
+  "steps()": {
+    "syntax": "steps( <integer>, <step-position>? )",
+    "groups": [
+      "CSS Easing Functions"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function/steps"
   },
   "symbols()": {
     "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -300,7 +300,7 @@
     "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
   },
   "easing-function": {
-    "syntax": "<linear-easing-function> | <cubic-bezier-timing-function> | <step-easing-function>"
+    "syntax": "<linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
   },
   "east-asian-variant-values": {
     "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -254,8 +254,11 @@
   "cross-fade()": {
     "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
   },
+  "cubic-bezier()": {
+    "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
+  },
   "cubic-bezier-timing-function": {
-    "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
+    "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
   },
   "custom-color-space": {
     "syntax": "<dashed-ident>"
@@ -297,7 +300,7 @@
     "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
   },
   "easing-function": {
-    "syntax": "linear | <cubic-bezier-timing-function> | <step-timing-function>"
+    "syntax": "<linear-easing-function> | <cubic-bezier-timing-function> | <step-easing-function>"
   },
   "east-asian-variant-values": {
     "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
@@ -506,11 +509,17 @@
   "line-width": {
     "syntax": "<length> | thin | medium | thick"
   },
+  "linear()": {
+    "syntax": "linear( [ <number> && <percentage>{0,2} ]# )"
+  },
   "linear-color-hint": {
     "syntax": "<length-percentage>"
   },
   "linear-color-stop": {
     "syntax": "<color> <color-stop-length>?"
+  },
+  "linear-easing-function": {
+    "syntax": "linear | <linear()>"
   },
   "linear-gradient()": {
     "syntax": "linear-gradient( [ [ <angle> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list> )"
@@ -917,8 +926,11 @@
   "step-position": {
     "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
   },
-  "step-timing-function": {
-    "syntax": "step-start | step-end | steps(<integer>[, <step-position>]?)"
+  "step-easing-function": {
+    "syntax": "step-start | step-end | <steps()>"
+  },
+  "steps()": {
+    "syntax": "steps( <integer>, <step-position>? )"
   },
   "subclass-selector": {
     "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"

--- a/css/types.json
+++ b/css/types.json
@@ -105,8 +105,7 @@
   },
   "easing-function": {
     "groups": [
-      "CSS Transitions",
-      "CSS Types"
+      "CSS Easing Functions"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

add *CSS Easing Functions* group and assgin `<easing-function>` to that group
extract `cubic-bezier()` function from `<cubic-bezier-timing-function>`, and update syntax of `cubic-bezier()` to match the spec, which is a simplify
renaming `<step-timing-function>` to be align with the spec, and extract `steps()` from `<step-timing-function>`
update syntax of `<easing-function>` to better represent `linear()` function, which also extract `<linear-easing-function>`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function
https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/cubic-bezier
https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/linear
https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/steps

https://drafts.csswg.org/css-easing-2/#typedef-easing-function
https://drafts.csswg.org/css-easing-2/#typedef-linear-easing-function
https://drafts.csswg.org/css-easing-2/#typedef-cubic-bezier-easing-function
https://drafts.csswg.org/css-easing-2/#typedef-step-easing-function

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/stylelint/stylelint/issues/8379

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
