### PR TITLE
ci(auto-merge): sync workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    if: github.repository_owner == 'mdn'
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

Syncs the `auto-merge.yml` workflow to ensure it uses the reusable workflow from `mdn/workflows` with the correct configuration:

- Sets `permissions: { contents: read }`
- Uses `mdn/workflows/.github/workflows/auto-merge.yml@main`
- Sets `auto-merge: true` only if the repository's existing workflow already auto-merges

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1395.
