### PR TITLE
feat(css): Update syntax for `border-image-*`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2929,7 +2929,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image"
   },
   "border-image-outset": {
-    "syntax": "[ <length> | <number> ]{1,4}",
+    "syntax": "[ <length [0,∞]> | <number [0,∞]> ]{1,4}  ",
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValueType",
@@ -2967,7 +2967,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-repeat"
   },
   "border-image-slice": {
-    "syntax": "<number-percentage>{1,4} && fill?",
+    "syntax": "[ <number [0,∞]> | <percentage [0,∞]> ]{1,4}  && fill?",
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValueType",
@@ -3005,7 +3005,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-source"
   },
   "border-image-width": {
-    "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
+    "syntax": "[ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}",
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValueType",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

these syntax changes add more support for value range limit

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-outset
https://drafts.csswg.org/css-backgrounds/#propdef-border-image-outset

https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-slice
https://drafts.csswg.org/css-backgrounds/#propdef-border-image-slice

https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-width
https://drafts.csswg.org/css-backgrounds/#propdef-border-image-width

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
