### PR TITLE
feat(css): Add data for `object-view-box`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7451,6 +7451,21 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-position"
   },
+  "object-view-box": {
+    "syntax": "none | <basic-shape-rect>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "asIfPossibleOtherwiseDiscrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "none",
+    "appliesto": "replacedElements",
+    "computed": "specifiedKeywordOrComputedFunction",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
   "offset": {
     "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -16,6 +16,7 @@
       "enum": [
         "angleBasicShapeOrPath",
         "angleOrBasicShapeOrPath",
+        "asIfPossibleOtherwiseDiscrete",
         "basicShapeOtherwiseNo",
         "byComputedValue",
         "byComputedValueType",
@@ -169,6 +170,7 @@
         "sameAsMinWidthAndMinHeight",
         "sameAsWidthAndHeight",
         "specifiedIntegerOrAbsoluteLength",
+        "specifiedKeywordOrComputedFunction",
         "specifiedValue",
         "specifiedValueClipped0To1",
         "specifiedValueNumberClipped0To1",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -83,6 +83,9 @@
   "basic-shape": {
     "syntax": "<inset()> | <circle()> | <ellipse()> | <polygon()> | <path()>"
   },
+  "basic-shape-rect": {
+    "syntax": "<inset()> | <rect()> | <xywh()>"
+  },
   "bg-clip": {
     "syntax": "<visual-box> | border-area | text"
   },

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -392,6 +392,9 @@
     "ja": "{{cssxref(\"basic-shape\")}} で定義された通り (与えられている場合は {{cssxref(\"shape-box\")}} が続く)、 URI を絶対化した {{cssxref(\"image\")}}、それ以外は指定通り。",
     "ru": "как определено для {{cssxref(\"basic-shape\")}} (c {{cssxref(\"shape-box\")}} последующим, если передается),  {{cssxref(\"image\")}} с его абсолютным URI, если другое не указано"
   },
+  "asIfPossibleOtherwiseDiscrete": {
+    "en-US": "as if possible, otherwise discrete"
+  },
   "asLength": {
     "de": "als {{cssxref(\"length\")}}",
     "en-US": "as {{cssxref(\"length\")}}",
@@ -1727,6 +1730,9 @@
     "fr": "l'entier spécifié ou une longueur absolue",
     "ja": "指定された整数値または絶対的な長さ",
     "ru": "указанное целое число или абсолютная длина"
+  },
+  "specifiedKeywordOrComputedFunction": {
+    "en-US": "specified keyword, or computed function"
   },
   "specifiedValue": {
     "en-US": "specified value"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

this is supported since chrome v102

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-images-5/#propdef-object-view-box

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
