### PR TITLE
fix(css): Fix syntax for `column-rule-style/width` and canonical order

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -4250,9 +4250,9 @@
     "media": "visual",
     "inherited": false,
     "animationType": [
-      "column-rule-color",
+      "column-rule-width",
       "column-rule-style",
-      "column-rule-width"
+      "column-rule-color"
     ],
     "percentages": "no",
     "groups": [
@@ -4265,9 +4265,9 @@
     ],
     "appliesto": "multicolElements",
     "computed": [
-      "column-rule-color",
+      "column-rule-width",
       "column-rule-style",
-      "column-rule-width"
+      "column-rule-color"
     ],
     "order": "perGrammar",
     "status": "standard",

--- a/css/properties.json
+++ b/css/properties.json
@@ -4290,7 +4290,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-color"
   },
   "column-rule-style": {
-    "syntax": "<'border-style'>",
+    "syntax": "<line-style>",
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
@@ -4306,7 +4306,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-style"
   },
   "column-rule-width": {
-    "syntax": "<'border-width'>",
+    "syntax": "<line-width>",
     "media": "visual",
     "inherited": false,
     "animationType": "length",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

This PR fixes some typos in the `column-rule` and `column-rule-style/width` properties, and does not include any normative updates.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
