### PR TITLE
feat(css): Update syntax for `animation-duration`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1868,7 +1868,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-direction"
   },
   "animation-duration": {
-    "syntax": "<time>#",
+    "syntax": "[ auto | <time [0s,∞]> ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "notAnimatable",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the update add support for the `auto` keyword, which is supported since chrome v115 and Safari v18.4

it also update the `<time>` type for specifying ranged value

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/animation-duration
https://drafts.csswg.org/css-animations-2/#propdef-animation-duration

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
