### PR TITLE
feat(css): Update syntax of `mix-blend-mode`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -7425,7 +7425,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-width"
   },
   "mix-blend-mode": {
-    "syntax": "<blend-mode> | plus-lighter",
+    "syntax": "<blend-mode> | plus-darker | plus-lighter",
     "media": "visual",
     "inherited": false,
     "animationType": "notAnimatable",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

for `mix-blend-mode`, update syntax to support the `plus-darker` keyword value, which is supported since Safari 9

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode
https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode
https://drafts.fxtf.org/compositing/#propdef-mix-blend-mode
https://drafts.fxtf.org/compositing/#ltblendmodegt

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
