### PR TITLE
feat: Mark zoom property as animatable

### DIFF
--- a/css/properties.json
+++ b/css/properties.json
@@ -12247,7 +12247,7 @@
     "syntax": "normal | reset | <number [0,∞]> || <percentage [0,∞]>",
     "media": "visual",
     "inherited": false,
-    "animationType": "notAnimatable",
+    "animationType": "byComputedValueType",
     "percentages": "convertedToNumber",
     "groups": [
       "CSS Viewport"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

From Chrome 150 onwards, the [`zoom`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/zoom) CSS property is animatable; see https://chromestatus.com/feature/5183671737909248.

The [spec](https://drafts.csswg.org/css-viewport/#zoom-property) has been updated so that `zoom` is now marked as animated by computed value type. This PR updates the `zoom` data to reflect this.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
