### PR TITLE
feat(css): Update syntax for `<generic-family>`

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -380,14 +380,17 @@
   "frequency-percentage": {
     "syntax": "<frequency> | <percentage>"
   },
+  "generic-complete": {
+    "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
+  },
   "general-enclosed": {
     "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
   },
   "generic-family": {
-    "syntax": "serif | sans-serif | cursive | fantasy | monospace"
+    "syntax": "<generic-complete> | <generic-incomplete> | emoji | fangsong"
   },
-  "generic-name": {
-    "syntax": "serif | sans-serif | cursive | fantasy | monospace"
+  "generic-incomplete": {
+    "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
   },
   "geometry-box": {
     "syntax": "<shape-box> | fill-box | stroke-box | view-box"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the `<generic-family>` is used by `font-family`, update it to match the latest spec and browser implement:

split `<generic-family>` into `<generic-complete>` and `<generic-incomplete>`, add support for non-standatd `emoji` and `fangsong` value

also remove the `<generic-name>` type which is never used

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

https://drafts.csswg.org/css-fonts/#propdef-font-family

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
