### PR TITLE
feat(css): update computed for `border/column-rule/outline-width`, `outline-offset`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -1214,7 +1214,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLength",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -1287,7 +1287,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLength",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -1359,7 +1359,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLength",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -1431,7 +1431,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLength",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "nonstandard"
   },
@@ -2804,7 +2804,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width"
@@ -2880,7 +2880,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-width"
@@ -3050,7 +3050,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -3405,7 +3405,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width"
@@ -3481,7 +3481,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width"
@@ -3613,7 +3613,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -3735,7 +3735,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -3944,7 +3944,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "alsoAppliesTo": [
       "::first-letter"
@@ -4582,7 +4582,7 @@
     ],
     "initial": "medium",
     "appliesto": "multicolElements",
-    "computed": "absoluteLength0IfColumnRuleStyleNoneOrHidden",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "perGrammar",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-width"
@@ -8586,7 +8586,7 @@
     ],
     "initial": "0",
     "appliesto": "allElements",
-    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-offset"
@@ -8624,7 +8624,7 @@
     ],
     "initial": "medium",
     "appliesto": "allElements",
-    "computed": "absoluteLength0ForNone",
+    "computed": "absoluteLengthSnappedAsLineWidth",
     "order": "uniqueOrder",
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-width"

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -104,12 +104,6 @@
     "computed": {
       "enum": [
         "absoluteLength",
-        "absoluteLength0ForNone",
-        "absoluteLength0IfColumnRuleStyleNoneOrHidden",
-        "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
-        "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
-        "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
-        "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
         "absoluteLengthOrAsSpecified",
         "absoluteLengthOrKeyword",
         "absoluteLengthOrNone",
@@ -118,7 +112,6 @@
         "absoluteLengthOrPercentageNumbersConverted",
         "absoluteLengthSnappedAsLineWidth",
         "absoluteLengthsSpecifiedColorAsSpecified",
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden",
         "absoluteLengthZeroOrLarger",
         "absoluteURIOrNone",
         "angleRoundedToNextQuarter",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -116,6 +116,7 @@
         "absoluteLengthOrNormal",
         "absoluteLengthOrPercentage",
         "absoluteLengthOrPercentageNumbersConverted",
+        "absoluteLengthSnappedAsLineWidth",
         "absoluteLengthsSpecifiedColorAsSpecified",
         "absoluteLengthZeroIfBorderStyleNoneOrHidden",
         "absoluteLengthZeroOrLarger",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -119,6 +119,9 @@
     "en-US": "an absolute {{cssxref(\"length\")}} or {{cssxref(\"percentage\")}}, numbers converted to absolute lengths first",
     "fr": "une longueur ({{cssxref(\"length\")}}) absolue ou un pourcentage ({{cssxref(\"percentage\")}}), les nombres étant d'abord convertis en longueurs absolues"
   },
+  "absoluteLengthSnappedAsLineWidth": {
+    "en-US": "the absolute length, <a title=\"To snap a &lt;length&gt; len as a line width:&#10;1. If len is an integer number of device pixels, leave it as is.&#10;2. If the absolute value of len is greater than zero, but less than 1 device pixel, round it away from zero to &pm;1 device pixel.&#10;3. If the absolute value of len is greater than 1 device pixel, round it towards zero to the nearest integer number of device pixels.\">snapped as a line width</a>"
+  },
   "absoluteLengthsSpecifiedColorAsSpecified": {
     "de": "Längen absolut gemacht; angegebene Farben berechnet; ansonsten wie angegeben",
     "en-US": "any length made absolute; any specified color computed; otherwise as specified",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -20,60 +20,6 @@
     "zh-CN": "绝对 {{cssxref(\"length\")}}",
     "zh-TW": "絕對{{cssxref(\"length\")}}"
   },
-  "absoluteLength0ForNone": {
-    "de": "eine absolute Länge; falls das Schlüsselwort <code>none</code> angegeben wurde, ist der berechnete Wert <code>0</code>",
-    "en-US": "an absolute length; if the keyword <code>none</code> is specified, the computed value is <code>0</code>",
-    "fr": "une longueur absolue&nbsp;; si le mot-clé <code>none</code> est défini, la valeur calculée sera <code>0</code>",
-    "ja": "絶対的な長さ、キーワード <code>none</code> が指定されると計算値は <code>0</code> になる",
-    "ru": "абсолютная длина; если указано ключевое слово <code>none</code>, вычисленное значение - <code>0</code>",
-    "zh-CN": "绝对长度；如果指定关键词为 <code>none</code>，则计算值为 <code>0</code>",
-    "zh-TW": "絕對長度；若指定了關鍵字 <code>none</code>，計算值則為 <code>0</code>"
-  },
-  "absoluteLength0IfColumnRuleStyleNoneOrHidden": {
-    "de": "die absolute Länge; <code>0</code> falls {{cssxref(\"column-rule-style\")}} <code>none</code> oder <code>hidden</code> ist",
-    "en-US": "the absolute length; <code>0</code> if the {{cssxref(\"column-rule-style\")}} is <code>none</code> or <code>hidden</code>",
-    "fr": "une longueur absolue ou <code>0</code> si {{cssxref(\"column-rule-style\")}} vaut <code>none</code> ou <code>hidden</code>",
-    "ja": "絶対的な長さ、列の罫線のスタイルが <code>none</code> か <code>hidden</code> なら <code>0</code>",
-    "ru": "абсолютная длина; <code>0</code>, если {{cssxref(\"column-rule-style\")}} - <code>none</code> или <code>hidden</code>",
-    "zh-CN": "绝对长度；如果 {{cssxref(\"column-rule-style\")}} 设为 <code>none</code> 或 <code>hidden</code>，则为 <code>0</code>",
-    "zh-TW": "絕對長度；若 {{cssxref(\"column-rule-style\")}} 為 <code>none</code> 或 <code>hidden</code>，則為 <code>0</code>"
-  },
-  "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden": {
-    "de": "die absolute Länge; <code>0</code> falls {{cssxref(\"border-bottom-style\")}} <code>none</code> oder <code>hidden</code> ist",
-    "en-US": "the absolute length or <code>0</code> if {{cssxref(\"border-bottom-style\")}} is <code>none</code> or <code>hidden</code>",
-    "fr": "la longueur absolue ou <code>0</code> si {{cssxref(\"border-bottom-style\")}} vaut <code>none</code> ou <code>hidden</code>",
-    "ja": "絶対的な長さ、または {{cssxref(\"border-bottom-style\")}} が <code>none</code> または <code>hidden</code> の場合は <code>0</code>",
-    "ru": "абсолютная длина или <code>0</code>, если {{cssxref(\"border-bottom-style\")}} - <code>none</code> или <code>hidden</code>",
-    "zh-CN": "绝对长度；或如果 {{cssxref(\"border-bottom-style\")}} 的值是 <code>none</code> 或 <code>hidden</code>，则为 <code>0</code>",
-    "zh-TW": "絕對長度，若 {{cssxref(\"border-bottom-style\")}} 為 <code>none</code> 或 <code>hidden</code>，則為 <code>0</code>"
-  },
-  "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden": {
-    "de": "die absolute Länge; <code>0</code> falls {{cssxref(\"border-left-style\")}} <code>none</code> oder <code>hidden</code> ist",
-    "en-US": "the absolute length or <code>0</code> if {{cssxref(\"border-left-style\")}} is <code>none</code> or <code>hidden</code>",
-    "fr": "la longueur absolue ou <code>0</code> si {{cssxref(\"border-left-style\")}} vaut <code>none</code> ou <code>hidden</code>",
-    "ja": "絶対的な長さ、または {{cssxref(\"border-left-style\")}} が <code>none</code> または <code>hidden</code> の場合は <code>0</code>",
-    "ru": "абсолютная длина или <code>0</code>, если {{cssxref(\"border-left-style\")}} - <code>none</code> или <code>hidden</code>",
-    "zh-CN": "绝对长度；或如果 {{cssxref(\"border-left-style\")}} 的值为 <code>none</code> 或 <code>hidden</code>，则为 <code>0</code>",
-    "zh-TW": "絕對長度，若 {{cssxref(\"border-left-style\")}} 為 <code>none</code> 或 <code>hidden</code>，則為 <code>0</code>"
-  },
-  "absoluteLengthOr0IfBorderRightStyleNoneOrHidden": {
-    "de": "die absolute Länge; <code>0</code> falls {{cssxref(\"border-right-style\")}} <code>none</code> oder <code>hidden</code> ist",
-    "en-US": "the absolute length or <code>0</code> if {{cssxref(\"border-right-style\")}} is <code>none</code> or <code>hidden</code>",
-    "fr": "la longueur absolue ou <code>0</code> si {{cssxref(\"border-right-style\")}} vaut <code>none</code> ou <code>hidden</code>",
-    "ja": "絶対的な長さ、または {{cssxref(\"border-right-style\")}} が <code>none</code> または <code>hidden</code> の場合は <code>0</code>",
-    "ru": "абсолютная длина или <code>0</code>, если {{cssxref(\"border-right-style\")}} - <code>none</code> или <code>hidden</code>",
-    "zh-CN": "绝对长度；或如果 {{cssxref(\"border-right-style\")}} 的值为 <code>none</code> 或 <code>hidden</code>，则为 <code>0</code>",
-    "zh-TW": "絕對長度，若 {{cssxref(\"border-right-style\")}} 為 <code>none</code> 或 <code>hidden</code>，則為 <code>0</code>"
-  },
-  "absoluteLengthOr0IfBorderTopStyleNoneOrHidden": {
-    "de": "die absolute Länge; <code>0</code> falls {{cssxref(\"border-top-style\")}} <code>none</code> oder <code>hidden</code> ist",
-    "en-US": "the absolute length or <code>0</code> if {{cssxref(\"border-top-style\")}} is <code>none</code> or <code>hidden</code>",
-    "fr": "la longueur absolue ou <code>0</code> si {{cssxref(\"border-top-style\")}} vaut <code>none</code> ou <code>hidden</code>",
-    "ja": "絶対的な長さ、または {{cssxref(\"border-top-style\")}} が <code>none</code> または <code>hidden</code> の場合は <code>0</code>",
-    "ru": "абсолютная длина или <code>0</code>, если {{cssxref(\"border-top-style\")}} - <code>none</code> или <code>hidden</code>",
-    "zh-CN": "绝对长度；或如果 {{cssxref(\"border-top-style\")}} 的值为 <code>none</code> 或 <code>hidden</code>，则为 <code>0</code>",
-    "zh-TW": "絕對長度，若 {{cssxref(\"border-top-style\")}} 為 <code>none</code> 或 <code>hidden</code>，則為 <code>0</code>"
-  },
   "absoluteLengthOrAsSpecified": {
     "de": "für Prozent- und Längenwerte die absolute Länge, ansonsten wie angegeben",
     "en-US": "for percentage and length values, the absolute length, otherwise as specified",
@@ -129,14 +75,6 @@
     "ja": "指定値（length は全て絶対値となり、color については計算値となる）",
     "ru": "любая абсолютная длина; работает любой указанный цвет; если другое не указано",
     "zh-TW": "任何長度均為絕對值；任何指定顏色均為計算值；否則按指定值"
-  },
-  "absoluteLengthZeroIfBorderStyleNoneOrHidden": {
-    "de": "absolute Länge; <code>0</code>, falls der Rahmenstil <code>none</code> oder <code>hidden</code> ist",
-    "en-US": "absolute length; <code>0</code> if the border style is <code>none</code> or <code>hidden</code>",
-    "fr": "une longueur absolue&nbsp;; <code>0</code> si le style de la bordure vaut <code>none</code> ou <code>hidden</code>",
-    "ja": "絶対的な長さ、境界スタイルが <code>none</code> または <code>hidden</code> であれば <code>0</code>",
-    "ru": "абсолютная длина; <code>0</code>, если стиль рамки <code>none</code> или <code>hidden</code>",
-    "zh-TW": "絕對長度；若框線樣式為 <code>none</code> 或 <code>hidden</code>，則為 <code>0</code>"
   },
   "absoluteLengthZeroOrLarger": {
     "de": "the absolute length, zero oder larger",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -120,7 +120,7 @@
     "fr": "une longueur ({{cssxref(\"length\")}}) absolue ou un pourcentage ({{cssxref(\"percentage\")}}), les nombres étant d'abord convertis en longueurs absolues"
   },
   "absoluteLengthSnappedAsLineWidth": {
-    "en-US": "the absolute length, <a href=\"/en-US/docs/Web/CSS/Reference/Values/length#snap_a_length_as_a_line_width\" title=\"To snap a &lt;length&gt; len as a line width:&#10;1. If len is an integer number of device pixels, leave it as is.&#10;2. If the absolute value of len is greater than zero, but less than 1 device pixel, round it away from zero to &pm;1 device pixel.&#10;3. If the absolute value of len is greater than 1 device pixel, round it towards zero to the nearest integer number of device pixels.\">snapped as a line width</a>"
+    "en-US": "the absolute {{cssxref(\"length\")}}, snapped as a line width"
   },
   "absoluteLengthsSpecifiedColorAsSpecified": {
     "de": "Längen absolut gemacht; angegebene Farben berechnet; ansonsten wie angegeben",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -120,7 +120,7 @@
     "fr": "une longueur ({{cssxref(\"length\")}}) absolue ou un pourcentage ({{cssxref(\"percentage\")}}), les nombres étant d'abord convertis en longueurs absolues"
   },
   "absoluteLengthSnappedAsLineWidth": {
-    "en-US": "the absolute length, <a title=\"To snap a &lt;length&gt; len as a line width:&#10;1. If len is an integer number of device pixels, leave it as is.&#10;2. If the absolute value of len is greater than zero, but less than 1 device pixel, round it away from zero to &pm;1 device pixel.&#10;3. If the absolute value of len is greater than 1 device pixel, round it towards zero to the nearest integer number of device pixels.\">snapped as a line width</a>"
+    "en-US": "the absolute length, <a href=\"/en-US/docs/Web/CSS/Reference/Values/length#snap_a_length_as_a_line_width\" title=\"To snap a &lt;length&gt; len as a line width:&#10;1. If len is an integer number of device pixels, leave it as is.&#10;2. If the absolute value of len is greater than zero, but less than 1 device pixel, round it away from zero to &pm;1 device pixel.&#10;3. If the absolute value of len is greater than 1 device pixel, round it towards zero to the nearest integer number of device pixels.\">snapped as a line width</a>"
   },
   "absoluteLengthsSpecifiedColorAsSpecified": {
     "de": "Längen absolut gemacht; angegebene Farben berechnet; ansonsten wie angegeben",


### PR DESCRIPTION
### Description

This PR updates the computed value for `border-*-width`, `column-rule-width`, `outline-width`, `outline-offset`, `-webkit-border-*-width`, to **"the absolute length, snapped as a line width"**.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

`border-*-width`, `column-rule-width`, `outline-width` snapped as a line width:
https://github.com/w3c/csswg-drafts/issues/5210

Computed value untangled from `*-style` properties value:
https://github.com/w3c/csswg-drafts/issues/11494#issuecomment-2675800489

`outline-offset` snapped as a line width:
https://github.com/w3c/csswg-drafts/issues/12906

Definition of "length snapped as a line width":
https://drafts.csswg.org/css-values-4/#snap-as-a-line-width

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

**Depends on:** https://github.com/mdn/content/issues/44193