### PR TITLE
feat(css): Add `anchor-center` keyword value support for `{align,justify}-{items,self}`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1672,7 +1672,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content"
   },
   "align-items": {
-    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
+    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -1689,7 +1689,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items"
   },
   "align-self": {
-    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position>",
+    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -6347,7 +6347,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content"
   },
   "justify-items": {
-    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ]",
+    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -6363,7 +6363,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items"
   },
   "justify-self": {
-    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ]",
+    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the syntax update add support for the `anchor-center` keyword value

these features are support since chrome v125

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
https://developer.mozilla.org/en-US/docs/Web/CSS/align-self
https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items
https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self
https://drafts.csswg.org/css-anchor-position/#valdef-justify-self-anchor-center

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
