### PR TITLE
feat(css): Add data for `font-width`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -5538,6 +5538,26 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-weight"
   },
+  "font-width": {
+    "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "percentage",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "experimental"
+  },
   "forced-color-adjust": {
     "syntax": "auto | none | preserve-parent-color",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -161,6 +161,7 @@
         "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
         "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
         "optimumValueOfAbsoluteLengthOrNormal",
+        "percentage",
         "percentageAsSpecifiedAbsoluteLengthOrNone",
         "percentageAsSpecifiedOrAbsoluteLength",
         "percentageAutoOrAbsoluteLength",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1295,6 +1295,9 @@
     "ja": "形式文法における値の出現順",
     "ru": "порядок появления в формальной грамматике значений"
   },
+  "percentage": {
+    "en-US": "percentage"
+  },
   "percentageAsSpecifiedAbsoluteLengthOrNone": {
     "de": "der Prozentwert wie angegeben oder die absolute Länge oder <code>none</code>",
     "en-US": "the percentage as specified or the absolute length or <code>none</code>",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

it is getting supported in safari at present

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://drafts.csswg.org/css-fonts/#propdef-font-width

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
