### PR TITLE
feat(css): Update `attr()` syntax to CSS Values Level 5

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -56,7 +56,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/atan2"
   },
   "attr()": {
-    "syntax": "attr( <attr-name> <type-or-unit>? [, <attr-fallback> ]? )",
+    "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )",
     "groups": [
       "CSS Values and Units"
     ],

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -57,13 +57,16 @@
     "syntax": "scroll | fixed | local"
   },
   "attr()": {
-    "syntax": "attr( <attr-name> <type-or-unit>? [, <attr-fallback> ]? )"
+    "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
   },
   "attr-matcher": {
     "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
   },
   "attr-modifier": {
     "syntax": "i | s"
+  },
+  "attr-type": {
+    "syntax": "type( <syntax> ) | raw-string | number | <attr-unit>"
   },
   "attribute-selector": {
     "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Update `attr()` function syntax to match CSS Values and Units Level 5 spec

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->
The `attr()` syntax has been updated.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

https://drafts.csswg.org/css-values-5/#attr-notation


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
