### PR TITLE
feat: added data for link-parameters property and param() function

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -463,6 +463,14 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette/palette-mix"
   },
+  "param()": {
+    "syntax": "mod( <dashed-ident>, <declaration-value>? )",
+    "groups": [
+      "CSS Values and Units"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/param"
+  },
   "path()": {
     "syntax": "path( <'fill-rule'>? , <string> )",
     "groups": [

--- a/css/properties.json
+++ b/css/properties.json
@@ -7405,6 +7405,22 @@
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-height-step"
   },
+  "link-parameters": {
+    "syntax": "none | <param()>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "n/a",
+    "groups": [
+      "CSS Values and Units"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/link-parameters"
+  },
   "list-style": {
     "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
     "media": "visual",

--- a/css/properties.json
+++ b/css/properties.json
@@ -7410,7 +7410,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "discrete",
-    "percentages": "n/a",
+    "percentages": "no",
     "groups": [
       "CSS Values and Units"
     ],


### PR DESCRIPTION
### Description

- Add data for `link-parameters` css property
- Add data for `param()` css function

### Motivation

- Working on [MDN issue #44466](https://github.com/mdn/content/issues/44466)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/44852)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/30088)
- [Associated BCD PR](https://github.com/mdn/browser-compat-data/pull/29909)
- [Firefox Release PR](https://github.com/mdn/content/pull/44851)