### PR TITLE
feat(css): Add appliesto definition for display:contents

### DIFF
--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -202,6 +202,7 @@
         "allElementsExceptTableRowColumnGroupsTableRowsColumns",
         "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
         "allElementsNoEffectIfDisplayNone",
+        "allElementsNoEffectIfDisplayNoneOrContents",
         "allElementsSomeValuesNoEffectOnNonInlineElements",
         "allElementsSVGContainerElements",
         "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

This pull request adds a new key, "allElementsNoEffectIfDisplayNoneOrContents", to the properties.schema.json to more accurately describe the applicability of certain CSS properties.

The existing key "allElementsNoEffectIfDisplayNone" is insufficient for properties like float, which also have no effect on elements with display: contents.

This change allows for more precise documentation by providing a key that covers both none and contents.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

This is achieved in three steps:

1. Updating the schema to allow a new key.
2. Adding the new key and its corresponding text definition.
3. Updating the float property in properties.json to use this new, more accurate key.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
