### PR TITLE
fix(css): Rename `<cubic-bezier-timing-function>` to `<cubic-bezier-easing-function>`

### DIFF
--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -272,7 +272,7 @@
   "cubic-bezier()": {
     "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
   },
-  "cubic-bezier-timing-function": {
+  "cubic-bezier-easing-function": {
     "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
   },
   "custom-color-space": {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

also notice `<cubic-bezier-timing-function>` is not used anywhere, while `<cubic-bezier-easing-function>` is used by `<easing-function>`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-easing-1/#typedef-cubic-bezier-easing-function

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #968 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
