### PR TITLE
feat: Add frame-sizing CSS property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -6370,6 +6370,22 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust"
   },
+  "frame-sizing": {
+    "syntax": "auto | content-width | content-height | content-block-size | content-inline-size",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "auto",
+    "appliesto": "replacedElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/frame-sizing"
+  },
   "gap": {
     "syntax": "<'row-gap'> <'column-gap'>?",
     "media": "visual",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

This PR adds data for the CSS [frame-sizing](https://drafts.csswg.org/css-sizing-4/#propdef-frame-sizing) property.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

https://github.com/mdn/content/pull/44598

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
