### PR TITLE
fix(css): `object-position` is not inherited

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -8339,7 +8339,7 @@
   "object-position": {
     "syntax": "<position>",
     "media": "visual",
-    "inherited": true,
+    "inherited": false,
     "animationType": "repeatableList",
     "percentages": "referToWidthAndHeightOfElement",
     "groups": [


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

`object-position` is not inherited by default

- 4.6. Positioning Objects: the [object-position](https://drafts.csswg.org/css-images-3/#propdef-object-position) property
- WPT Inheritance of CSS Images properties: https://github.com/web-platform-tests/wpt/blob/master/css/css-images/inheritance.html

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
