### PR TITLE
Add data for border-shape property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -3743,6 +3743,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-width"
   },
+  "border-shape": {
+    "syntax": "none | [ <basic-shape> <geometry-box>?]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-shape"
+  },
   "border-spacing": {
     "syntax": "<length>{1,2}",
     "media": "visual",

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -87,7 +87,7 @@
     "syntax": "[ first | last ]? baseline"
   },
   "basic-shape": {
-    "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()>"
+    "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()> | shape()"
   },
   "basic-shape-rect": {
     "syntax": "<inset()> | <rect()> | <xywh()>"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Chrome adds support for the `border-shape` property; see https://chromestatus.com/feature/5459864205393920. This PR adds data for this property, but also adds the `shape()` function to the `<basic-shape>` value syntax, as it was missing.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
