### PR TITLE
feat(css): Update syntax for `bottom` `top` `left` `right`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3705,12 +3705,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-width"
   },
   "bottom": {
-    "syntax": "<length> | <percentage> | auto",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
     "percentages": "referToContainingBlockHeight",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Positioned Layout"
     ],
     "initial": "auto",
@@ -6394,12 +6395,13 @@
     "status": "nonstandard"
   },
   "left": {
-    "syntax": "<length> | <percentage> | auto",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
     "percentages": "referToWidthOfContainingBlock",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Positioned Layout"
     ],
     "initial": "auto",
@@ -8623,12 +8625,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/resize"
   },
   "right": {
-    "syntax": "<length> | <percentage> | auto",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
     "percentages": "referToWidthOfContainingBlock",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Positioned Layout"
     ],
     "initial": "auto",
@@ -10329,12 +10332,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-scope"
   },
   "top": {
-    "syntax": "<length> | <percentage> | auto",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
     "percentages": "referToContainingBlockHeight",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Positioned Layout"
     ],
     "initial": "auto",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

add support for `anchor()` and `anchor-size()`, which are supported since chrome v125 and chrome v132

also combine `<length>` and `<percentage>` into `<length-percentage>`

also add these properties to CSS Anchor Positioning group since this module also defines some of these features

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/bottom
https://developer.mozilla.org/en-US/docs/Web/CSS/top
https://developer.mozilla.org/en-US/docs/Web/CSS/left
https://developer.mozilla.org/en-US/docs/Web/CSS/right
https://drafts.csswg.org/css-anchor-position/#funcdef-anchor

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
