### PR TITLE
feat: Add data for text-fit property

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -11135,6 +11135,25 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style"
   },
+  "text-fit": {
+    "syntax": "[ none | grow | shrink ] [consistent | per-line | per-line-all]? <percentage>?",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainerElements",
+    "computed": "specifiedKeywordOrComputedPercentage",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-fit"
+  },
   "text-indent": {
     "syntax": "<length-percentage> && hanging? && each-line?",
     "media": "visual",

--- a/css/properties.schema.json
+++ b/css/properties.schema.json
@@ -174,6 +174,7 @@
         "specifiedInteger",
         "specifiedIntegerOrAbsoluteLength",
         "specifiedKeywordOrComputedFunction",
+        "specifiedKeywordOrComputedPercentage",
         "specifiedValue",
         "specifiedValueClipped0To1",
         "specifiedValueNumberClipped0To1",

--- a/l10n/css.json
+++ b/l10n/css.json
@@ -1921,6 +1921,9 @@
     "en-US": "specified keyword, or computed function",
     "fr": "mot-clé défini, ou fonction calculée"
   },
+  "specifiedKeywordOrComputedPercentage": {
+    "en-US": "specified keyword, or computed <code>&lt;percentage&gt;</code>"
+  },
   "specifiedValue": {
     "en-US": "specified value",
     "fr": "valeur définie"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

Chrome 150 adds support for the CSS [`text-fit`](https://drafts.csswg.org/css-text-5/#text-fit-property) property; see https://chromestatus.com/feature/5104141688635392.

This PR adds data for the new property

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
