### PR TITLE
feat(css): Update syntax for `margin-*`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6674,12 +6674,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-start"
   },
   "margin-bottom": {
-    "syntax": "<length-percentage> | auto",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "length",
     "percentages": "referToWidthOfContainingBlock",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Box Model"
     ],
     "initial": "0",
@@ -6747,12 +6748,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-start"
   },
   "margin-left": {
-    "syntax": "<length-percentage> | auto",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "length",
     "percentages": "referToWidthOfContainingBlock",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Box Model"
     ],
     "initial": "0",
@@ -6766,12 +6768,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-left"
   },
   "margin-right": {
-    "syntax": "<length-percentage> | auto",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "length",
     "percentages": "referToWidthOfContainingBlock",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Box Model"
     ],
     "initial": "0",
@@ -6785,12 +6788,13 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-right"
   },
   "margin-top": {
-    "syntax": "<length-percentage> | auto",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
     "media": "visual",
     "inherited": false,
     "animationType": "length",
     "percentages": "referToWidthOfContainingBlock",
     "groups": [
+      "CSS Anchor Positioning",
       "CSS Box Model"
     ],
     "initial": "0",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the update add support for `anchor-size()` value, which are supported since chrome v132

also add these features to CSS Anchor Positioning group

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom
https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left
https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right
https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top
https://drafts.csswg.org/css-anchor-position/#funcdef-anchor-size

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
