### PR TITLE
feat: updated the value for `text-decoration-inset`

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -10947,7 +10947,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-color"
   },
   "text-decoration-inset": {
-    "syntax": "<length>{1,2} | auto",
+    "syntax": "<length-percentage>{1,2} | auto",
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValue",

--- a/css/properties.json
+++ b/css/properties.json
@@ -10951,7 +10951,7 @@
     "media": "visual",
     "inherited": false,
     "animationType": "byComputedValue",
-    "percentages": "no",
+    "percentages": "referToSizeOfElement",
     "groups": [
       "CSS Text Decoration"
     ],


### PR DESCRIPTION
### Description

- updated the value for `text-decoration-inset` from `<length>` to `<length-percentage>`

### Motivation

- Working on [MDN issue #44840](https://github.com/mdn/content/issues/44840)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/45028)
- [Firefox Release PR](https://github.com/mdn/content/pull/45027)