### PR TITLE
feat(css): Update the syntax for `background-*`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2101,7 +2101,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backface-visibility"
   },
   "background": {
-    "syntax": "[ <bg-layer> , ]* <final-bg-layer>",
+    "syntax": "<bg-layer>#? , <final-bg-layer>",
     "media": "visual",
     "inherited": false,
     "animationType": [

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -90,7 +90,7 @@
     "syntax": "<visual-box> | border-area | text"
   },
   "bg-image": {
-    "syntax": "none | <image>"
+    "syntax": "<image> | none"
   },
   "bg-layer": {
     "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
@@ -99,7 +99,7 @@
     "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
   },
   "bg-size": {
-    "syntax": "[ <length-percentage> | auto ]{1,2} | cover | contain"
+    "syntax": "[ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain"
   },
   "blend-mode": {
     "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
@@ -369,7 +369,7 @@
     "syntax": "[ <filter-function> | <url> ]+"
   },
   "final-bg-layer": {
-    "syntax": "<'background-color'> || <bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
+    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
   },
   "fit-content()": {
     "syntax": "fit-content( <length-percentage [0,∞]> )"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

for `background`, simply the syntax to match the spec
for `<final-bg-layer>` & `<bg-image>`, adjust order to match the spec
for `<bg-size>`, update range value support, to be consistent with the spec

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/background
https://drafts.csswg.org/css-backgrounds/#propdef-background
https://drafts.csswg.org/css-backgrounds/#typedef-bg-layer
https://drafts.csswg.org/css-backgrounds/#typedef-final-bg-layer
https://drafts.csswg.org/css-backgrounds/#typedef-bg-image

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
