### PR TITLE
added text-autospace property to the css properties file

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -9816,6 +9816,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-anchor"
   },
+  "text-autospace": {
+    "syntax": "normal | <autospace> | auto ",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-autospace"
+  },
   "text-box": {
     "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
     "media": "visual",

--- a/css/properties.json
+++ b/css/properties.json
@@ -9817,7 +9817,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-anchor"
   },
   "text-autospace": {
-    "syntax": "normal | <autospace> | auto ",
+    "syntax": "normal | <autospace> | auto",
     "media": "visual",
     "inherited": true,
     "animationType": "discrete",


### PR DESCRIPTION
### Description

- Added the CSS `text-autospace` property to the properties.json file

### Motivation

- Working on [MDN issue #40776](https://github.com/mdn/content/issues/40776)
- Need to add the `text-autospace` page

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/40912)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/27672)
- [Firefox Release Note PR](https://github.com/mdn/content/pull/40966)