### PR TITLE
feat(css): Add data for `ruby-overhang`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8682,10 +8682,25 @@
       "CSS Ruby"
     ],
     "initial": "separate",
-    "appliesto": "rubyAnnotationsContainers",
+    "appliesto": "rubyAnnotationContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "experimental"
+  },
+  "ruby-overhang": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Ruby"
+    ],
+    "initial": "auto",
+    "appliesto": "rubyAnnotationContainers",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
   },
   "ruby-position": {
     "syntax": "[ alternate || [ over | under ] ] | inter-character",
@@ -8697,7 +8712,7 @@
       "CSS Ruby"
     ],
     "initial": "alternate",
-    "appliesto": "rubyAnnotationsContainers",
+    "appliesto": "rubyAnnotationContainers",
     "computed": "asSpecified",
     "order": "uniqueOrder",
     "status": "standard",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -282,7 +282,7 @@
         "positionedElements",
         "positionedElementsWithADefaultAnchorElement",
         "replacedElements",
-        "rubyAnnotationsContainers",
+        "rubyAnnotationContainers",
         "rubyBasesAnnotationsBaseAnnotationContainers",
         "sameAsMargin",
         "sameAsWidthAndHeight",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1631,9 +1631,9 @@
     "ru": "заменяемые элементы",
     "zh-CN": "替换元素"
   },
-  "rubyAnnotationsContainers": {
+  "rubyAnnotationContainers": {
     "de": "Ruby-Anmerkungscontainer",
-    "en-US": "ruby annotations containers",
+    "en-US": "ruby annotation containers",
     "fr": "annotations ruby des conteneurs",
     "ja": "ルビ注釈コンテナー",
     "ru": "контейнеры ruby-аннотаций"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

per bcd, it is supported in safari since v18.2

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-ruby/#propdef-ruby-overhang

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
