### PR TITLE
Add data for view-transition-scope property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -11929,6 +11929,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-transition-name"
   },
+  "view-transition-scope": {
+    "syntax": "none | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS View Transitions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-transition-scope"
+  },
   "visibility": {
     "syntax": "visible | hidden | collapse",
     "media": "visual",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

This PR adds data for the [`view-transition-scope`](https://drafts.csswg.org/css-view-transitions-2/#view-transition-scope-prop) CSS property, which is added to Chrome 147+ as part of [element-scoped view transitions](https://developer.chrome.com/docs/css-ui/view-transitions/element-scoped-view-transitions).

I am documenting this feature in https://github.com/mdn/content/pull/44217.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
