### PR TITLE
fix(css): correct the malformed reference in patternProperties for custom properties schema.

### DIFF
--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -471,7 +471,7 @@
   },
   "patternProperties": {
     "^--": {
-      "$ref": "#/definitions/additionalProperties"
+      "$ref": "#/additionalProperties"
     }
   }
 }


### PR DESCRIPTION
### Description

Fixes the incorrect reference pattern that was breaking the lint check.

### Motivation

Fix requested by @caugner

### Related issues and pull requests

Introduced by #1057