### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Setup
         if: ${{ github.event.inputs.force-npm-publish || steps.release.outputs.release_created }}
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Checkout
         if: ${{ github.event.inputs.force-npm-publish || steps.release.outputs.release_created }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
