### PR TITLE
feat(css): Add data for `stroke-color`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9565,6 +9565,21 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke"
   },
+  "stroke-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "transparent",
+    "appliesto": "textAndSVGShapes",
+    "computed": "computedColor",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
   "stroke-dasharray": {
     "syntax": "none | <dasharray>",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -292,6 +292,7 @@
         "tableCellElements",
         "tableElements",
         "textAndBlockContainers",
+        "textAndSVGShapes",
         "textElements",
         "textFields",
         "transformableElements",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1786,6 +1786,9 @@
     "en-US": "text and block containers",
     "zh-CN": "文本和区块容器"
   },
+  "textAndSVGShapes": {
+    "en-US": "text and SVG shapes"
+  },
   "textElements": {
     "de": "Textelemente",
     "en-US": "text elements",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

currently only safari support this, since v11.1

also notice that though spec defines `<color>#`, but syntax like `red, red` is not supported at present via manually test, so `<color>` is used at present

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.fxtf.org/fill-stroke-3/#stroke-color

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
