### PR TITLE
ci(CODEOWNERS): add content team for npm dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,5 @@
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/content-team @mdn/engineering
 /SECURITY.md @mdn/engineering
+/package.json       @mdn/content-team @mdn-bot
+/package-lock.json  @mdn/content-team @mdn-bot


### PR DESCRIPTION
### Description

To align with the rest of the org.