### PR TITLE
feat(css): Add `view-transition-name: match-element`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10759,7 +10759,7 @@
     "status": "standard"
   },
   "view-transition-name": {
-    "syntax": "none | <custom-ident>",
+    "syntax": "none | <custom-ident> | match-element",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

add `view-transition-name: match-element`, which is supported in chrome v137

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

https://github.com/mdn/browser-compat-data/pull/26964
https://github.com/mdn/content/pull/39759
https://chromestatus.com/feature/5098745710247936
https://drafts.csswg.org/css-view-transitions-2/#auto-vt-name

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
