### PR TITLE
feat(css): Update syntax for `border-*-radius`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2725,7 +2725,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-color"
   },
   "border-bottom-left-radius": {
-    "syntax": "<length-percentage>{1,2}",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -2744,7 +2744,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius"
   },
   "border-bottom-right-radius": {
-    "syntax": "<length-percentage>{1,2}",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -2801,7 +2801,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-width"
   },
   "border-collapse": {
-    "syntax": "collapse | separate",
+    "syntax": "separate | collapse",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",
@@ -3340,7 +3340,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-width"
   },
   "border-radius": {
-    "syntax": "<length-percentage>{1,4} [ / <length-percentage>{1,4} ]?",
+    "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
     "media": "visual",
     "inherited": false,
     "animationType": [
@@ -3595,7 +3595,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-color"
   },
   "border-top-left-radius": {
-    "syntax": "<length-percentage>{1,2}",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",
@@ -3614,7 +3614,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius"
   },
   "border-top-right-radius": {
-    "syntax": "<length-percentage>{1,2}",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
     "media": "visual",
     "inherited": false,
     "animationType": "lpc",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

the change add range limit to `<length-percentage>` type

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius
https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius
https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius
https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius
https://drafts.csswg.org/css-backgrounds/#border-radius
https://drafts.csswg.org/css-tables/#border-collapse-property

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
