### PR TITLE
feat(css): Update syntax for `content` property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4492,7 +4492,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-type"
   },
   "content": {
-    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> ]+ ]?",
+    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
     "media": "all",
     "inherited": false,
     "animationType": "discrete",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -228,7 +228,7 @@
     "syntax": "space-between | space-around | space-evenly | stretch"
   },
   "content-list": {
-    "syntax": "[ <string> | contents | <image> | <counter> | <quote> | <target> | <leader()> ]+"
+    "syntax": "[ <string> | <image | <attr()> | <quote> | <counter> ]+ "
   },
   "content-position": {
     "syntax": "center | start | end | flex-start | flex-end"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

update `content` property: add `attr()`
update `<content-list>` syntax: add `attr()`; remove `contents` `leader()` and `<target>` which are not supported and non-standard at all

note that spec defines as `[ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+`, but many are not-supported so not added at present

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/content
https://drafts.csswg.org/css-content/#propdef-content
https://drafts.csswg.org/css-content/#typedef-content-content-list

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
