### PR TITLE
fix: Replace Markdown formatting with HTML

### DIFF
--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1495,7 +1495,7 @@
     "ru": "относятся к размеру маски области рисования минус размер маски слоя изображения (смотрите статью о {{cssxref(\"background-position\")}})"
   },
   "referToSVGViewportDiagonal": {
-    "en-US": "refer to the normalized diagonal measure of the current SVG viewport's applied {{SVGAttr(\"viewBox\")}}, or of the viewport itself if no `viewBox` is specified"
+    "en-US": "refer to the normalized diagonal measure of the current SVG viewport's applied {{SVGAttr(\"viewBox\")}}, or of the viewport itself if no <code>viewBox</code> is specified"
   },
   "referToSVGViewportHeight": {
     "en-US": "refer to the height of the current SVG viewport"


### PR DESCRIPTION
This is showing up as raw markdown, so we should use plain HTML instead