### PR TITLE
Add property data for scroll triggered animations

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -2034,7 +2034,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-trigger"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-trigger"
   },
   "appearance": {
     "syntax": "none | auto | <compat-auto> | <compat-special>",
@@ -11086,7 +11086,7 @@
     ],
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger"
   },
   "timeline-trigger-name": {
     "syntax": "none | <dashed-ident>#",
@@ -11102,7 +11102,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-name"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-name"
   },
   "timeline-trigger-exit-range": {
     "syntax": "[ <'timeline-trigger-exit-range-start'> <'timeline-trigger-exit-range-end'>? ]#",
@@ -11127,7 +11127,7 @@
     ],
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-exit-range"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range"
   },
   "timeline-trigger-exit-range-end": {
     "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
@@ -11143,7 +11143,7 @@
     "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-exit-range-end"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range-end"
   },
   "timeline-trigger-exit-range-start": {
     "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
@@ -11159,7 +11159,7 @@
     "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-exit-range-start"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range-start"
   },
   "timeline-trigger-range": {
     "syntax": "[ <'timeline-trigger-range-start'> <'timeline-trigger-range-end'>? ]#",
@@ -11184,7 +11184,7 @@
     ],
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-range"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-range"
   },
   "timeline-trigger-range-end": {
     "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
@@ -11200,7 +11200,7 @@
     "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-range-end"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-range-end"
   },
   "timeline-trigger-range-start": {
     "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
@@ -11216,7 +11216,7 @@
     "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-range-start"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-range-start"
   },
   "timeline-trigger-source": {
     "syntax": "<single-animation-timeline>#",
@@ -11232,7 +11232,7 @@
     "computed": "listOfNoneAutoIdentScrollOrView",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-source"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-source"
   },
   "top": {
     "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
@@ -11472,7 +11472,7 @@
     "computed": "asSpecified",
     "order": "perGrammar",
     "status": "standard",
-    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/trigger-scope"
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/trigger-scope"
   },
   "unicode-bidi": {
     "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",

--- a/css/properties.json
+++ b/css/properties.json
@@ -11130,7 +11130,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range"
   },
   "timeline-trigger-exit-range-end": {
-    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "notAnimatable",
@@ -11146,7 +11146,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range-end"
   },
   "timeline-trigger-exit-range-start": {
-    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
     "media": "visual",
     "inherited": false,
     "animationType": "notAnimatable",

--- a/css/properties.json
+++ b/css/properties.json
@@ -2020,6 +2020,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timing-function"
   },
+  "animation-trigger": {
+    "syntax": "[ none | [ <dashed-ident> <animation-action>+ ]+ ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-trigger"
+  },
   "appearance": {
     "syntax": "none | auto | <compat-auto> | <compat-special>",
     "media": "all",
@@ -11041,6 +11057,183 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-scope"
   },
+  "timeline-trigger": {
+    "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-range'> [ '/' <'timeline-trigger-exit-range'> ]? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-range",
+      "timeline-trigger-exit-range"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-range",
+      "timeline-trigger-exit-range"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-range",
+      "timeline-trigger-exit-range"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger"
+  },
+  "timeline-trigger-name": {
+    "syntax": "none | <dashed-ident>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-name"
+  },
+  "timeline-trigger-exit-range": {
+    "syntax": "[ <'timeline-trigger-exit-range-start'> <'timeline-trigger-exit-range-end'>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": [
+      "timeline-trigger-exit-range-start",
+      "timeline-trigger-exit-range-end"
+    ],
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "timeline-trigger-exit-range-start",
+      "timeline-trigger-exit-range-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "timeline-trigger-exit-range-start",
+      "timeline-trigger-exit-range-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-exit-range"
+  },
+  "timeline-trigger-exit-range-end": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-exit-range-end"
+  },
+  "timeline-trigger-exit-range-start": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-exit-range-start"
+  },
+  "timeline-trigger-range": {
+    "syntax": "[ <'timeline-trigger-range-start'> <'timeline-trigger-range-end'>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": [
+      "timeline-trigger-range-start",
+      "timeline-trigger-range-end"
+    ],
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "timeline-trigger-range-start",
+      "timeline-trigger-range-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "timeline-trigger-range-start",
+      "timeline-trigger-range-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-range"
+  },
+  "timeline-trigger-range-end": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-range-end"
+  },
+  "timeline-trigger-range-start": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-range-start"
+  },
+  "timeline-trigger-source": {
+    "syntax": "<single-animation-timeline>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "listOfNoneAutoIdentScrollOrView",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-trigger-source"
+  },
   "top": {
     "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
     "media": "visual",
@@ -11264,6 +11457,22 @@
     "stacking": true,
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/translate"
+  },
+  "trigger-scope": {
+    "syntax": "none | all | <dashed-ident>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/trigger-scope"
   },
   "unicode-bidi": {
     "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -159,6 +159,7 @@
         "listEachItemHasTwoKeywordsOnePerDimension",
         "listEachItemIdentifierOrNoneAuto",
         "listEachItemTwoKeywordsOriginOffsets",
+        "listOfNoneAutoIdentScrollOrView",
         "noneOrImageWithAbsoluteURI",
         "noneOrOrderedListOfIdentifiers",
         "normalizedAngle",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -44,6 +44,9 @@
   "animateable-feature": {
     "syntax": "scroll-position | contents | <custom-ident>"
   },
+  "animation-action": {
+    "syntax": "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
+  },
   "asin()": {
     "syntax": "asin( <calc-sum> )"
   },

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1219,6 +1219,9 @@
     "zh-CN": "列表项",
     "zh-TW": "清單項目"
   },
+  "listOfNoneAutoIdentScrollOrView": {
+    "en-US": "A list, with each item being either the keyword <code>none</code>, the keyword <code>auto</code>, a case-sensitive {{cssxref(\"&lt;ident>\")}}, a computed {{cssxref(\"animation-timeline/scroll\")}} function, or a computed {{cssxref(\"animation-timeline/view\")}} function."
+  },
   "listSeparator": {
     "de": ", ",
     "en-US": ", ",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1220,7 +1220,8 @@
     "zh-TW": "清單項目"
   },
   "listOfNoneAutoIdentScrollOrView": {
-    "en-US": "A list, with each item being either the keyword <code>none</code>, the keyword <code>auto</code>, a case-sensitive {{cssxref(\"&lt;ident>\")}}, a computed {{cssxref(\"animation-timeline/scroll\")}} function, or a computed {{cssxref(\"animation-timeline/view\")}} function."
+    "en-US": "A list, with each item being either the keyword <code>none</code>, the keyword <code>auto</code>, a case-sensitive {{cssxref(\"&lt;ident>\")}}, a computed {{cssxref(\"animation-timeline/scroll\")}} function, or a computed {{cssxref(\"animation-timeline/view\")}} function.",
+    "fr": "Une liste dont chaque élément est soit le mot-clé <code>none</code>, le mot-clé <code>auto</code>, un identifiant ({{CSSxRef(\"&lt;ident>\")}}), sensible à la casse, une fonction calculée {{CSSxRef(\"animation-timeline/scroll\")}} ou une fonction calculée {{CSSxRef(\"animation-timeline/view\")}}."
   },
   "listSeparator": {
     "de": ", ",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Chrome 146 adds support for scroll-driven animations; see https://chromestatus.com/feature/5181996801982464.

This PR adds property and type data for the new functionality.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
