### PR TITLE
feat(css): add schema validation and supplementary documentation for custom properties

### DIFF
--- a/css/properties.md
+++ b/css/properties.md
@@ -117,3 +117,7 @@ There are 3 more properties that are optional:
 * `mdn_url` (string): a URL linking to the property's page on MDN. This URL must omit the localization part of the URL (such as `en-US/`).
 * `stacking` (boolean): Whether or not the property creates a stacking context. See [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) for details.
 * `alsoAppliesTo` (enum): To which elements the property also applies to. See the schema for [a list of enums](https://github.com/mdn/data/blob/main/css/properties.schema.json#L253).
+
+### Custom Properties
+
+Custom properties are a special case, since they have variable keys. These keys must be prefixed by two dashes, (e.g. `--brand-color`), and are validated by a regular expression in the [`patternProperties` section of the schema](https://github.com/mdn/data/blob/main/css/properties.schema.json#L472).

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -468,5 +468,10 @@
         "$ref": "#/definitions/mdn_url"
       }
     }
+  },
+  "patternProperties": {
+    "^--": {
+      "$ref": "#/definitions/additionalProperties"
+    }
   }
 }


### PR DESCRIPTION
### Description

Adds `patternProperties` validation to the CSS properties schema to explicitly validate custom property names (CSS variables). Custom properties matching the pattern `^--` are now recognized as valid property keys in the schema.

### Motivation

The schema currently validates properties through `additionalProperties`, which treats every key individually without recognizing patterns. While `properties.json` contains a `"--*"` entry to document custom properties, the schema doesn't express that **any** key starting with `--` is valid (e.g., `--brand-color`, `--spacing-md`).

This creates several problems:

1. **Semantic mismatch**: The `"--*"` entry represents a pattern, but the schema has no pattern validation
2. **Downstream confusion**: Libraries like `csstype` must hardcode special-case handling for custom properties because the schema doesn't express the pattern (see [frenic/csstype#189](https://github.com/frenic/csstype/issues/189))
3. **Incomplete validation**: Tools consuming this schema can't programmatically validate that custom property names are structurally valid
4. **Spec alignment**: The CSS spec defines custom properties as a naming pattern, not individual properties—the schema should reflect this

Adding `patternProperties` makes the schema semantically accurate and enables automated validation of custom properties without special-case logic.

### Additional details

- Pattern uses `^--` to match the CSS Custom Properties spec ([CSS Variables Level 1](https://www.w3.org/TR/css-variables-1/#defining-variables))
- The existing `"--*"` entry in `properties.json` is preserved as documentation/reference
- Schema change is backwards compatible—only adds validation, doesn't restrict existing valid data
- Documentation updated in `css/properties.md` to explain the pattern validation

### Related issues and pull requests

The most notable downstream consumer is frenic/csstype#63, because several large ecosystems including giants like React all depend on the `csstype` library, which itself depends on `mdn/data`. As a result, there are StackOverflow questions and GitHub issues _everywhere_ regarding this lack of schema recognition.
